### PR TITLE
Feature/letterboxd watchlist

### DIFF
--- a/server/lib/collections/external/letterboxd.ts
+++ b/server/lib/collections/external/letterboxd.ts
@@ -72,13 +72,16 @@ export class LetterboxdCollectionSync extends BaseCollectionSync {
         );
       }
 
-      if (config.subtype !== 'custom' && config.subtype !== 'random') {
-        throw this.createSyncError(
-          CollectionSyncErrorType.CONFIGURATION_ERROR,
-          'Only custom and random Letterboxd lists are supported'
-        );
-      }
-
+      if (
+      config.subtype !== 'custom' &&
+      config.subtype !== 'random' &&
+      config.subtype !== 'watchlist'
+    ) {
+      throw this.createSyncError(
+        CollectionSyncErrorType.CONFIGURATION_ERROR,
+        'Only custom, watchlist, and random Letterboxd lists are supported'
+      );
+    }
       // Determine which URL to use based on subtype
       let listUrl: string;
       if (config.subtype === 'random') {
@@ -701,6 +704,8 @@ export class LetterboxdCollectionSync extends BaseCollectionSync {
       const patterns = [
         // Primary pattern - current structure
         /<li[^>]*class="[^"]*posteritem[^"]*"[^>]*>(.*?)<\/li>/gs,
+        // Secondary pattern - grid items (watchlists)
+        /<li[^>]*class="[^"]*griditem[^"]*"[^>]*>(.*?)<\/li>/gs,
         // Fallback pattern - any li containing film data
         /<li[^>]*[^>]*>(.*?data-film-id="[^"]*".*?)<\/li>/gs,
       ];
@@ -818,6 +823,16 @@ export class LetterboxdCollectionSync extends BaseCollectionSync {
   }
 
   private extractListNameFromUrl(url: string): string {
+    // Check for watchlist
+    const watchlistMatch = url.match(/letterboxd\.com\/([^/]+)\/watchlist/);
+    if (watchlistMatch) {
+      const username = watchlistMatch[1]
+        .replace(/-/g, ' ')
+        .replace(/\b\w/g, (l: string) => l.toUpperCase());
+      return `${username}'s Watchlist`;
+    }
+
+    // Check for standard list
     const match = url.match(/letterboxd\.com\/[^/]+\/list\/([^/?]+)/);
     if (match) {
       return match[1]

--- a/server/routes/collections.ts
+++ b/server/routes/collections.ts
@@ -142,11 +142,14 @@ export function validateExternalUrl(
         }
         break;
       case 'letterboxd':
-        if (!urlObj.pathname.match(/^\/[^/]+\/list\/[^/?]+\/?$/)) {
+        if (
+          !urlObj.pathname.match(/^\/[^/]+\/list\/[^/?]+\/?$/) &&
+          !urlObj.pathname.match(/^\/[^/]+\/watchlist\/?$/)
+        ) {
           return {
             isValid: false,
             error:
-              'Invalid Letterboxd list URL format. Expected: https://letterboxd.com/username/list/listname',
+              'Invalid Letterboxd list URL format. Expected: https://letterboxd.com/username/list/listname or https://letterboxd.com/username/watchlist/',
           };
         }
         break;

--- a/server/routes/fetch-title.ts
+++ b/server/routes/fetch-title.ts
@@ -345,10 +345,14 @@ fetchTitleRoutes.post('/', isAuthenticated(), async (req, res) => {
         const axios = (await import('axios')).default;
 
         try {
-          const urlMatch = sanitizedUrl.match(
+          const watchlistMatch = sanitizedUrl.match(
+            /letterboxd\.com\/([^/]+)\/watchlist/
+          );
+          const listMatch = sanitizedUrl.match(
             /letterboxd\.com\/([^/]+)\/list\/([^/?]+)/
           );
-          if (!urlMatch) {
+
+          if (!watchlistMatch && !listMatch) {
             return res.status(400).json({
               status: 'error',
               message: 'Invalid Letterboxd list URL format',
@@ -363,48 +367,55 @@ fetchTitleRoutes.post('/', isAuthenticated(), async (req, res) => {
             timeout: 10000,
           });
 
-          // Extract title from HTML and clean it up
-          const titleMatch = response.data.match(/<title>([^<]+)<\/title>/i);
-          if (titleMatch) {
-            let rawTitle = titleMatch[1];
+          if (watchlistMatch) {
+            const username = watchlistMatch[1]
+              .replace(/-/g, ' ')
+              .replace(/\b\w/g, (l: string) => l.toUpperCase());
+            title = `${username}'s Watchlist`;
+          } else {
+            // Extract title from HTML and clean it up
+            const titleMatch = response.data.match(/<title>([^<]+)<\/title>/i);
+            if (titleMatch) {
+              let rawTitle = titleMatch[1];
 
-            // Decode HTML entities
-            rawTitle = rawTitle
-              .replace(/&lrm;/g, '') // Remove left-to-right mark
-              .replace(/&rlm;/g, '') // Remove right-to-left mark
-              .replace(/&bull;/g, '•') // Replace bullet entity with actual bullet
-              .replace(/&ndash;/g, '–') // Replace en-dash
-              .replace(/&mdash;/g, '—') // Replace em-dash
-              .replace(/&hellip;/g, '…') // Replace ellipsis
-              .replace(/&quot;/g, '"') // Replace quotes
-              .replace(/&#39;/g, "'") // Replace apostrophe
-              .replace(/&amp;/g, '&') // Replace ampersand (do this last)
-              .replace(/&lt;/g, '<')
-              .replace(/&gt;/g, '>');
+              // Decode HTML entities
+              rawTitle = rawTitle
+                .replace(/&lrm;/g, '') // Remove left-to-right mark
+                .replace(/&rlm;/g, '') // Remove right-to-left mark
+                .replace(/&bull;/g, '•') // Replace bullet entity with actual bullet
+                .replace(/&ndash;/g, '–') // Replace en-dash
+                .replace(/&mdash;/g, '—') // Replace em-dash
+                .replace(/&hellip;/g, '…') // Replace ellipsis
+                .replace(/&quot;/g, '"') // Replace quotes
+                .replace(/&#39;/g, "'") // Replace apostrophe
+                .replace(/&amp;/g, '&') // Replace ampersand (do this last)
+                .replace(/&lt;/g, '<')
+                .replace(/&gt;/g, '>');
 
-            // Extract list name (everything before " • Letterboxd" or ", a list of films by")
-            const patterns = [
-              /^(.*?),\s*a\s+list\s+of\s+films?\s+by/i, // ", a list of films by"
-              /^(.*?)\s*•\s*Letterboxd/i, // " • Letterboxd"
-              /^(.*?)\s*-\s*Letterboxd/i, // " - Letterboxd"
-              /^(.*?)\s*\|\s*Letterboxd/i, // " | Letterboxd"
-            ];
+              // Extract list name (everything before " • Letterboxd" or ", a list of films by")
+              const patterns = [
+                /^(.*?),\s*a\s+list\s+of\s+films?\s+by/i, // ", a list of films by"
+                /^(.*?)\s*•\s*Letterboxd/i, // " • Letterboxd"
+                /^(.*?)\s*-\s*Letterboxd/i, // " - Letterboxd"
+                /^(.*?)\s*\|\s*Letterboxd/i, // " | Letterboxd"
+              ];
 
-            for (const pattern of patterns) {
-              const match = rawTitle.match(pattern);
-              if (match && match[1]) {
-                title = match[1].trim();
-                break;
+              for (const pattern of patterns) {
+                const match = rawTitle.match(pattern);
+                if (match && match[1]) {
+                  title = match[1].trim();
+                  break;
+                }
               }
-            }
 
-            // If no pattern matched, use fallback cleanup
-            if (!title) {
-              title = rawTitle
-                .replace(/\s*•\s*Letterboxd.*$/i, '') // Remove " • Letterboxd" suffix
-                .replace(/\s*-\s*Letterboxd.*$/i, '') // Remove " - Letterboxd" suffix
-                .replace(/\s*\|\s*Letterboxd.*$/i, '') // Remove " | Letterboxd" suffix
-                .trim();
+              // If no pattern matched, use fallback cleanup
+              if (!title) {
+                title = rawTitle
+                  .replace(/\s*•\s*Letterboxd.*$/i, '') // Remove " • Letterboxd" suffix
+                  .replace(/\s*-\s*Letterboxd.*$/i, '') // Remove " - Letterboxd" suffix
+                  .replace(/\s*\|\s*Letterboxd.*$/i, '') // Remove " | Letterboxd" suffix
+                  .trim();
+              }
             }
           }
 

--- a/src/components/Collections/FormSections/CollectionTypeSection.tsx
+++ b/src/components/Collections/FormSections/CollectionTypeSection.tsx
@@ -246,6 +246,11 @@ const CollectionTypeSection = ({
         return [
           { value: 'custom', label: 'Custom List' },
           {
+            value: 'watchlist',
+            label: 'Watchlist',
+            description: 'Import a user\'s watchlist by URL',
+          },
+          {
             value: 'random',
             label: 'Random Lists',
             description: 'Randomly select from configured Letterboxd lists',

--- a/src/components/Collections/FormSections/CustomUrlSection.tsx
+++ b/src/components/Collections/FormSections/CustomUrlSection.tsx
@@ -239,49 +239,93 @@ const CustomUrlSection = ({
   }
 
   // Custom Letterboxd List URL
-  if (values.type === 'letterboxd' && values.subtype === 'custom') {
-    return (
-      <div>
-        <label
-          htmlFor="letterboxdCustomListUrl"
-          className="mb-2 block text-sm text-gray-300"
-        >
-          {intl.formatMessage(messages.customLetterboxdListUrl)}{' '}
-          <span className="text-red-500">*</span>
-        </label>
-        <div className="flex gap-2">
-          <Field
-            type="url"
-            id="letterboxdCustomListUrl"
+  if (values.type === 'letterboxd') {
+    if (values.subtype === 'custom') {
+      return (
+        <div>
+          <label
+            htmlFor="letterboxdCustomListUrl"
+            className="mb-2 block text-sm text-gray-300"
+          >
+            {intl.formatMessage(messages.customLetterboxdListUrl)}{' '}
+            <span className="text-red-500">*</span>
+          </label>
+          <div className="flex gap-2">
+            <Field
+              type="url"
+              id="letterboxdCustomListUrl"
+              name="letterboxdCustomListUrl"
+              placeholder="https://letterboxd.com/username/list/listname/"
+              className="flex-1 rounded-md border border-stone-500 bg-stone-700 px-3 py-2 text-white placeholder-gray-400 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
+            />
+            {fetchLetterboxdTitle && (
+              <button
+                type="button"
+                onClick={() => handleFetchTitle('letterboxd')}
+                disabled={
+                  !values.letterboxdCustomListUrl || isLoadingTitle.letterboxd
+                }
+                className="whitespace-nowrap rounded-md bg-orange-600 px-3 py-2 text-white hover:bg-orange-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isLoadingTitle.letterboxd
+                  ? intl.formatMessage(messages.fetching)
+                  : intl.formatMessage(messages.fetchTitle)}
+              </button>
+            )}
+          </div>
+          <ErrorMessage
             name="letterboxdCustomListUrl"
-            placeholder="https://letterboxd.com/username/list/listname/"
-            className="flex-1 rounded-md border border-stone-500 bg-stone-700 px-3 py-2 text-white placeholder-gray-400 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
+            component="div"
+            className="mt-1 text-sm text-red-500"
           />
-          {fetchLetterboxdTitle && (
-            <button
-              type="button"
-              onClick={() => handleFetchTitle('letterboxd')}
-              disabled={
-                !values.letterboxdCustomListUrl || isLoadingTitle.letterboxd
-              }
-              className="whitespace-nowrap rounded-md bg-orange-600 px-3 py-2 text-white hover:bg-orange-700 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {isLoadingTitle.letterboxd
-                ? intl.formatMessage(messages.fetching)
-                : intl.formatMessage(messages.fetchTitle)}
-            </button>
-          )}
+          <p className="mt-1 text-xs text-gray-400">
+            Example: https://letterboxd.com/username/list/listname/
+          </p>
         </div>
-        <ErrorMessage
-          name="letterboxdCustomListUrl"
-          component="div"
-          className="mt-1 text-sm text-red-500"
-        />
-        <p className="mt-1 text-xs text-gray-400">
-          Example: https://letterboxd.com/username/list/listname/
-        </p>
-      </div>
-    );
+      );
+    } else if (values.subtype === 'watchlist') {
+      return (
+        <div>
+          <label
+            htmlFor="letterboxdCustomListUrl"
+            className="mb-2 block text-sm text-gray-300"
+          >
+            Letterboxd Watchlist URL <span className="text-red-500">*</span>
+          </label>
+          <div className="flex gap-2">
+            <Field
+              type="url"
+              id="letterboxdCustomListUrl"
+              name="letterboxdCustomListUrl"
+              placeholder="https://letterboxd.com/username/watchlist/"
+              className="flex-1 rounded-md border border-stone-500 bg-stone-700 px-3 py-2 text-white placeholder-gray-400 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
+            />
+            {fetchLetterboxdTitle && (
+              <button
+                type="button"
+                onClick={() => handleFetchTitle('letterboxd')}
+                disabled={
+                  !values.letterboxdCustomListUrl || isLoadingTitle.letterboxd
+                }
+                className="whitespace-nowrap rounded-md bg-orange-600 px-3 py-2 text-white hover:bg-orange-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isLoadingTitle.letterboxd
+                  ? intl.formatMessage(messages.fetching)
+                  : intl.formatMessage(messages.fetchTitle)}
+              </button>
+            )}
+          </div>
+          <ErrorMessage
+            name="letterboxdCustomListUrl"
+            component="div"
+            className="mt-1 text-sm text-red-500"
+          />
+          <p className="mt-1 text-xs text-gray-400">
+            Enter the full URL to your Letterboxd watchlist.
+          </p>
+        </div>
+      );
+    }
   }
 
   // Custom AniList List URL

--- a/src/components/Collections/FormSections/MultiSourceConfigSection.tsx
+++ b/src/components/Collections/FormSections/MultiSourceConfigSection.tsx
@@ -769,6 +769,11 @@ const MultiSourceConfigSection = ({
         return [
           { value: 'custom', label: 'Custom List' },
           {
+            value: 'watchlist',
+            label: 'Watchlist',
+            description: "Import a user's watchlist by URL",
+          },
+          {
             value: 'random',
             label: 'Random Lists',
             description: 'Randomly select from configured Letterboxd lists',

--- a/src/components/Collections/Forms/CollectionConfigForm.tsx
+++ b/src/components/Collections/Forms/CollectionConfigForm.tsx
@@ -488,7 +488,19 @@ const CollectionFormConfigForm = ({
             /letterboxd\.com\/[^/]+\/list\/[^/?]+/,
             'Please enter a valid Letterboxd list URL (e.g., https://letterboxd.com/username/list/list-name/)'
           ),
-      otherwise: (schema) => schema,
+      otherwise: (schema) =>
+        schema.when(['type', 'subtype'], {
+          is: (type: string, subtype: string) =>
+            type === 'letterboxd' && subtype === 'watchlist',
+          then: (schema) =>
+            schema
+              .required('Letterboxd watchlist URL is required')
+              .matches(
+                /letterboxd\.com\/[^/]+\/watchlist\/?/,
+                'Please enter a valid Letterboxd watchlist URL (e.g., https://letterboxd.com/username/watchlist/)'
+              ),
+          otherwise: (schema) => schema,
+        }),
     }),
 
     anilistCustomListUrl: Yup.string().when(['type', 'subtype'], {

--- a/src/utils/collections/validation.ts
+++ b/src/utils/collections/validation.ts
@@ -127,7 +127,19 @@ const customUrlValidations = {
           /letterboxd\.com\/[^/]+\/list\/[^/?]+/,
           'Please enter a valid Letterboxd list URL (e.g., https://letterboxd.com/username/list/list-name/)'
         ),
-    otherwise: (schema) => schema,
+    otherwise: (schema) =>
+      schema.when(['type', 'subtype'], {
+        is: (type: string, subtype: string) =>
+          type === 'letterboxd' && subtype === 'watchlist',
+        then: (schema) =>
+          schema
+            .required('Letterboxd watchlist URL is required')
+            .matches(
+              /letterboxd\.com\/[^/]+\/watchlist\/?/,
+              'Please enter a valid Letterboxd watchlist URL (e.g., https://letterboxd.com/username/watchlist/)'
+            ),
+        otherwise: (schema) => schema,
+      }),
   }),
 
   anilistCustomListUrl: Yup.string().when(['type', 'subtype'], {


### PR DESCRIPTION
#### Description
Implement Letterboxd watchlist support across backend/list parsing, validation, and UI so collections can import watchlists just like custom/random lists (server/lib/collections/external/letterboxd.ts, server/routes/*, validation hooks, and collection forms).
Expose the watchlist option in the collection type picker and multi-source config section so the UI can surface the new subtype.
Update the validation, fetch-title helper, and configuration form to accept watchlist URLs, with clearer guidance for users.

