### PR TITLE
feat: Add Radarr/Sonarr tag support for overlay conditions

### DIFF
--- a/agregarr-api.yml
+++ b/agregarr-api.yml
@@ -9444,6 +9444,21 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/ServiceProfile'
+  /settings/radarr/alltags:
+    get:
+      summary: Get all Radarr tags from all instances
+      description: Returns a deduplicated list of tags from all configured Radarr instances.
+      tags:
+        - settings-services
+      responses:
+        '200':
+          description: List of tags from all Radarr instances
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ServarrTag'
   /settings/radarr/{radarrId}:
     put:
       summary: Update Radarr instance
@@ -9671,6 +9686,21 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/ServiceProfile'
+  /settings/sonarr/alltags:
+    get:
+      summary: Get all Sonarr tags from all instances
+      description: Returns a deduplicated list of tags from all configured Sonarr instances.
+      tags:
+        - settings-services
+      responses:
+        '200':
+          description: List of tags from all Sonarr instances
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ServarrTag'
   /settings/sonarr/{sonarrId}:
     put:
       summary: Update Sonarr instance

--- a/server/lib/overlays/OverlayContextBuilder.ts
+++ b/server/lib/overlays/OverlayContextBuilder.ts
@@ -655,6 +655,8 @@ export async function checkMonitoringStatus(
   inSonarr?: boolean;
   isMonitored?: boolean;
   hasFile?: boolean;
+  radarrTags?: string[];
+  sonarrTags?: string[];
 }> {
   try {
     const settings = getSettings();
@@ -675,16 +677,47 @@ export async function checkMonitoringStatus(
           const movie = movies.find((m) => m.tmdbId === tmdbId);
 
           if (movie) {
+            // Fetch tags if movie has any
+            let tagNames: string[] = [];
+            if (movie.tags && movie.tags.length > 0) {
+              try {
+                const RadarrAPI = (await import('@server/api/servarr/radarr'))
+                  .default;
+                const radarr = new RadarrAPI({
+                  url: `${radarrSettings.useSsl ? 'https' : 'http'}://${
+                    radarrSettings.hostname
+                  }:${radarrSettings.port}${
+                    radarrSettings.baseUrl || ''
+                  }/api/v3`,
+                  apiKey: radarrSettings.apiKey,
+                });
+                const allTags = await radarr.getTags();
+                tagNames = movie.tags
+                  .map((tagId) => allTags.find((t) => t.id === tagId)?.label)
+                  .filter((label): label is string => label !== undefined);
+              } catch (tagError) {
+                logger.debug('Failed to fetch Radarr tags', {
+                  label: 'OverlayContextBuilder',
+                  error:
+                    tagError instanceof Error
+                      ? tagError.message
+                      : String(tagError),
+                });
+              }
+            }
+
             logger.debug('Found movie in Radarr', {
               label: 'OverlayContextBuilder',
               tmdbId,
               monitored: movie.monitored,
               hasFile: movie.hasFile,
+              tags: tagNames,
             });
             return {
               inRadarr: true,
               isMonitored: movie.monitored,
               hasFile: movie.hasFile,
+              radarrTags: tagNames.length > 0 ? tagNames : undefined,
             };
           }
         } catch (error) {
@@ -750,6 +783,35 @@ export async function checkMonitoringStatus(
           if (series) {
             const hasFile = (series.statistics?.episodeFileCount || 0) > 0;
 
+            // Fetch tags if series has any
+            let tagNames: string[] = [];
+            if (series.tags && series.tags.length > 0) {
+              try {
+                const SonarrAPI = (await import('@server/api/servarr/sonarr'))
+                  .default;
+                const sonarr = new SonarrAPI({
+                  url: `${sonarrSettings.useSsl ? 'https' : 'http'}://${
+                    sonarrSettings.hostname
+                  }:${sonarrSettings.port}${
+                    sonarrSettings.baseUrl || ''
+                  }/api/v3`,
+                  apiKey: sonarrSettings.apiKey,
+                });
+                const allTags = await sonarr.getTags();
+                tagNames = series.tags
+                  .map((tagId) => allTags.find((t) => t.id === tagId)?.label)
+                  .filter((label): label is string => label !== undefined);
+              } catch (tagError) {
+                logger.debug('Failed to fetch Sonarr tags', {
+                  label: 'OverlayContextBuilder',
+                  error:
+                    tagError instanceof Error
+                      ? tagError.message
+                      : String(tagError),
+                });
+              }
+            }
+
             logger.debug('Found series in Sonarr', {
               label: 'OverlayContextBuilder',
               tmdbId,
@@ -761,12 +823,14 @@ export async function checkMonitoringStatus(
               monitored: series.monitored,
               episodeFileCount: series.statistics?.episodeFileCount,
               hasFile,
+              tags: tagNames,
             });
 
             return {
               inSonarr: true,
               isMonitored: series.monitored,
               hasFile,
+              sonarrTags: tagNames.length > 0 ? tagNames : undefined,
             };
           }
         } catch (error) {

--- a/server/lib/overlays/OverlayTemplateRenderer.ts
+++ b/server/lib/overlays/OverlayTemplateRenderer.ts
@@ -344,6 +344,8 @@ export interface OverlayRenderContext {
   inSonarr?: boolean;
   hasFile?: boolean; // Whether *arr reports item has files
   downloaded?: boolean; // Derived from hasFile for monitored items, or !isPlaceholder for others
+  radarrTags?: string[]; // Array of Radarr tag names
+  sonarrTags?: string[]; // Array of Sonarr tag names
 
   // Maintainerr integration
   daysUntilAction?: number; // Days until Maintainerr takes action (negative = overdue)

--- a/server/lib/overlays/OverlayTemplateRenderer.ts
+++ b/server/lib/overlays/OverlayTemplateRenderer.ts
@@ -355,7 +355,7 @@ export interface OverlayRenderContext {
   mediaType: 'movie' | 'show';
 
   // Future extensibility
-  [key: string]: string | number | boolean | Date | undefined;
+  [key: string]: string | number | boolean | Date | string[] | undefined;
 }
 
 /**

--- a/server/lib/overlays/OverlayTemplateRenderer.ts
+++ b/server/lib/overlays/OverlayTemplateRenderer.ts
@@ -182,12 +182,28 @@ function evaluateRule(
 
   switch (rule.operator) {
     case 'eq':
+      // For array fields (like radarrTags/sonarrTags), check if array contains the value
+      if (Array.isArray(value) && typeof conditionValue === 'string') {
+        return value.some(
+          (item) =>
+            typeof item === 'string' &&
+            item.toLowerCase() === conditionValue.toLowerCase()
+        );
+      }
       // Case-insensitive comparison for strings
       if (typeof value === 'string' && typeof conditionValue === 'string') {
         return value.toLowerCase() === conditionValue.toLowerCase();
       }
       return value === conditionValue;
     case 'neq':
+      // For array fields, check if array does NOT contain the value
+      if (Array.isArray(value) && typeof conditionValue === 'string') {
+        return !value.some(
+          (item) =>
+            typeof item === 'string' &&
+            item.toLowerCase() === conditionValue.toLowerCase()
+        );
+      }
       // Case-insensitive comparison for strings
       if (typeof value === 'string' && typeof conditionValue === 'string') {
         return value.toLowerCase() !== conditionValue.toLowerCase();
@@ -231,6 +247,14 @@ function evaluateRule(
         conditionValue.includes(value as string | number)
       );
     case 'contains':
+      // For array fields, check if array contains the value
+      if (Array.isArray(value) && typeof conditionValue === 'string') {
+        return value.some(
+          (item) =>
+            typeof item === 'string' &&
+            item.toLowerCase().includes(conditionValue.toLowerCase())
+        );
+      }
       return (
         typeof value === 'string' &&
         typeof conditionValue === 'string' &&

--- a/server/routes/settings/radarr.ts
+++ b/server/routes/settings/radarr.ts
@@ -74,41 +74,8 @@ radarrRoutes.post<
   }
 });
 
-radarrRoutes.get('/alltags', async (_req, res) => {
-  const settings = getSettings();
-  const allTags: { id: number; label: string }[] = [];
-  const seenLabels = new Set<string>();
-
-  // Fetch tags from all Radarr instances
-  for (const radarrSettings of settings.radarr) {
-    if (!radarrSettings.hostname) continue;
-
-    try {
-      const radarr = new RadarrAPI({
-        apiKey: radarrSettings.apiKey,
-        url: RadarrAPI.buildUrl(radarrSettings, '/api/v3'),
-      });
-
-      const tags = await radarr.getTags();
-
-      // Add unique tags (deduplicate by label)
-      for (const tag of tags) {
-        if (!seenLabels.has(tag.label)) {
-          seenLabels.add(tag.label);
-          allTags.push(tag);
-        }
-      }
-    } catch (e) {
-      logger.debug('Failed to fetch tags from Radarr instance', {
-        label: 'Radarr',
-        hostname: radarrSettings.hostname,
-        message: e.message,
-      });
-      // Continue with other instances
-    }
-  }
-
-  return res.status(200).json(allTags);
+radarrRoutes.get('/alltags', (_req, res) => {
+  return res.status(200).json([{ id: 1, label: 'test' }]);
 });
 
 radarrRoutes.put<{ id: string }, RadarrSettings, RadarrSettings>(

--- a/server/routes/settings/radarr.ts
+++ b/server/routes/settings/radarr.ts
@@ -229,8 +229,41 @@ radarrRoutes.delete<{ id: string }>('/:id', (req, res, next) => {
   return res.status(200).json(removed[0]);
 });
 
-radarrRoutes.get('/alltags', (_req, res) => {
-  return res.status(200).json([{ id: 1, label: 'test' }]);
+radarrRoutes.get('/alltags', async (_req, res) => {
+  const settings = getSettings();
+  const allTags: { id: number; label: string }[] = [];
+  const seenLabels = new Set<string>();
+
+  // Fetch tags from all Radarr instances
+  for (const radarrSettings of settings.radarr) {
+    if (!radarrSettings.hostname) continue;
+
+    try {
+      const radarr = new RadarrAPI({
+        apiKey: radarrSettings.apiKey,
+        url: RadarrAPI.buildUrl(radarrSettings, '/api/v3'),
+      });
+
+      const tags = await radarr.getTags();
+
+      // Add unique tags (deduplicate by label)
+      for (const tag of tags) {
+        if (!seenLabels.has(tag.label)) {
+          seenLabels.add(tag.label);
+          allTags.push(tag);
+        }
+      }
+    } catch (e) {
+      logger.debug('Failed to fetch tags from Radarr instance', {
+        label: 'Radarr',
+        hostname: radarrSettings.hostname,
+        message: e.message,
+      });
+      // Continue with other instances
+    }
+  }
+
+  return res.status(200).json(allTags);
 });
 
 export default radarrRoutes;

--- a/server/routes/settings/radarr.ts
+++ b/server/routes/settings/radarr.ts
@@ -74,7 +74,7 @@ radarrRoutes.post<
   }
 });
 
-radarrRoutes.get('/tags/all', async (_req, res) => {
+radarrRoutes.get('/alltags', async (_req, res) => {
   const settings = getSettings();
   const allTags: { id: number; label: string }[] = [];
   const seenLabels = new Set<string>();

--- a/server/routes/settings/radarr.ts
+++ b/server/routes/settings/radarr.ts
@@ -160,6 +160,43 @@ radarrRoutes.get<{ id: string }>('/:id/rootfolders', async (req, res, next) => {
   );
 });
 
+radarrRoutes.get('/tags/all', async (_req, res) => {
+  const settings = getSettings();
+  const allTags: { id: number; label: string }[] = [];
+  const seenLabels = new Set<string>();
+
+  // Fetch tags from all Radarr instances
+  for (const radarrSettings of settings.radarr) {
+    if (!radarrSettings.hostname) continue;
+
+    try {
+      const radarr = new RadarrAPI({
+        apiKey: radarrSettings.apiKey,
+        url: RadarrAPI.buildUrl(radarrSettings, '/api/v3'),
+      });
+
+      const tags = await radarr.getTags();
+
+      // Add unique tags (deduplicate by label)
+      for (const tag of tags) {
+        if (!seenLabels.has(tag.label)) {
+          seenLabels.add(tag.label);
+          allTags.push(tag);
+        }
+      }
+    } catch (e) {
+      logger.debug('Failed to fetch tags from Radarr instance', {
+        label: 'Radarr',
+        hostname: radarrSettings.hostname,
+        message: e.message,
+      });
+      // Continue with other instances
+    }
+  }
+
+  return res.status(200).json(allTags);
+});
+
 radarrRoutes.get<{ id: string }>('/:id/tags', async (req, res, next) => {
   const settings = getSettings();
 

--- a/server/routes/settings/radarr.ts
+++ b/server/routes/settings/radarr.ts
@@ -74,10 +74,6 @@ radarrRoutes.post<
   }
 });
 
-radarrRoutes.get('/alltags', (_req, res) => {
-  return res.status(200).json([{ id: 1, label: 'test' }]);
-});
-
 radarrRoutes.put<{ id: string }, RadarrSettings, RadarrSettings>(
   '/:id',
   (req, res, next) => {
@@ -231,6 +227,10 @@ radarrRoutes.delete<{ id: string }>('/:id', (req, res, next) => {
   settings.save();
 
   return res.status(200).json(removed[0]);
+});
+
+radarrRoutes.get('/alltags', (_req, res) => {
+  return res.status(200).json([{ id: 1, label: 'test' }]);
 });
 
 export default radarrRoutes;

--- a/server/routes/settings/radarr.ts
+++ b/server/routes/settings/radarr.ts
@@ -74,6 +74,43 @@ radarrRoutes.post<
   }
 });
 
+radarrRoutes.get('/tags/all', async (_req, res) => {
+  const settings = getSettings();
+  const allTags: { id: number; label: string }[] = [];
+  const seenLabels = new Set<string>();
+
+  // Fetch tags from all Radarr instances
+  for (const radarrSettings of settings.radarr) {
+    if (!radarrSettings.hostname) continue;
+
+    try {
+      const radarr = new RadarrAPI({
+        apiKey: radarrSettings.apiKey,
+        url: RadarrAPI.buildUrl(radarrSettings, '/api/v3'),
+      });
+
+      const tags = await radarr.getTags();
+
+      // Add unique tags (deduplicate by label)
+      for (const tag of tags) {
+        if (!seenLabels.has(tag.label)) {
+          seenLabels.add(tag.label);
+          allTags.push(tag);
+        }
+      }
+    } catch (e) {
+      logger.debug('Failed to fetch tags from Radarr instance', {
+        label: 'Radarr',
+        hostname: radarrSettings.hostname,
+        message: e.message,
+      });
+      // Continue with other instances
+    }
+  }
+
+  return res.status(200).json(allTags);
+});
+
 radarrRoutes.put<{ id: string }, RadarrSettings, RadarrSettings>(
   '/:id',
   (req, res, next) => {
@@ -158,43 +195,6 @@ radarrRoutes.get<{ id: string }>('/:id/rootfolders', async (req, res, next) => {
       path: folder.path,
     }))
   );
-});
-
-radarrRoutes.get('/tags/all', async (_req, res) => {
-  const settings = getSettings();
-  const allTags: { id: number; label: string }[] = [];
-  const seenLabels = new Set<string>();
-
-  // Fetch tags from all Radarr instances
-  for (const radarrSettings of settings.radarr) {
-    if (!radarrSettings.hostname) continue;
-
-    try {
-      const radarr = new RadarrAPI({
-        apiKey: radarrSettings.apiKey,
-        url: RadarrAPI.buildUrl(radarrSettings, '/api/v3'),
-      });
-
-      const tags = await radarr.getTags();
-
-      // Add unique tags (deduplicate by label)
-      for (const tag of tags) {
-        if (!seenLabels.has(tag.label)) {
-          seenLabels.add(tag.label);
-          allTags.push(tag);
-        }
-      }
-    } catch (e) {
-      logger.debug('Failed to fetch tags from Radarr instance', {
-        label: 'Radarr',
-        hostname: radarrSettings.hostname,
-        message: e.message,
-      });
-      // Continue with other instances
-    }
-  }
-
-  return res.status(200).json(allTags);
 });
 
 radarrRoutes.get<{ id: string }>('/:id/tags', async (req, res, next) => {

--- a/server/routes/settings/sonarr.ts
+++ b/server/routes/settings/sonarr.ts
@@ -72,6 +72,43 @@ sonarrRoutes.post('/test', async (req, res, next) => {
   }
 });
 
+sonarrRoutes.get('/tags/all', async (_req, res) => {
+  const settings = getSettings();
+  const allTags: { id: number; label: string }[] = [];
+  const seenLabels = new Set<string>();
+
+  // Fetch tags from all Sonarr instances
+  for (const sonarrSettings of settings.sonarr) {
+    if (!sonarrSettings.hostname) continue;
+
+    try {
+      const sonarr = new SonarrAPI({
+        apiKey: sonarrSettings.apiKey,
+        url: SonarrAPI.buildUrl(sonarrSettings, '/api/v3'),
+      });
+
+      const tags = await sonarr.getTags();
+
+      // Add unique tags (deduplicate by label)
+      for (const tag of tags) {
+        if (!seenLabels.has(tag.label)) {
+          seenLabels.add(tag.label);
+          allTags.push(tag);
+        }
+      }
+    } catch (e) {
+      logger.debug('Failed to fetch tags from Sonarr instance', {
+        label: 'Sonarr',
+        hostname: sonarrSettings.hostname,
+        message: e.message,
+      });
+      // Continue with other instances
+    }
+  }
+
+  return res.status(200).json(allTags);
+});
+
 sonarrRoutes.put<{ id: string }>('/:id', (req, res) => {
   const settings = getSettings();
 
@@ -155,43 +192,6 @@ sonarrRoutes.get<{ id: string }>('/:id/rootfolders', async (req, res, next) => {
       path: folder.path,
     }))
   );
-});
-
-sonarrRoutes.get('/tags/all', async (_req, res) => {
-  const settings = getSettings();
-  const allTags: { id: number; label: string }[] = [];
-  const seenLabels = new Set<string>();
-
-  // Fetch tags from all Sonarr instances
-  for (const sonarrSettings of settings.sonarr) {
-    if (!sonarrSettings.hostname) continue;
-
-    try {
-      const sonarr = new SonarrAPI({
-        apiKey: sonarrSettings.apiKey,
-        url: SonarrAPI.buildUrl(sonarrSettings, '/api/v3'),
-      });
-
-      const tags = await sonarr.getTags();
-
-      // Add unique tags (deduplicate by label)
-      for (const tag of tags) {
-        if (!seenLabels.has(tag.label)) {
-          seenLabels.add(tag.label);
-          allTags.push(tag);
-        }
-      }
-    } catch (e) {
-      logger.debug('Failed to fetch tags from Sonarr instance', {
-        label: 'Sonarr',
-        hostname: sonarrSettings.hostname,
-        message: e.message,
-      });
-      // Continue with other instances
-    }
-  }
-
-  return res.status(200).json(allTags);
 });
 
 sonarrRoutes.get<{ id: string }>('/:id/tags', async (req, res, next) => {

--- a/server/routes/settings/sonarr.ts
+++ b/server/routes/settings/sonarr.ts
@@ -72,43 +72,6 @@ sonarrRoutes.post('/test', async (req, res, next) => {
   }
 });
 
-sonarrRoutes.get('/alltags', async (_req, res) => {
-  const settings = getSettings();
-  const allTags: { id: number; label: string }[] = [];
-  const seenLabels = new Set<string>();
-
-  // Fetch tags from all Sonarr instances
-  for (const sonarrSettings of settings.sonarr) {
-    if (!sonarrSettings.hostname) continue;
-
-    try {
-      const sonarr = new SonarrAPI({
-        apiKey: sonarrSettings.apiKey,
-        url: SonarrAPI.buildUrl(sonarrSettings, '/api/v3'),
-      });
-
-      const tags = await sonarr.getTags();
-
-      // Add unique tags (deduplicate by label)
-      for (const tag of tags) {
-        if (!seenLabels.has(tag.label)) {
-          seenLabels.add(tag.label);
-          allTags.push(tag);
-        }
-      }
-    } catch (e) {
-      logger.debug('Failed to fetch tags from Sonarr instance', {
-        label: 'Sonarr',
-        hostname: sonarrSettings.hostname,
-        message: e.message,
-      });
-      // Continue with other instances
-    }
-  }
-
-  return res.status(200).json(allTags);
-});
-
 sonarrRoutes.put<{ id: string }>('/:id', (req, res) => {
   const settings = getSettings();
 
@@ -263,6 +226,43 @@ sonarrRoutes.delete<{ id: string }>('/:id', (req, res) => {
   settings.save();
 
   return res.status(200).json(removed[0]);
+});
+
+sonarrRoutes.get('/alltags', async (_req, res) => {
+  const settings = getSettings();
+  const allTags: { id: number; label: string }[] = [];
+  const seenLabels = new Set<string>();
+
+  // Fetch tags from all Sonarr instances
+  for (const sonarrSettings of settings.sonarr) {
+    if (!sonarrSettings.hostname) continue;
+
+    try {
+      const sonarr = new SonarrAPI({
+        apiKey: sonarrSettings.apiKey,
+        url: SonarrAPI.buildUrl(sonarrSettings, '/api/v3'),
+      });
+
+      const tags = await sonarr.getTags();
+
+      // Add unique tags (deduplicate by label)
+      for (const tag of tags) {
+        if (!seenLabels.has(tag.label)) {
+          seenLabels.add(tag.label);
+          allTags.push(tag);
+        }
+      }
+    } catch (e) {
+      logger.debug('Failed to fetch tags from Sonarr instance', {
+        label: 'Sonarr',
+        hostname: sonarrSettings.hostname,
+        message: e.message,
+      });
+      // Continue with other instances
+    }
+  }
+
+  return res.status(200).json(allTags);
 });
 
 export default sonarrRoutes;

--- a/server/routes/settings/sonarr.ts
+++ b/server/routes/settings/sonarr.ts
@@ -72,7 +72,7 @@ sonarrRoutes.post('/test', async (req, res, next) => {
   }
 });
 
-sonarrRoutes.get('/tags/all', async (_req, res) => {
+sonarrRoutes.get('/alltags', async (_req, res) => {
   const settings = getSettings();
   const allTags: { id: number; label: string }[] = [];
   const seenLabels = new Set<string>();

--- a/server/routes/settings/sonarr.ts
+++ b/server/routes/settings/sonarr.ts
@@ -157,6 +157,43 @@ sonarrRoutes.get<{ id: string }>('/:id/rootfolders', async (req, res, next) => {
   );
 });
 
+sonarrRoutes.get('/tags/all', async (_req, res) => {
+  const settings = getSettings();
+  const allTags: { id: number; label: string }[] = [];
+  const seenLabels = new Set<string>();
+
+  // Fetch tags from all Sonarr instances
+  for (const sonarrSettings of settings.sonarr) {
+    if (!sonarrSettings.hostname) continue;
+
+    try {
+      const sonarr = new SonarrAPI({
+        apiKey: sonarrSettings.apiKey,
+        url: SonarrAPI.buildUrl(sonarrSettings, '/api/v3'),
+      });
+
+      const tags = await sonarr.getTags();
+
+      // Add unique tags (deduplicate by label)
+      for (const tag of tags) {
+        if (!seenLabels.has(tag.label)) {
+          seenLabels.add(tag.label);
+          allTags.push(tag);
+        }
+      }
+    } catch (e) {
+      logger.debug('Failed to fetch tags from Sonarr instance', {
+        label: 'Sonarr',
+        hostname: sonarrSettings.hostname,
+        message: e.message,
+      });
+      // Continue with other instances
+    }
+  }
+
+  return res.status(200).json(allTags);
+});
+
 sonarrRoutes.get<{ id: string }>('/:id/tags', async (req, res, next) => {
   const settings = getSettings();
 

--- a/src/components/OverlayEditor/ConditionEditorModal.tsx
+++ b/src/components/OverlayEditor/ConditionEditorModal.tsx
@@ -144,13 +144,13 @@ const RuleItem: React.FC<RuleItemProps> = ({
 
   // Fetch all tags from all Radarr instances
   const { data: radarrTags } = useSWR<ArrTag[]>(
-    isRadarrTags ? '/api/v1/settings/radarr/tags/all' : null,
+    isRadarrTags ? '/api/v1/settings/radarr/alltags' : null,
     (url) => fetch(url).then((res) => res.json())
   );
 
   // Fetch all tags from all Sonarr instances
   const { data: sonarrTags } = useSWR<ArrTag[]>(
-    isSonarrTags ? '/api/v1/settings/sonarr/tags/all' : null,
+    isSonarrTags ? '/api/v1/settings/sonarr/alltags' : null,
     (url) => fetch(url).then((res) => res.json())
   );
 

--- a/src/components/OverlayEditor/ConditionEditorModal.tsx
+++ b/src/components/OverlayEditor/ConditionEditorModal.tsx
@@ -155,9 +155,13 @@ const RuleItem: React.FC<RuleItemProps> = ({
   );
 
   const availableTags = isRadarrTags
-    ? radarrTags || []
+    ? Array.isArray(radarrTags)
+      ? radarrTags
+      : []
     : isSonarrTags
-    ? sonarrTags || []
+    ? Array.isArray(sonarrTags)
+      ? sonarrTags
+      : []
     : [];
 
   // Sanitize operator if it's invalid for the current field type (on mount)
@@ -222,7 +226,7 @@ const RuleItem: React.FC<RuleItemProps> = ({
             value: isNewFieldBoolean ? true : '',
           });
         }}
-        className="flex-1 rounded border border-stone-600 bg-stone-700 px-2 py-1 text-sm text-white"
+        className="flex-1 select-none rounded border border-stone-600 bg-stone-700 px-2 py-1 text-sm text-white"
       >
         {Object.entries(CONDITION_FIELD_CATEGORIES).map(
           ([category, fields]) => (

--- a/src/components/OverlayEditor/ConditionEditorModal.tsx
+++ b/src/components/OverlayEditor/ConditionEditorModal.tsx
@@ -22,7 +22,6 @@ import type {
   ConditionRule,
   ConditionSection,
 } from '@server/entity/OverlayTemplate';
-import type { RadarrSettings, SonarrSettings } from '@server/lib/settings';
 import { useEffect, useRef, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import useSWR from 'swr';
@@ -143,66 +142,22 @@ const RuleItem: React.FC<RuleItemProps> = ({
   const isSonarrTags = field === 'sonarrTags';
   const isTagField = isRadarrTags || isSonarrTags;
 
-  // Fetch Radarr/Sonarr instances and tags
-  const { data: radarrInstances } = useSWR<RadarrSettings[]>(
-    isRadarrTags ? '/api/v1/settings/radarr' : null,
+  // Fetch all tags from all Radarr instances
+  const { data: radarrTags } = useSWR<ArrTag[]>(
+    isRadarrTags ? '/api/v1/settings/radarr/tags/all' : null,
     (url) => fetch(url).then((res) => res.json())
   );
 
-  const { data: sonarrInstances } = useSWR<SonarrSettings[]>(
-    isSonarrTags ? '/api/v1/settings/sonarr' : null,
+  // Fetch all tags from all Sonarr instances
+  const { data: sonarrTags } = useSWR<ArrTag[]>(
+    isSonarrTags ? '/api/v1/settings/sonarr/tags/all' : null,
     (url) => fetch(url).then((res) => res.json())
   );
-
-  // Fetch tags from all instances
-  const radarrTagUrls =
-    radarrInstances?.map((instance, idx) => ({
-      url: `/api/v1/settings/radarr/${idx}/tags`,
-      instanceName: instance.hostname,
-    })) || [];
-
-  const sonarrTagUrls =
-    sonarrInstances?.map((instance, idx) => ({
-      url: `/api/v1/settings/sonarr/${idx}/tags`,
-      instanceName: instance.hostname,
-    })) || [];
-
-  // Fetch all tags from all instances
-  const radarrTagsQueries = radarrTagUrls.map(({ url }) =>
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useSWR<ArrTag[]>(isRadarrTags ? url : null, (u) =>
-      fetch(u).then((res) => res.json())
-    )
-  );
-
-  const sonarrTagsQueries = sonarrTagUrls.map(({ url }) =>
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useSWR<ArrTag[]>(isSonarrTags ? url : null, (u) =>
-      fetch(u).then((res) => res.json())
-    )
-  );
-
-  // Combine all tags from all instances
-  const allRadarrTags =
-    radarrTagsQueries
-      .flatMap((query) => query.data || [])
-      .filter(
-        (tag, index, self) =>
-          index === self.findIndex((t) => t.label === tag.label)
-      ) || [];
-
-  const allSonarrTags =
-    sonarrTagsQueries
-      .flatMap((query) => query.data || [])
-      .filter(
-        (tag, index, self) =>
-          index === self.findIndex((t) => t.label === tag.label)
-      ) || [];
 
   const availableTags = isRadarrTags
-    ? allRadarrTags
+    ? radarrTags || []
     : isSonarrTags
-    ? allSonarrTags
+    ? sonarrTags || []
     : [];
 
   // Sanitize operator if it's invalid for the current field type (on mount)

--- a/src/components/OverlayEditor/ConditionEditorModal.tsx
+++ b/src/components/OverlayEditor/ConditionEditorModal.tsx
@@ -22,9 +22,16 @@ import type {
   ConditionRule,
   ConditionSection,
 } from '@server/entity/OverlayTemplate';
+import type { RadarrSettings, SonarrSettings } from '@server/lib/settings';
 import { useEffect, useRef, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
+import useSWR from 'swr';
 import { CONDITION_FIELD_CATEGORIES } from './types';
+
+interface ArrTag {
+  id: number;
+  label: string;
+}
 
 const messages = defineMessages({
   title: 'Edit Application Conditions',
@@ -132,6 +139,71 @@ const RuleItem: React.FC<RuleItemProps> = ({
 
   const isNumeric = NUMERIC_FIELDS.includes(field);
   const isBoolean = BOOLEAN_FIELDS.includes(field);
+  const isRadarrTags = field === 'radarrTags';
+  const isSonarrTags = field === 'sonarrTags';
+  const isTagField = isRadarrTags || isSonarrTags;
+
+  // Fetch Radarr/Sonarr instances and tags
+  const { data: radarrInstances } = useSWR<RadarrSettings[]>(
+    isRadarrTags ? '/api/v1/settings/radarr' : null,
+    (url) => fetch(url).then((res) => res.json())
+  );
+
+  const { data: sonarrInstances } = useSWR<SonarrSettings[]>(
+    isSonarrTags ? '/api/v1/settings/sonarr' : null,
+    (url) => fetch(url).then((res) => res.json())
+  );
+
+  // Fetch tags from all instances
+  const radarrTagUrls =
+    radarrInstances?.map((instance, idx) => ({
+      url: `/api/v1/settings/radarr/${idx}/tags`,
+      instanceName: instance.hostname,
+    })) || [];
+
+  const sonarrTagUrls =
+    sonarrInstances?.map((instance, idx) => ({
+      url: `/api/v1/settings/sonarr/${idx}/tags`,
+      instanceName: instance.hostname,
+    })) || [];
+
+  // Fetch all tags from all instances
+  const radarrTagsQueries = radarrTagUrls.map(({ url }) =>
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useSWR<ArrTag[]>(isRadarrTags ? url : null, (u) =>
+      fetch(u).then((res) => res.json())
+    )
+  );
+
+  const sonarrTagsQueries = sonarrTagUrls.map(({ url }) =>
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useSWR<ArrTag[]>(isSonarrTags ? url : null, (u) =>
+      fetch(u).then((res) => res.json())
+    )
+  );
+
+  // Combine all tags from all instances
+  const allRadarrTags =
+    radarrTagsQueries
+      .flatMap((query) => query.data || [])
+      .filter(
+        (tag, index, self) =>
+          index === self.findIndex((t) => t.label === tag.label)
+      ) || [];
+
+  const allSonarrTags =
+    sonarrTagsQueries
+      .flatMap((query) => query.data || [])
+      .filter(
+        (tag, index, self) =>
+          index === self.findIndex((t) => t.label === tag.label)
+      ) || [];
+
+  const availableTags = isRadarrTags
+    ? allRadarrTags
+    : isSonarrTags
+    ? allSonarrTags
+    : [];
 
   // Sanitize operator if it's invalid for the current field type (on mount)
   const lastSanitizedKey = useRef<string>('');
@@ -270,6 +342,24 @@ const RuleItem: React.FC<RuleItemProps> = ({
         >
           <option value="true">true</option>
           <option value="false">false</option>
+        </select>
+      ) : isTagField ? (
+        <select
+          value={String(value)}
+          onChange={(e) => {
+            onChange({
+              ...rule,
+              value: e.target.value,
+            });
+          }}
+          className="flex-1 rounded border border-stone-600 bg-stone-700 px-2 py-1 text-sm text-white"
+        >
+          <option value="">Select tag...</option>
+          {availableTags.map((tag) => (
+            <option key={tag.id} value={tag.label}>
+              {tag.label}
+            </option>
+          ))}
         </select>
       ) : (
         <input

--- a/src/components/OverlayEditor/types.ts
+++ b/src/components/OverlayEditor/types.ts
@@ -225,6 +225,8 @@ export interface OverlayRenderContext {
   inRadarr?: boolean;
   inSonarr?: boolean;
   downloaded?: boolean;
+  radarrTags?: string[]; // Array of Radarr tag names
+  sonarrTags?: string[]; // Array of Sonarr tag names
 
   // Maintainerr integration
   daysUntilAction?: number; // Days until Maintainerr takes action (negative = overdue)
@@ -361,6 +363,8 @@ export const AVAILABLE_VARIABLES = {
     { field: 'inRadarr', label: 'In Radarr', example: 'true' },
     { field: 'inSonarr', label: 'In Sonarr', example: 'true' },
     { field: 'downloaded', label: 'Downloaded', example: 'true' },
+    { field: 'radarrTags', label: 'Radarr Tags', example: 'english-audio' },
+    { field: 'sonarrTags', label: 'Sonarr Tags', example: 'german-audio' },
     {
       field: 'daysUntilAction',
       label: 'Days Until Maintainerr Action',
@@ -478,6 +482,8 @@ export const CONDITION_FIELD_CATEGORIES = {
     { field: 'inRadarr', label: 'In Radarr', example: 'true' },
     { field: 'inSonarr', label: 'In Sonarr', example: 'true' },
     { field: 'downloaded', label: 'Downloaded', example: 'true' },
+    { field: 'radarrTags', label: 'Radarr Tags', example: 'english-audio' },
+    { field: 'sonarrTags', label: 'Sonarr Tags', example: 'german-audio' },
     {
       field: 'daysUntilAction',
       label: 'Days Until Maintainerr Action',

--- a/src/components/OverlayEditor/types.ts
+++ b/src/components/OverlayEditor/types.ts
@@ -239,7 +239,7 @@ export interface OverlayRenderContext {
   status?: string;
 
   // Allow additional fields
-  [key: string]: string | number | boolean | Date | undefined;
+  [key: string]: string | number | boolean | Date | string[] | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds support for using Radarr and Sonarr tags in overlay conditions, allowing users to display overlays (like language flags) based on media tags.

- Added `radarrTags` and `sonarrTags` fields to overlay context
- Created `/settings/radarr/alltags` and `/settings/sonarr/alltags` API endpoints to fetch deduplicated tags from all configured instances
- Added tag selector dropdown in condition editor to prevent typos
- Fixed condition evaluation to properly handle array fields (check if array contains value)
- Includes Firefox bulk edit table fix (prevents Selection API error)

## Example Use Case

Display a German audio flag overlay on media tagged with "german-audio" in Radarr/Sonarr:
- Condition: `radarrTags = german-audio` OR `sonarrTags = german-audio`

## Test Plan

- Configure a Radarr/Sonarr tag on some media items
- Create an overlay template with a condition using `radarrTags` or `sonarrTags`
- Verify the tag dropdown populates with available tags
- Trigger a library sync and confirm overlays apply to matching items

reference images:
<img width="1788" height="1228" alt="grafik" src="https://github.com/user-attachments/assets/ed3eaf90-6a2b-4b3c-a84d-93216768f523" />

<img width="949" height="815" alt="Screenshot 2026-01-02 at 01 35 31" src="https://github.com/user-attachments/assets/e0d22bc5-7814-4ce7-bfc9-74b3fca961bd" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)