### PR TITLE
fix: spacing between button text & icon

### DIFF
--- a/src/components/Dashboard/MissingItemsFeed.tsx
+++ b/src/components/Dashboard/MissingItemsFeed.tsx
@@ -217,7 +217,7 @@ const MissingItemsFeed: React.FC = () => {
               onClick={() => setActiveTab('movies')}
             >
               <FilmIcon className="mr-1 h-4 w-4" />
-              {intl.formatMessage(messages.movies)}
+              <span>{intl.formatMessage(messages.movies)}</span>
             </Button>
             <Button
               buttonSize="sm"
@@ -225,7 +225,7 @@ const MissingItemsFeed: React.FC = () => {
               onClick={() => setActiveTab('tv')}
             >
               <TvIcon className="mr-1 h-4 w-4" />
-              {intl.formatMessage(messages.tvShows)}
+              <span>{intl.formatMessage(messages.tvShows)}</span>
             </Button>
           </div>
         )}


### PR DESCRIPTION
Just added a span wrapper around the text within a button so that the spacing shows up properly.

Before:
<img width="382" height="139" alt="image" src="https://github.com/user-attachments/assets/4715416c-8dcb-4878-89df-1e21b7a4c5a0" />

After:
<img width="382" height="139" alt="image" src="https://github.com/user-attachments/assets/865ed982-0e57-4ea0-a900-7c7f7f9e5395" />
