### PR TITLE
fix(collections): Filter daily shows from Coming Soon collections

### DIFF
--- a/server/lib/collections/sources/comingsoon/comingSoonFetch.ts
+++ b/server/lib/collections/sources/comingsoon/comingSoonFetch.ts
@@ -263,6 +263,17 @@ export async function fetchMonitoredShows(
           continue;
         }
 
+        // Skip daily shows (soaps, talk shows) - they always have "upcoming" episodes
+        // which pollutes Coming Soon collections with irrelevant content
+        if (series.seriesType === 'daily') {
+          logger.debug('Skipping daily show from Coming Soon', {
+            label: 'Coming Soon Collections',
+            title: series.title,
+            seriesType: series.seriesType,
+          });
+          continue;
+        }
+
         if (!series.id) {
           // Series doesn't have an ID yet (not added to Sonarr), skip
           continue;


### PR DESCRIPTION
## The Problem

Daily shows like EastEnders, Coronation Street, and other soaps always have upcoming episodes. Every day there's another episode coming. This means they perpetually appear in "Coming Soon" collections, which obscures the shows that are actually notable - new seasons, limited series, etc.

## What This PR Does

Added a check in `fetchMonitoredShows` (in `server/lib/collections/sources/comingsoon/comingSoonFetch.ts`) that skips any TV series where `seriesType === 'daily'`.

```typescript
// Skip daily shows (soaps, talk shows) - they always have "upcoming" episodes
// which pollutes Coming Soon collections with irrelevant content
if (series.seriesType === 'daily') {
  logger.debug('Skipping daily show from Coming Soon', {
    label: 'Coming Soon Collections',
    title: series.title,
    seriesType: series.seriesType,
  });
  continue;
}
```

**Sonarr field reference:** The `seriesType` field is part of Sonarr's Series model (v3 API). Valid values are `standard`, `daily`, and `anime`. This field has been stable since Sonarr v3.0. If the field is missing or has an unexpected value, the series passes through as normal - no breakage.

**Scope:** This only affects TV series in Coming Soon collections. Movies are unaffected (they use Radarr, not Sonarr).

## Why This Approach

Could have added this as a user-configurable option, but:

1. The primary use case for Coming Soon is "what notable new content is arriving" - daily shows don't fit that mental model since they air constantly
2. Adding config options increases complexity for a corner case
3. If someone does want to track daily shows specifically, a Smart Collection filtered by seriesType would be more appropriate than mixing them into Coming Soon

That said, if maintainers prefer a configurable approach, I'm open to adding an exclusion list or toggle.

## Test Plan

- [x] Verify Sonarr API returns `seriesType: 'daily'` for known soaps
- [x] Run Coming Soon collection sync
- [x] Confirm daily shows are not included in results
- [x] Check debug logs show "Skipping daily show" messages
- [x] Confirm non-daily shows (standard/anime) still appear correctly