### PR TITLE
feat(overlays): Add real-time job progress feedback

### DIFF
--- a/server/lib/overlays/OverlayLibraryService.ts
+++ b/server/lib/overlays/OverlayLibraryService.ts
@@ -31,6 +31,72 @@ export interface OverlayItemInput {
 }
 
 /**
+ * Job state machine states
+ */
+export type JobState =
+  | 'running'
+  | 'cancelling'
+  | 'completed'
+  | 'cancelled'
+  | 'failed';
+
+/**
+ * Internal progress tracking for a library overlay job
+ */
+interface LibraryProgress {
+  // Identity
+  libraryName: string;
+  startTime: number;
+
+  // State machine
+  state: JobState;
+  completedAt?: number; // For TTL cleanup after completion
+
+  // Progress
+  totalItems: number;
+  currentItem: number;
+  currentTitle: string;
+  filteredCount: number; // Episodes/seasons skipped by type filter
+
+  // Outcome counts
+  // INVARIANT: successCount + errorCount + skippedCount + filteredCount === currentItem
+  successCount: number;
+  errorCount: number;
+  skippedCount: number; // Items with no changes (hash matched)
+
+  // ETA calculation (private, not serialized)
+  _recentItemTimes: number[]; // Rolling window of last 20 item timestamps
+  _promise: Promise<void>; // For mutex, not serialized
+}
+
+/**
+ * Public status shape returned by API
+ */
+export interface LibraryStatus {
+  running: boolean;
+  state: JobState;
+  libraryName: string;
+  startTime: number;
+  runningFor: number;
+  totalItems: number;
+  currentItem: number;
+  currentTitle: string;
+  filteredCount: number;
+  successCount: number;
+  errorCount: number;
+  skippedCount: number;
+  progressPercent: number; // Clamped 0-100
+  estimatedSecondsRemaining: number | null; // Capped at 7200 (2h)
+}
+
+/**
+ * Result from applying overlays to a single item
+ */
+interface OverlayApplyResult {
+  skipped: boolean; // true if nothing changed (hash match)
+}
+
+/**
  * Service for applying overlay templates to Plex library items
  */
 class OverlayLibraryService {
@@ -39,38 +105,147 @@ class OverlayLibraryService {
   private sonarrSeriesCache?: Map<string, SonarrSeries[]>;
   private maintainerrCollectionsCache?: MaintainerrCollection[];
 
-  // Track running libraries
-  private runningLibraries = new Map<
-    string,
-    { libraryName: string; startTime: number }
-  >();
+  // Track running libraries with mutex-like behavior and detailed progress
+  // Prevents concurrent processing of the same library
+  private runningLibraries = new Map<string, LibraryProgress>();
+
+  // Track libraries that have been requested to cancel
+  private cancelledLibraries = new Set<string>();
+
+  // TTL for completed jobs (visible to UI before cleanup)
+  private static readonly COMPLETED_TTL_MS = 10_000;
+
+  /**
+   * Request cancellation of a library overlay job
+   * Returns 'requested' if newly requested, 'already' if already cancelling, 'not_found' otherwise
+   */
+  public requestCancellation(libraryId: string): 'requested' | 'already' | 'not_found' {
+    const progress = this.runningLibraries.get(libraryId);
+    if (!progress) {
+      return 'not_found';
+    }
+    if (progress.state === 'cancelling') {
+      return 'already'; // Idempotent - already in progress
+    }
+    if (progress.state === 'running') {
+      this.cancelledLibraries.add(libraryId);
+      progress.state = 'cancelling';
+      return 'requested';
+    }
+    return 'not_found'; // Job completed/failed/cancelled
+  }
+
+  /**
+   * Safely update progress for a library (while running or cancelling)
+   * Allows final progress updates during cancellation to maintain count accuracy
+   */
+  private updateProgress(
+    libraryId: string,
+    mutator: (progress: LibraryProgress) => void
+  ): void {
+    const progress = this.runningLibraries.get(libraryId);
+    if (progress && (progress.state === 'running' || progress.state === 'cancelling')) {
+      mutator(progress);
+    }
+  }
+
+  /**
+   * Clean up completed jobs after TTL expires
+   */
+  private cleanupCompletedJobs(): void {
+    const now = Date.now();
+    for (const [id, status] of this.runningLibraries) {
+      if (
+        status.completedAt &&
+        now - status.completedAt > OverlayLibraryService.COMPLETED_TTL_MS
+      ) {
+        this.runningLibraries.delete(id);
+      }
+    }
+  }
+
+  /**
+   * Calculate ETA using rolling average of recent item times
+   * Returns null if not enough data, caps at 2 hours
+   */
+  private calculateEta(progress: LibraryProgress): number | null {
+    const times = progress._recentItemTimes;
+
+    // Need at least 5 samples and library must have 20+ items
+    if (times.length < 5 || progress.totalItems < 20) {
+      return null;
+    }
+
+    // Calculate average ms per item from rolling window
+    const windowDuration = times[times.length - 1] - times[0];
+    const avgMsPerItem = windowDuration / (times.length - 1);
+
+    // Estimate remaining time
+    const remaining = progress.totalItems - progress.currentItem;
+    const etaMs = remaining * avgMsPerItem;
+
+    // Cap at 2 hours (7200 seconds)
+    return Math.min(7200, Math.round(etaMs / 1000));
+  }
 
   /**
    * Get status for a specific library
    */
-  public getLibraryStatus(libraryId: string) {
-    const status = this.runningLibraries.get(libraryId);
-    if (!status) {
+  public getLibraryStatus(libraryId: string): LibraryStatus | { running: false } {
+    // Clean up expired entries first
+    this.cleanupCompletedJobs();
+
+    const progress = this.runningLibraries.get(libraryId);
+    if (!progress) {
       return { running: false };
     }
+
+    const runningFor = Math.round((Date.now() - progress.startTime) / 1000);
+
+    // Calculate progress percent (clamped 0-100)
+    const rawPercent =
+      progress.totalItems > 0
+        ? (progress.currentItem / progress.totalItems) * 100
+        : 0;
+    const progressPercent = Math.min(100, Math.max(0, Math.round(rawPercent)));
+
+    // Calculate ETA
+    const estimatedSecondsRemaining = this.calculateEta(progress);
+
+    // Return cloned status object
     return {
-      running: true,
-      libraryName: status.libraryName,
-      startTime: status.startTime,
+      running: progress.state === 'running' || progress.state === 'cancelling',
+      state: progress.state,
+      libraryName: progress.libraryName,
+      startTime: progress.startTime,
+      runningFor,
+      totalItems: progress.totalItems,
+      currentItem: progress.currentItem,
+      currentTitle: progress.currentTitle,
+      filteredCount: progress.filteredCount,
+      successCount: progress.successCount,
+      errorCount: progress.errorCount,
+      skippedCount: progress.skippedCount,
+      progressPercent,
+      estimatedSecondsRemaining,
     };
   }
 
   /**
-   * Get all running libraries
+   * Get all running libraries with full status
    */
-  public getAllRunningLibraries() {
-    return Array.from(this.runningLibraries.entries()).map(
-      ([libraryId, status]) => ({
-        libraryId,
-        libraryName: status.libraryName,
-        startTime: status.startTime,
+  public getAllRunningLibraries(): (LibraryStatus & { libraryId: string })[] {
+    this.cleanupCompletedJobs();
+
+    return Array.from(this.runningLibraries.entries())
+      .map(([libraryId, _]) => {
+        const status = this.getLibraryStatus(libraryId);
+        if ('state' in status) {
+          return { libraryId, ...status };
+        }
+        return null;
       })
-    );
+      .filter((s): s is LibraryStatus & { libraryId: string } => s !== null);
   }
 
   /**
@@ -84,26 +259,129 @@ class OverlayLibraryService {
 
   /**
    * Apply overlays to all items in a library
+   * Uses mutex-like behavior to prevent concurrent processing of the same library
    */
   async applyOverlaysToLibrary(
     libraryId: string,
     checkCancelled?: () => boolean
   ): Promise<void> {
-    // Get library configuration first to get name
-    const configRepository = getRepository(OverlayLibraryConfig);
-    const config = await configRepository.findOne({
-      where: { libraryId },
+    // Check if library is already being processed (mutex check)
+    // Must check AND set before any await to prevent race condition
+    // Wait for ANY in-progress job (running OR cancelling) to prevent concurrent execution
+    const existing = this.runningLibraries.get(libraryId);
+    if (existing && (existing.state === 'running' || existing.state === 'cancelling')) {
+      logger.warn('Library already being processed, waiting for completion', {
+        label: 'OverlayLibrary',
+        libraryId,
+        libraryName: existing.libraryName,
+        state: existing.state,
+        startedAt: new Date(existing.startTime).toISOString(),
+        runningFor: `${Math.round((Date.now() - existing.startTime) / 1000)}s`,
+      });
+      // Wait for existing job to complete instead of running concurrently
+      await existing._promise;
+      // After waiting, run our job (the previous one is done)
+    }
+
+    // Clean up old completed jobs
+    this.cleanupCompletedJobs();
+
+    // Create a deferred promise to set in the map immediately
+    // This prevents race conditions where two calls pass the check before either awaits
+    let resolveDeferred: () => void;
+    let rejectDeferred: (error: Error) => void;
+    const deferredPromise = new Promise<void>((resolve, reject) => {
+      resolveDeferred = resolve;
+      rejectDeferred = reject;
     });
 
-    // Mark as running
+    // Initialize progress with all fields BEFORE any await (to prevent race condition)
     this.runningLibraries.set(libraryId, {
-      libraryName: config?.libraryName || libraryId,
+      libraryName: libraryId, // Will update after config fetch
       startTime: Date.now(),
+      state: 'running',
+      completedAt: undefined,
+      totalItems: 0,
+      currentItem: 0,
+      currentTitle: '',
+      filteredCount: 0,
+      successCount: 0,
+      errorCount: 0,
+      skippedCount: 0,
+      _recentItemTimes: [],
+      _promise: deferredPromise,
     });
 
+    // Create cancellation checker that includes both external callback and internal set
+    const combinedCheckCancelled = () => {
+      if (checkCancelled && checkCancelled()) return true;
+      return this.cancelledLibraries.has(libraryId);
+    };
+
+    try {
+      // Get library configuration
+      const configRepository = getRepository(OverlayLibraryConfig);
+      const config = await configRepository.findOne({
+        where: { libraryId },
+      });
+
+      // Update libraryName now that we have config
+      this.updateProgress(libraryId, (p) => {
+        p.libraryName = config?.libraryName || libraryId;
+      });
+
+      // Process the library
+      await this.processLibraryOverlays(libraryId, config, combinedCheckCancelled);
+
+      // Mark completed (stays in map for TTL period)
+      // Set completedAt for ANY state to ensure TTL cleanup works
+      const progress = this.runningLibraries.get(libraryId);
+      if (progress) {
+        // If still running, mark completed. If cancelling but finished, mark cancelled.
+        if (progress.state === 'running') {
+          progress.state = 'completed';
+        } else if (progress.state === 'cancelling') {
+          progress.state = 'cancelled';
+        }
+        // Always set completedAt for TTL cleanup
+        progress.completedAt = Date.now();
+      }
+      resolveDeferred!();
+    } catch (error) {
+      // Mark failed
+      const progress = this.runningLibraries.get(libraryId);
+      if (progress) {
+        progress.state = 'failed';
+        progress.completedAt = Date.now();
+      }
+      rejectDeferred!(error instanceof Error ? error : new Error(String(error)));
+      throw error;
+    } finally {
+      // Clean up cancellation flag
+      this.cancelledLibraries.delete(libraryId);
+    }
+  }
+
+  /**
+   * Internal method to process library overlays
+   */
+  private async processLibraryOverlays(
+    libraryId: string,
+    config: OverlayLibraryConfig | null,
+    checkCancelled?: () => boolean
+  ): Promise<void> {
     try {
       // Clear library caches at start of job
       this.clearLibraryCaches();
+
+      // Clear TMDB URL cache to avoid stale data from previous runs
+      const { plexBasePosterManager } = await import(
+        '@server/lib/overlays/PlexBasePosterManager'
+      );
+      plexBasePosterManager.clearTmdbUrlCache();
+
+      // Also clean up expired TMDB poster files
+      await plexBasePosterManager.cleanTmdbCache();
 
       logger.info('Starting overlay application for library', {
         label: 'OverlayLibrary',
@@ -208,35 +486,67 @@ class OverlayLibraryService {
         offset += pageSize;
       }
 
+      // Set total items count
+      this.updateProgress(libraryId, (p) => {
+        p.totalItems = allItems.length;
+      });
+
       logger.info('Processing library items', {
         label: 'OverlayLibrary',
         libraryId,
         itemCount: allItems.length,
       });
 
-      // Process each item
-      let successCount = 0;
-      let errorCount = 0;
+      // Handle empty library - mark completed immediately
+      if (allItems.length === 0) {
+        logger.info('Library has no items to process', {
+          label: 'OverlayLibrary',
+          libraryId,
+        });
+        return;
+      }
 
+      // Process each item
       for (const item of allItems) {
         // CRITICAL: Skip episodes and seasons - overlays only apply to movies and shows
         if (item.type === 'episode' || item.type === 'season') {
+          this.updateProgress(libraryId, (p) => {
+            p.currentItem++; // Advance currentItem to maintain accurate progress %
+            p.filteredCount++;
+          });
           continue;
         }
 
-        // Check for cancellation
+        // Check for cancellation FIRST
         if (checkCancelled && checkCancelled()) {
+          // Transition to cancelling state
+          const progress = this.runningLibraries.get(libraryId);
+          if (progress) {
+            progress.state = 'cancelling';
+          }
+
           logger.info(
             'Overlay application cancelled during library processing',
             {
               label: 'OverlayLibrary',
               libraryId,
-              processedItems: successCount + errorCount,
+              processedItems: progress?.currentItem || 0,
               totalItems: allItems.length,
             }
           );
-          break;
+
+          // Mark cancelled (not completed)
+          if (progress) {
+            progress.state = 'cancelled';
+            progress.completedAt = Date.now();
+          }
+          return; // Exit early, don't continue processing
         }
+
+        // Update current item title (before processing)
+        this.updateProgress(libraryId, (p) => {
+          p.currentTitle = item.title || '';
+        });
 
         try {
           // Fetch full metadata including Stream details (needed for HDR, bitDepth, etc.)
@@ -248,7 +558,7 @@ class OverlayLibraryService {
             Media: fullMetadata.Media,
           };
 
-          await this.applyOverlaysToItem(
+          const result = await this.applyOverlaysToItem(
             plexApi,
             itemWithFullMetadata,
             sortedTemplates,
@@ -256,9 +566,36 @@ class OverlayLibraryService {
             libraryId,
             config.libraryName
           );
-          successCount++;
+
+          // Update counts AFTER outcome is known
+          this.updateProgress(libraryId, (p) => {
+            p.currentItem++;
+
+            // Track timing for ETA
+            p._recentItemTimes.push(Date.now());
+            if (p._recentItemTimes.length > 20) {
+              p._recentItemTimes.shift();
+            }
+
+            if (result.skipped) {
+              p.skippedCount++;
+            } else {
+              p.successCount++;
+            }
+          });
         } catch (error) {
-          errorCount++;
+          // Update error count AFTER failure
+          this.updateProgress(libraryId, (p) => {
+            p.currentItem++;
+            p.errorCount++;
+
+            // Track timing for ETA even on errors
+            p._recentItemTimes.push(Date.now());
+            if (p._recentItemTimes.length > 20) {
+              p._recentItemTimes.shift();
+            }
+          });
+
           logger.error('Failed to apply overlays to item', {
             label: 'OverlayLibrary',
             itemTitle: item.title,
@@ -270,11 +607,15 @@ class OverlayLibraryService {
         }
       }
 
+      // Get final counts from progress
+      const finalProgress = this.runningLibraries.get(libraryId);
       logger.info('Completed overlay application for library', {
         label: 'OverlayLibrary',
         libraryId,
-        successCount,
-        errorCount,
+        successCount: finalProgress?.successCount || 0,
+        errorCount: finalProgress?.errorCount || 0,
+        skippedCount: finalProgress?.skippedCount || 0,
+        filteredCount: finalProgress?.filteredCount || 0,
       });
     } catch (error) {
       logger.error('Failed to apply overlays to library', {
@@ -283,10 +624,8 @@ class OverlayLibraryService {
         error: error instanceof Error ? error.message : String(error),
       });
       throw error;
-    } finally {
-      // Remove from running libraries
-      this.runningLibraries.delete(libraryId);
     }
+    // Note: runningLibraries cleanup is handled by the caller (applyOverlaysToLibrary)
   }
 
   /**
@@ -463,7 +802,7 @@ class OverlayLibraryService {
     libraryId: string,
     libraryName: string,
     contextOverrides?: Partial<OverlayRenderContext>
-  ): Promise<void> {
+  ): Promise<OverlayApplyResult> {
     try {
       // CRITICAL: Derive actual media type from item.type, not library config
       // This prevents TMDB API namespace mismatches that cause wrong posters
@@ -754,7 +1093,7 @@ class OverlayLibraryService {
             plexPosterMissing: false,
             basePosterSourceChanged: false,
           });
-          return; // Skip this item - no need to download poster
+          return { skipped: true }; // Skip this item - no need to download poster
         }
 
         logger.info('Applying overlays - changes detected', {
@@ -809,13 +1148,11 @@ class OverlayLibraryService {
           tmdbId
         );
       } catch (error) {
-        logger.error('Failed to get base poster, skipping overlay', {
-          label: 'OverlayLibrary',
-          itemTitle: item.title,
-          ratingKey: item.ratingKey,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return;
+        // Re-throw to let caller track this as a failure
+        // Previously this was silently returning, causing failed items to be counted as success
+        throw new Error(
+          `Failed to get base poster for "${item.title}": ${error instanceof Error ? error.message : String(error)}`
+        );
       }
 
       const posterBuffer = basePosterResult.posterBuffer;
@@ -949,6 +1286,8 @@ class OverlayLibraryService {
           templateCount: templates.length,
           templatesApplied,
         });
+
+        return { skipped: false };
       } finally {
         // Clean up temp file
         await fs.unlink(tempFilePath).catch(() => {

--- a/server/routes/overlayLibraryConfigs.ts
+++ b/server/routes/overlayLibraryConfigs.ts
@@ -274,6 +274,33 @@ router.post('/:libraryId/apply', async (req, res, next) => {
   }
 });
 
+// POST /api/v1/overlay-library-configs/:libraryId/stop - Stop overlay application for library
+router.post('/:libraryId/stop', (req, res) => {
+  const { libraryId } = req.params;
+
+  const result = overlayLibraryService.requestCancellation(libraryId);
+  if (result === 'requested') {
+    logger.info('Requested cancellation of overlay application', {
+      libraryId,
+      userId: req.user?.id,
+    });
+    return res.status(200).json({
+      message: 'Stop requested',
+      libraryId,
+    });
+  } else if (result === 'already') {
+    // Idempotent - return success if already stopping
+    return res.status(200).json({
+      message: 'Stop already in progress',
+      libraryId,
+    });
+  } else {
+    return res.status(404).json({
+      error: 'No running job found for this library',
+    });
+  }
+});
+
 // GET /api/v1/overlay-library-configs/:libraryId/status - Get overlay application status for library
 router.get('/:libraryId/status', (req, res) => {
   const { libraryId } = req.params;

--- a/src/components/Dashboard/RunningJobsCard.tsx
+++ b/src/components/Dashboard/RunningJobsCard.tsx
@@ -1,0 +1,80 @@
+import axios from 'axios';
+import { useState } from 'react';
+import { useToasts } from 'react-toast-notifications';
+import useSWR from 'swr';
+import LibraryProgressCard, {
+  type LibraryStatus,
+} from '@app/components/PostersView/LibraryProgressCard';
+
+interface RunningLibrariesResponse {
+  runningLibraries: LibraryStatus[];
+}
+
+const RunningJobsCard: React.FC = () => {
+  const [stoppingIds, setStoppingIds] = useState<Set<string>>(new Set());
+  const { addToast } = useToasts();
+
+  const { data, mutate } = useSWR<RunningLibrariesResponse>(
+    '/api/v1/overlay-library-configs/status/all',
+    {
+      refreshInterval: (latestData) => {
+        // Only poll when there are running jobs
+        const hasRunning = latestData?.runningLibraries?.some(
+          (lib) => lib.state === 'running' || lib.state === 'cancelling'
+        );
+        return hasRunning ? 1000 : 5000; // Slow poll when idle to catch new jobs
+      },
+      revalidateOnFocus: false,
+      dedupingInterval: 2000,
+    }
+  );
+
+  const runningJobs =
+    data?.runningLibraries.filter(
+      (lib) => lib.state === 'running' || lib.state === 'cancelling'
+    ) || [];
+
+  const handleStop = async (libraryId: string) => {
+    if (stoppingIds.has(libraryId)) return; // Prevent double-click
+
+    setStoppingIds((prev) => new Set(prev).add(libraryId));
+    try {
+      // Cancel the scheduled overlay job (this cancels the entire job, not just one library)
+      await axios.post('/api/v1/settings/jobs/overlay-application/cancel');
+      await mutate();
+    } catch (error) {
+      addToast('Failed to stop overlay job', {
+        appearance: 'error',
+        autoDismiss: true,
+      });
+    } finally {
+      setStoppingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(libraryId);
+        return next;
+      });
+    }
+  };
+
+  if (runningJobs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-6">
+      <h3 className="mb-4 text-lg font-semibold text-white">Overlay Jobs</h3>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {runningJobs.map((lib) => (
+          <LibraryProgressCard
+            key={lib.libraryId}
+            status={lib}
+            onStop={() => handleStop(lib.libraryId)}
+            isStopping={stoppingIds.has(lib.libraryId)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RunningJobsCard;

--- a/src/components/PostersView/LibraryConfigView.tsx
+++ b/src/components/PostersView/LibraryConfigView.tsx
@@ -14,6 +14,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import { useToasts } from 'react-toast-notifications';
 import useSWR from 'swr';
 import LibraryDetailConfigView from './LibraryDetailConfigView';
+import LibraryProgressCard, { type LibraryStatus } from './LibraryProgressCard';
 import PosterResetModal from './PosterResetModal';
 
 const messages = defineMessages({
@@ -194,11 +195,11 @@ const LibraryConfigView: React.FC = () => {
   >(new Set());
   const confirmTimeoutsRef = useRef<Map<string, NodeJS.Timeout>>(new Map());
 
-  // Poll for running library overlays
-  const { data: runningLibrariesData } = useSWR<{
-    runningLibraries: { libraryId: string }[];
+  // Poll for running library overlays with full progress status
+  const { data: runningLibrariesData, mutate: mutateRunningLibraries } = useSWR<{
+    runningLibraries: (LibraryStatus & { libraryId: string })[];
   }>('/api/v1/overlay-library-configs/status/all', {
-    refreshInterval: 3000, // Poll every 3 seconds
+    refreshInterval: 1000, // Poll every second for responsive progress updates
   });
 
   // Update syncing libraries based on actual status
@@ -236,6 +237,19 @@ const LibraryConfigView: React.FC = () => {
   const handleResetComplete = () => {
     // Refresh the library configs after reset
     setResetModalOpen(false);
+  };
+
+  const handleStopSync = async (_libraryId: string) => {
+    try {
+      // Cancel the scheduled overlay job (this cancels the entire job, not just one library)
+      await axios.post('/api/v1/settings/jobs/overlay-application/cancel');
+      mutateRunningLibraries();
+    } catch (error) {
+      addToast('Failed to stop overlay sync', {
+        appearance: 'error',
+        autoDismiss: true,
+      });
+    }
   };
 
   const handleLibrarySync = async (libraryId: string, libraryName: string) => {
@@ -355,8 +369,29 @@ const LibraryConfigView: React.FC = () => {
     return configsData?.configs.find((c) => c.libraryId === libraryId);
   };
 
+  // Get running jobs for progress display
+  const runningJobs = runningLibrariesData?.runningLibraries.filter(
+    (lib) => lib.running
+  ) || [];
+
   return (
     <div className="space-y-6">
+      {/* Progress Cards for Running Jobs */}
+      {runningJobs.length > 0 && (
+        <div className="space-y-4">
+          <h3 className="text-sm font-medium text-stone-400">Running Jobs</h3>
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {runningJobs.map((lib) => (
+              <LibraryProgressCard
+                key={lib.libraryId}
+                status={lib}
+                onStop={() => handleStopSync(lib.libraryId)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {libraries.map((library) => {
           const config = getLibraryConfig(library.key);

--- a/src/components/PostersView/LibraryProgressCard.tsx
+++ b/src/components/PostersView/LibraryProgressCard.tsx
@@ -1,0 +1,214 @@
+import Button from '@app/components/Common/Button';
+import {
+  CheckIcon,
+  ExclamationTriangleIcon,
+  ForwardIcon,
+  FunnelIcon,
+  StopIcon,
+} from '@heroicons/react/24/outline';
+import type React from 'react';
+import { useMemo } from 'react';
+
+export type JobState = 'running' | 'cancelling' | 'completed' | 'cancelled' | 'failed';
+
+export interface LibraryStatus {
+  libraryId: string;
+  running: boolean;
+  state: JobState;
+  libraryName: string;
+  startTime: number;
+  runningFor: number;
+  totalItems: number;
+  currentItem: number;
+  currentTitle: string;
+  filteredCount: number;
+  successCount: number;
+  errorCount: number;
+  skippedCount: number;
+  progressPercent: number;
+  estimatedSecondsRemaining: number | null;
+}
+
+interface LibraryProgressCardProps {
+  status: LibraryStatus;
+  onStop: () => void;
+  isStopping?: boolean;
+}
+
+const formatTime = (seconds: number): string => {
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  if (minutes < 60) return `${minutes}m ${secs}s`;
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  return `${hours}h ${mins}m`;
+};
+
+const getBorderColor = (state: JobState): string => {
+  switch (state) {
+    case 'completed':
+      return 'border-green-500';
+    case 'cancelled':
+    case 'cancelling':
+      return 'border-amber-500';
+    case 'failed':
+      return 'border-red-500';
+    case 'running':
+    default:
+      return 'border-orange-500';
+  }
+};
+
+const getProgressBarColor = (state: JobState): string => {
+  switch (state) {
+    case 'completed':
+      return 'bg-green-500';
+    case 'cancelled':
+    case 'cancelling':
+      return 'bg-amber-500';
+    case 'failed':
+      return 'bg-red-500';
+    case 'running':
+    default:
+      return 'bg-orange-500';
+  }
+};
+
+const LibraryProgressCard: React.FC<LibraryProgressCardProps> = ({
+  status,
+  onStop,
+  isStopping = false,
+}) => {
+  const borderColor = useMemo(() => getBorderColor(status.state), [status.state]);
+  const progressBarColor = useMemo(
+    () => getProgressBarColor(status.state),
+    [status.state]
+  );
+
+  const eta = useMemo(() => {
+    if (status.estimatedSecondsRemaining === null) return null;
+    return formatTime(status.estimatedSecondsRemaining);
+  }, [status.estimatedSecondsRemaining]);
+
+  const totalProcessed = useMemo(
+    () =>
+      status.successCount +
+      status.errorCount +
+      status.skippedCount +
+      status.filteredCount,
+    [status.successCount, status.errorCount, status.skippedCount, status.filteredCount]
+  );
+
+  return (
+    <div
+      className={`rounded-lg border-2 ${borderColor} bg-stone-800 p-6 shadow-sm transition-all`}
+    >
+      {/* Header */}
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-white">{status.libraryName}</h3>
+          <p className="text-xs text-gray-400">
+            {status.state === 'cancelling'
+              ? 'Stopping...'
+              : status.state === 'running'
+                ? 'In Progress'
+                : status.state.charAt(0).toUpperCase() + status.state.slice(1)}
+          </p>
+        </div>
+        <Button
+          buttonType="danger"
+          buttonSize="sm"
+          onClick={onStop}
+          disabled={status.state === 'cancelling' || isStopping}
+          className="flex items-center gap-1.5"
+        >
+          <StopIcon className="h-4 w-4" />
+          {isStopping ? 'Stopping...' : 'Stop'}
+        </Button>
+      </div>
+
+      {/* Progress Bar */}
+      <div className="mb-4">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-xs font-medium text-gray-300">Progress</span>
+          <span className="text-xs text-gray-400">{status.progressPercent}%</span>
+        </div>
+        <div className="h-2 overflow-hidden rounded-full bg-gray-700">
+          <div
+            className={`h-full transition-all duration-300 ${progressBarColor}`}
+            style={{ width: `${status.progressPercent}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Current Item */}
+      {status.currentTitle && (
+        <div className="mb-4 rounded-md bg-stone-900 p-3">
+          <p className="text-xs text-gray-500">Processing</p>
+          <p className="truncate text-sm font-medium text-white">{status.currentTitle}</p>
+          <p className="text-xs text-gray-500">
+            Item {status.currentItem} of {status.totalItems}
+          </p>
+        </div>
+      )}
+
+      {/* Stats Row */}
+      <div className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div className="rounded-md bg-stone-900 p-3">
+          <div className="flex items-center gap-2">
+            <CheckIcon className="h-4 w-4 text-green-400" />
+            <span className="text-xs text-gray-400">Success</span>
+          </div>
+          <p className="mt-1 text-lg font-semibold text-green-400">
+            {status.successCount}
+          </p>
+        </div>
+
+        <div className="rounded-md bg-stone-900 p-3">
+          <div className="flex items-center gap-2">
+            <ExclamationTriangleIcon className="h-4 w-4 text-red-400" />
+            <span className="text-xs text-gray-400">Errors</span>
+          </div>
+          <p className="mt-1 text-lg font-semibold text-red-400">
+            {status.errorCount}
+          </p>
+        </div>
+
+        <div className="rounded-md bg-stone-900 p-3">
+          <div className="flex items-center gap-2">
+            <ForwardIcon className="h-4 w-4 text-amber-400" />
+            <span className="text-xs text-gray-400">Unchanged</span>
+          </div>
+          <p className="mt-1 text-lg font-semibold text-amber-400">
+            {status.skippedCount}
+          </p>
+        </div>
+
+        <div className="rounded-md bg-stone-900 p-3">
+          <div className="flex items-center gap-2">
+            <FunnelIcon className="h-4 w-4 text-blue-400" />
+            <span className="text-xs text-gray-400">Filtered</span>
+          </div>
+          <p className="mt-1 text-lg font-semibold text-blue-400">
+            {status.filteredCount}
+          </p>
+        </div>
+      </div>
+
+      {/* Footer Info */}
+      <div className="flex items-center justify-between text-xs text-gray-500">
+        <span>
+          Processed {totalProcessed} / {status.totalItems}
+        </span>
+        {eta && (
+          <span>
+            ETA: <span className="text-gray-300">{eta}</span>
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default LibraryProgressCard;

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -3,10 +3,10 @@ import PageTitle from '@app/components/Common/PageTitle';
 import { Permission, useUser } from '@app/hooks/useUser';
 import type { NextPage } from 'next';
 import { defineMessages, useIntl } from 'react-intl';
-// useSWR import removed - not used in simplified dashboard
 import CollectionStatsGrid from '@app/components/Dashboard/CollectionStatsGrid';
 import DashboardStats from '@app/components/Dashboard/DashboardStats';
 import MissingItemsFeed from '@app/components/Dashboard/MissingItemsFeed';
+import RunningJobsCard from '@app/components/Dashboard/RunningJobsCard';
 
 const messages = defineMessages({
   dashboardTitle: 'Dashboard',
@@ -49,6 +49,9 @@ const DashboardPage: NextPage = () => {
       </div>
 
       <div className="space-y-6">
+        {/* Running Jobs - shown at top when jobs are active */}
+        <RunningJobsCard />
+
         {/* Overview Stats */}
         <DashboardStats />
 


### PR DESCRIPTION
## Summary

Adds a dashboard card showing live overlay job progress:

- Progress bar with percentage and ETA (rolling 20-item average)
- Real-time item counts: Success, Errors, Unchanged, Filtered
- Current item title being processed
- Stop/cancel functionality
- Conditional polling (1s when active, 5s when idle)

![Job Progress Card](https://github.com/user-attachments/assets/placeholder)

## Backend Changes

- `JobState` enum: `running` → `cancelling` → `cancelled`/`completed`/`failed`
- `LibraryProgress` tracks per-library state with mutex prevention
- Completed jobs visible for 10s TTL before cleanup
- Mutex waits on cancelling jobs (not just running)

## API Additions

- `GET /api/v1/overlay-library-configs/status/all` - returns all running jobs with progress
- Stop uses existing `/api/v1/settings/jobs/overlay-application/cancel`

## Count Invariant

```
success + error + unchanged + filtered = processed
```

## Test Plan

- [ ] Start overlay job, verify progress card appears on dashboard
- [ ] Verify counts increment correctly during processing
- [ ] Verify ETA appears after ~5 items processed
- [ ] Click Stop, verify job cancels
- [ ] Verify card disappears after job completes (10s TTL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)