### PR TITLE
fix(security): Harden error logging and input validation

### DIFF
--- a/server/api/animeIds.ts
+++ b/server/api/animeIds.ts
@@ -38,46 +38,91 @@ export function getAllValues<T>(value: T | T[] | undefined): T[] {
   return normalizeToArray(value);
 }
 
+// Maximum response size (50MB) and timeout (30s)
+const MAX_RESPONSE_SIZE = 50 * 1024 * 1024;
+const FETCH_TIMEOUT_MS = 30000;
+
 export async function loadAnimeIds(
   url = 'https://raw.githubusercontent.com/eliasbenb/PlexAniBridge-Mappings/refs/heads/v2/mappings.json'
 ): Promise<void> {
-  const res = await fetch(url, {
-    headers: { Accept: 'application/json' },
-    // be explicit that we want fresh-ish
-    cache: 'no-store' as RequestCache,
-  });
-  if (!res.ok) throw new Error(`Anime-IDs fetch failed: ${res.status}`);
-  const json = (await res.json()) as RawAnimeIds;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
-  const byAniList = new Map<number, AnimeIdsRow>();
-  const byAniDB = new Map<number, AnimeIdsRow>();
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store' as RequestCache,
+      signal: controller.signal,
+    });
 
-  // Build indices - keys are now AniList IDs directly!
-  for (const [anilistIdStr, row] of Object.entries(json)) {
-    // Skip metadata keys like "$includes"
-    if (anilistIdStr.startsWith('$')) continue;
+    if (!res.ok) throw new Error(`Anime-IDs fetch failed: ${res.status}`);
 
-    const anilistId = parseInt(anilistIdStr);
-    if (!anilistId || !Number.isFinite(anilistId)) continue;
-
-    // Store the row as-is (already well-structured)
-    const normalized: AnimeIdsRow = {
-      ...row,
-      anilist_id: anilistId, // Add the key as a field for completeness
-    };
-
-    // Store by AniList ID (primary key)
-    byAniList.set(anilistId, normalized);
-
-    // Also index by AniDB ID if present
-    if (row.anidb_id) {
-      byAniDB.set(row.anidb_id, normalized);
+    // Check content-length header first
+    const contentLength = res.headers.get('content-length');
+    if (contentLength && parseInt(contentLength, 10) > MAX_RESPONSE_SIZE) {
+      throw new Error(`Response too large: ${contentLength} bytes`);
     }
-  }
 
-  _byAniList = byAniList;
-  _byAniDB = byAniDB;
-  _loadedAt = Date.now();
+    // Stream response with real-time size enforcement
+    const reader = res.body?.getReader();
+    if (!reader) throw new Error('Response body not readable');
+
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        totalBytes += value.length;
+        if (totalBytes > MAX_RESPONSE_SIZE) {
+          controller.abort();
+          throw new Error(`Response exceeded ${MAX_RESPONSE_SIZE} bytes`);
+        }
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    // Combine chunks and parse
+    const combined = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      combined.set(chunk, offset);
+      offset += chunk.length;
+    }
+
+    const json = JSON.parse(new TextDecoder().decode(combined)) as RawAnimeIds;
+
+    const byAniList = new Map<number, AnimeIdsRow>();
+    const byAniDB = new Map<number, AnimeIdsRow>();
+
+    for (const [anilistIdStr, row] of Object.entries(json)) {
+      if (anilistIdStr.startsWith('$')) continue;
+
+      const anilistId = parseInt(anilistIdStr);
+      if (!anilistId || !Number.isFinite(anilistId)) continue;
+
+      const normalized: AnimeIdsRow = {
+        ...row,
+        anilist_id: anilistId,
+      };
+
+      byAniList.set(anilistId, normalized);
+
+      if (row.anidb_id) {
+        byAniDB.set(row.anidb_id, normalized);
+      }
+    }
+
+    _byAniList = byAniList;
+    _byAniDB = byAniDB;
+    _loadedAt = Date.now();
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 export async function ensureAnimeIdsLoaded(

--- a/server/api/animeIds.ts
+++ b/server/api/animeIds.ts
@@ -10,16 +10,16 @@ export type AnimeIdsRow = {
   tmdb_movie_id?: number | number[]; // TMDB Movie ID(s) - can be single or array
   tmdb_show_id?: number; // TMDB Show ID - always single
   tvdb_id?: number; // TVDB ID - always single
-  tmdb_mappings?: Record<string, string>; // TMDB season mappings (e.g., {"s1": "e1-e12|2"})
-  tvdb_mappings?: Record<string, string>; // TVDB season mappings
+  tmdb_mappings?: Record; // TMDB season mappings (e.g., {"s1": "e1-e12|2"})
+  tvdb_mappings?: Record; // TVDB season mappings
 };
 
-type RawAnimeIds = Record<string, AnimeIdsRow>; // keyed by AniList ID
+type RawAnimeIds = Record; // keyed by AniList ID
 
 let _loadedAt = 0;
-let _byAniList = new Map<number, AnimeIdsRow>();
-let _byAniDB = new Map<number, AnimeIdsRow>(); // For AniDB lookups
-let _loadInFlight: Promise<void> | null = null;
+let _byAniList = new Map();
+let _byAniDB = new Map(); // For AniDB lookups
+let _loadInFlight: Promise | null = null;
 
 // Normalize array fields to always be arrays for consistent handling
 function normalizeToArray<T>(value: T | T[] | undefined): T[] {
@@ -44,7 +44,7 @@ const FETCH_TIMEOUT_MS = 30000;
 
 export async function loadAnimeIds(
   url = 'https://raw.githubusercontent.com/eliasbenb/PlexAniBridge-Mappings/refs/heads/v2/mappings.json'
-): Promise<void> {
+): Promise {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
@@ -96,8 +96,8 @@ export async function loadAnimeIds(
 
     const json = JSON.parse(new TextDecoder().decode(combined)) as RawAnimeIds;
 
-    const byAniList = new Map<number, AnimeIdsRow>();
-    const byAniDB = new Map<number, AnimeIdsRow>();
+    const byAniList = new Map();
+    const byAniDB = new Map();
 
     for (const [anilistIdStr, row] of Object.entries(json)) {
       if (anilistIdStr.startsWith('$')) continue;
@@ -127,7 +127,7 @@ export async function loadAnimeIds(
 
 export async function ensureAnimeIdsLoaded(
   ttlMs = 12 * 60 * 60 * 1000
-): Promise<void> {
+): Promise {
   const stale = Date.now() - _loadedAt > ttlMs;
   if (_byAniList.size > 0 && !stale) return;
   if (_loadInFlight) return _loadInFlight;

--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -1,8 +1,8 @@
+import logger from '@server/logger';
 import type { AxiosInstance, AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 import rateLimit from 'axios-rate-limit';
 import type NodeCache from 'node-cache';
-import logger from '@server/logger';
 
 // 5 minute default TTL (in seconds)
 const DEFAULT_TTL = 300;
@@ -12,7 +12,7 @@ const DEFAULT_ROLLING_BUFFER = 10000;
 
 interface ExternalAPIOptions {
   nodeCache?: NodeCache;
-  headers?: Record<string, unknown>;
+  headers?: Record;
   rateLimit?: {
     maxRPS: number;
     maxRequests: number;
@@ -26,7 +26,7 @@ class ExternalAPI {
 
   constructor(
     baseUrl: string,
-    params: Record<string, unknown>,
+    params: Record,
     options: ExternalAPIOptions = {}
   ) {
     this.axios = axios.create({
@@ -54,14 +54,14 @@ class ExternalAPI {
     endpoint: string,
     config?: AxiosRequestConfig,
     ttl?: number
-  ): Promise<T> {
+  ): Promise {
     const cacheKey = this.serializeCacheKey(endpoint, config?.params);
-    const cachedItem = this.cache?.get<T>(cacheKey);
+    const cachedItem = this.cache?.get(cacheKey);
     if (cachedItem) {
       return cachedItem;
     }
 
-    const response = await this.axios.get<T>(endpoint, config);
+    const response = await this.axios.get(endpoint, config);
 
     if (this.cache) {
       this.cache.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
@@ -72,20 +72,20 @@ class ExternalAPI {
 
   protected async post<T>(
     endpoint: string,
-    data: Record<string, unknown>,
+    data: Record,
     config?: AxiosRequestConfig,
     ttl?: number
-  ): Promise<T> {
+  ): Promise {
     const cacheKey = this.serializeCacheKey(endpoint, {
       config: config?.params,
       data,
     });
-    const cachedItem = this.cache?.get<T>(cacheKey);
+    const cachedItem = this.cache?.get(cacheKey);
     if (cachedItem) {
       return cachedItem;
     }
 
-    const response = await this.axios.post<T>(endpoint, data, config);
+    const response = await this.axios.post(endpoint, data, config);
 
     if (this.cache) {
       this.cache.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
@@ -98,9 +98,9 @@ class ExternalAPI {
     endpoint: string,
     config?: AxiosRequestConfig,
     ttl?: number
-  ): Promise<T> {
+  ): Promise {
     const cacheKey = this.serializeCacheKey(endpoint, config?.params);
-    const cachedItem = this.cache?.get<T>(cacheKey);
+    const cachedItem = this.cache?.get(cacheKey);
 
     if (cachedItem) {
       const keyTtl = this.cache?.getTtl(cacheKey) ?? 0;
@@ -111,7 +111,7 @@ class ExternalAPI {
         Date.now() - DEFAULT_ROLLING_BUFFER
       ) {
         this.axios
-          .get<T>(endpoint, config)
+          .get(endpoint, config)
           .then((response) => {
             this.cache?.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
           })
@@ -127,7 +127,7 @@ class ExternalAPI {
       return cachedItem;
     }
 
-    const response = await this.axios.get<T>(endpoint, config);
+    const response = await this.axios.get(endpoint, config);
 
     if (this.cache) {
       this.cache.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
@@ -136,10 +136,7 @@ class ExternalAPI {
     return response.data;
   }
 
-  private serializeCacheKey(
-    endpoint: string,
-    params?: Record<string, unknown>
-  ) {
+  private serializeCacheKey(endpoint: string, params?: Record) {
     if (!params) {
       return `${this.baseUrl}${endpoint}`;
     }

--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -2,6 +2,7 @@ import type { AxiosInstance, AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 import rateLimit from 'axios-rate-limit';
 import type NodeCache from 'node-cache';
+import logger from '@server/logger';
 
 // 5 minute default TTL (in seconds)
 const DEFAULT_TTL = 300;
@@ -109,9 +110,19 @@ class ExternalAPI {
         keyTtl - (ttl ?? DEFAULT_TTL) * 1000 <
         Date.now() - DEFAULT_ROLLING_BUFFER
       ) {
-        this.axios.get<T>(endpoint, config).then((response) => {
-          this.cache?.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
-        });
+        this.axios
+          .get<T>(endpoint, config)
+          .then((response) => {
+            this.cache?.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
+          })
+          .catch((error) => {
+            // Log but don't throw - background refresh failure is acceptable
+            logger.warn('Rolling cache refresh failed', {
+              label: 'ExternalAPI',
+              endpoint,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          });
       }
       return cachedItem;
     }

--- a/server/api/overseerr.ts
+++ b/server/api/overseerr.ts
@@ -202,10 +202,10 @@ class OverseerrAPI {
    * Retry helper with exponential backoff for transient network errors
    */
   private async retryWithBackoff<T>(
-    fn: () => Promise<T>,
+    fn: () => Promise,
     maxRetries = 3,
     initialDelayMs = 1000
-  ): Promise<T> {
+  ): Promise {
     let lastError: Error | undefined;
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -250,7 +250,7 @@ class OverseerrAPI {
    * Uses /auth/me endpoint to validate API key authentication
    * Throws the actual error for proper error handling in routes
    */
-  async testConnection(): Promise<{ success: boolean }> {
+  async testConnection(): Promise {
     await this.axios.get('/auth/me');
     return {
       success: true,
@@ -260,10 +260,7 @@ class OverseerrAPI {
   /**
    * Get all users from Overseerr
    */
-  async getUsers(params?: { take?: number; skip?: number }): Promise<{
-    results: OverseerrUser[];
-    total: number;
-  }> {
+  async getUsers(params?: { take?: number; skip?: number }): Promise {
     const response = await this.axios.get('/user', { params });
     return response.data;
   }
@@ -271,7 +268,7 @@ class OverseerrAPI {
   /**
    * Get specific user by ID
    */
-  async getUser(userId: number): Promise<OverseerrUser> {
+  async getUser(userId: number): Promise {
     const response = await this.axios.get(`/user/${userId}`);
     return response.data;
   }
@@ -279,7 +276,7 @@ class OverseerrAPI {
   /**
    * Create or update a service user
    */
-  async createUser(userData: CreateUserRequest): Promise<OverseerrUser> {
+  async createUser(userData: CreateUserRequest): Promise {
     const response = await this.axios.post('/user', userData);
     return response.data;
   }
@@ -287,10 +284,7 @@ class OverseerrAPI {
   /**
    * Update user permissions
    */
-  async updateUserPermissions(
-    userId: number,
-    permissions: number
-  ): Promise<void> {
+  async updateUserPermissions(userId: number, permissions: number): Promise {
     await this.axios.post(`/user/${userId}/settings/permissions`, {
       permissions: permissions,
     });
@@ -299,7 +293,7 @@ class OverseerrAPI {
   /**
    * Get current authenticated user (admin check)
    */
-  async getCurrentUser(): Promise<OverseerrUser> {
+  async getCurrentUser(): Promise {
     const response = await this.axios.get('/auth/me');
     return response.data;
   }
@@ -322,10 +316,7 @@ class OverseerrAPI {
       | 'deleted'
       | 'completed';
     sort?: 'added' | 'modified';
-  }): Promise<{
-    results: OverseerrMediaRequest[];
-    total: number;
-  }> {
+  }): Promise {
     const response = await this.axios.get('/request', { params });
     return response.data;
   }
@@ -333,9 +324,7 @@ class OverseerrAPI {
   /**
    * Create a new media request
    */
-  async createRequest(
-    requestData: CreateMediaRequestParams
-  ): Promise<OverseerrMediaRequest> {
+  async createRequest(requestData: CreateMediaRequestParams): Promise {
     const payload: OverseerrRequestPayload = {
       mediaId: requestData.mediaId,
       mediaType: requestData.mediaType,
@@ -379,7 +368,7 @@ class OverseerrAPI {
   /**
    * Check if media exists in Plex by TMDB ID
    */
-  async getMediaByTmdbId(tmdbId: number): Promise<OverseerrMedia | null> {
+  async getMediaByTmdbId(tmdbId: number): Promise {
     try {
       const response = await this.axios.get(`/media/${tmdbId}`);
       return response.data;
@@ -394,10 +383,7 @@ class OverseerrAPI {
   /**
    * Search for existing requests to avoid duplicates
    */
-  async checkRequestExists(
-    tmdbId: number,
-    userId: number
-  ): Promise<OverseerrMediaRequest | null> {
+  async checkRequestExists(tmdbId: number, userId: number): Promise {
     try {
       // Get user's requests and check for this TMDB ID
       const requests = await this.getRequests({
@@ -421,7 +407,7 @@ class OverseerrAPI {
   /**
    * Get request count (for admin operations)
    */
-  async getRequestCount(): Promise<number> {
+  async getRequestCount(): Promise {
     const response = await this.axios.get('/request/count');
     return response.data;
   }
@@ -429,7 +415,7 @@ class OverseerrAPI {
   /**
    * Get media season count for TV shows
    */
-  async getMediaSeasonCount(tmdbId: number): Promise<number> {
+  async getMediaSeasonCount(tmdbId: number): Promise {
     const media = await this.getMediaByTmdbId(tmdbId);
     return media?.seasonCount || 0;
   }
@@ -437,7 +423,7 @@ class OverseerrAPI {
   /**
    * Batch get users by IDs
    */
-  async getUsersByIds(userIds: number[]): Promise<OverseerrUser[]> {
+  async getUsersByIds(userIds: number[]): Promise {
     // Overseerr doesn't have batch user endpoint, so fetch individually
     const users: OverseerrUser[] = [];
 
@@ -458,7 +444,7 @@ class OverseerrAPI {
   /**
    * Get admin user (typically user ID 1) with caching and retry logic
    */
-  async getAdminUser(): Promise<OverseerrUser | null> {
+  async getAdminUser(): Promise {
     // Check cache first
     if (
       this.adminUserCache &&
@@ -507,10 +493,7 @@ class OverseerrAPI {
    * Get main settings from external Overseerr instance
    * Used for template variables like {domain} and {appTitle}
    */
-  async getMainSettings(): Promise<{
-    applicationUrl?: string;
-    applicationTitle?: string;
-  } | null> {
+  async getMainSettings(): Promise {
     try {
       const response = await this.axios.get('/settings/main');
       return {
@@ -531,16 +514,7 @@ class OverseerrAPI {
   /**
    * Get Radarr servers from Overseerr
    */
-  async getRadarrServers(): Promise<
-    {
-      id: number;
-      name: string;
-      hostname: string;
-      port: number;
-      is4k: boolean;
-      isDefault: boolean;
-    }[]
-  > {
+  async getRadarrServers(): Promise {
     try {
       const response = await this.axios.get('/settings/radarr');
       return response.data;
@@ -558,16 +532,7 @@ class OverseerrAPI {
   /**
    * Get Sonarr servers from Overseerr
    */
-  async getSonarrServers(): Promise<
-    {
-      id: number;
-      name: string;
-      hostname: string;
-      port: number;
-      is4k: boolean;
-      isDefault: boolean;
-    }[]
-  > {
+  async getSonarrServers(): Promise {
     try {
       const response = await this.axios.get('/settings/sonarr');
       return response.data;
@@ -585,9 +550,7 @@ class OverseerrAPI {
   /**
    * Get quality profiles from a Radarr server
    */
-  async getRadarrProfiles(
-    serverId: number
-  ): Promise<{ id: number; name: string }[]> {
+  async getRadarrProfiles(serverId: number): Promise {
     try {
       const response = await this.axios.get(`/service/radarr/${serverId}`);
       return response.data.profiles || [];
@@ -605,9 +568,7 @@ class OverseerrAPI {
   /**
    * Get quality profiles from a Sonarr server
    */
-  async getSonarrProfiles(
-    serverId: number
-  ): Promise<{ id: number; name: string }[]> {
+  async getSonarrProfiles(serverId: number): Promise {
     try {
       const response = await this.axios.get(`/service/sonarr/${serverId}`);
       return response.data.profiles || [];
@@ -625,9 +586,7 @@ class OverseerrAPI {
   /**
    * Get root folders from a Radarr server
    */
-  async getRadarrRootFolders(
-    serverId: number
-  ): Promise<{ id: number; path: string }[]> {
+  async getRadarrRootFolders(serverId: number): Promise {
     try {
       const response = await this.axios.get(`/service/radarr/${serverId}`);
       return response.data.rootFolders || [];
@@ -645,9 +604,7 @@ class OverseerrAPI {
   /**
    * Get root folders from a Sonarr server
    */
-  async getSonarrRootFolders(
-    serverId: number
-  ): Promise<{ id: number; path: string }[]> {
+  async getSonarrRootFolders(serverId: number): Promise {
     try {
       const response = await this.axios.get(`/service/sonarr/${serverId}`);
       return response.data.rootFolders || [];
@@ -665,9 +622,7 @@ class OverseerrAPI {
   /**
    * Get tags from a Radarr server
    */
-  async getRadarrTags(
-    serverId: number
-  ): Promise<{ id: number; label: string }[]> {
+  async getRadarrTags(serverId: number): Promise {
     try {
       const response = await this.axios.get(`/service/radarr/${serverId}`);
       return response.data.tags || [];
@@ -685,9 +640,7 @@ class OverseerrAPI {
   /**
    * Get tags from a Sonarr server
    */
-  async getSonarrTags(
-    serverId: number
-  ): Promise<{ id: number; label: string }[]> {
+  async getSonarrTags(serverId: number): Promise {
     try {
       const response = await this.axios.get(`/service/sonarr/${serverId}`);
       return response.data.tags || [];
@@ -705,10 +658,7 @@ class OverseerrAPI {
   /**
    * Get a user's Plex watchlist
    */
-  async getUserWatchlist(userId: number): Promise<{
-    results: OverseerrWatchlistItem[];
-    total: number;
-  }> {
+  async getUserWatchlist(userId: number): Promise {
     try {
       const response = await this.axios.get(`/user/${userId}/watchlist`);
       return {

--- a/server/api/overseerr.ts
+++ b/server/api/overseerr.ts
@@ -154,21 +154,44 @@ class OverseerrAPI {
       timeout: 30000,
     });
 
-    // Add response/error logging
+    // Add response/error logging (with sensitive data redacted)
     this.axios.interceptors.response.use(
       (response) => {
         return response;
       },
       (error) => {
+        // Redact sensitive headers to prevent credential leaks in logs
+        const safeHeaders = error.config?.headers
+          ? { ...error.config.headers }
+          : undefined;
+        if (safeHeaders) {
+          delete safeHeaders['X-Api-Key'];
+          delete safeHeaders['Authorization'];
+          delete safeHeaders['x-api-key'];
+          delete safeHeaders['authorization'];
+        }
+
+        // Truncate response data to prevent log bloat and credential echo
+        let safeResponseData: string | undefined;
+        if (error.response?.data) {
+          const dataStr =
+            typeof error.response.data === 'string'
+              ? error.response.data
+              : JSON.stringify(error.response.data);
+          safeResponseData =
+            dataStr.length > 500
+              ? dataStr.substring(0, 500) + '... [truncated]'
+              : dataStr;
+        }
+
         logger.error(`Overseerr API Error: ${error.message}`, {
           label: 'OverseerrAPI',
           url: error.config?.url,
           method: error.config?.method?.toUpperCase(),
           status: error.response?.status,
           statusText: error.response?.statusText,
-          responseData: error.response?.data,
-          requestHeaders: error.config?.headers,
-          requestData: error.config?.data,
+          responseData: safeResponseData,
+          requestHeaders: safeHeaders,
         });
         throw error;
       }

--- a/server/lib/collections/services/MultiSourceOrchestrator.ts
+++ b/server/lib/collections/services/MultiSourceOrchestrator.ts
@@ -156,6 +156,16 @@ export class MultiSourceOrchestrator {
         isActive: timeRestrictionResult.isActive,
       });
 
+      // Validate sources array is not empty (prevents division by zero in cycle_lists)
+      if (!config.sources || config.sources.length === 0) {
+        logger.error(`Multi-source collection has no sources: ${config.name}`, {
+          label: 'Multi-Source Orchestrator',
+          configId: config.id,
+          combineMode: config.combineMode,
+        });
+        return { created: 0, updated: 0 };
+      }
+
       // Increment sync counter for cycle_lists mode
       if (config.combineMode === 'cycle_lists') {
         const newCounter = incrementCollectionSyncCounter(config.id);

--- a/server/lib/collections/services/MultiSourceOrchestrator.ts
+++ b/server/lib/collections/services/MultiSourceOrchestrator.ts
@@ -69,8 +69,8 @@ interface CollectionUpdateOptions {
   sortOrderLibrary?: number;
   isLibraryPromoted?: boolean;
   totalCollectionsInLibrary?: number;
-  customPoster?: string | Record<string, string>;
-  processedCollectionKeys?: Set<string>;
+  customPoster?: string | Record;
+  processedCollectionKeys?: Set;
   libraryKey: string;
   config: MultiSourceCollectionConfig;
 }
@@ -80,7 +80,7 @@ interface MetadataUpdateOptions {
   visibilityConfig: CollectionVisibilityConfig;
   sortOrderLibrary?: number;
   isLibraryPromoted?: boolean;
-  customPoster?: string | Record<string, string>;
+  customPoster?: string | Record;
   config: MultiSourceCollectionConfig;
 }
 
@@ -96,10 +96,7 @@ interface MetadataUpdateOptions {
  * This approach reuses all existing sync logic while keeping multi-source as a separate concern.
  */
 export class MultiSourceOrchestrator {
-  private syncServices = new Map<
-    string,
-    BaseCollectionSync<CollectionSource>
-  >();
+  private syncServices = new Map();
   private dynamicCycleTitle: string | null = null;
 
   constructor() {
@@ -113,10 +110,10 @@ export class MultiSourceOrchestrator {
     config: MultiSourceCollectionConfig,
     plexClient: PlexAPI,
     allCollections: PlexCollection[],
-    processedCollectionKeys?: Set<string>,
+    processedCollectionKeys?: Set,
     libraryCache?: LibraryItemsCache,
     options?: CollectionSyncOptions
-  ): Promise<{ created: number; updated: number }> {
+  ): Promise {
     let configForSync: MultiSourceCollectionConfig = config;
     let collectionNameForSync = config.name;
 
@@ -212,9 +209,8 @@ export class MultiSourceOrchestrator {
         sourcesToFetch.length === 1
       ) {
         const activeSource = sourcesToFetch[0];
-        this.dynamicCycleTitle = await this.extractTitleFromSource(
-          activeSource
-        );
+        this.dynamicCycleTitle =
+          await this.extractTitleFromSource(activeSource);
 
         if (this.dynamicCycleTitle) {
           const previousName = config.name;
@@ -280,7 +276,7 @@ export class MultiSourceOrchestrator {
         } catch (error) {
           // Proper error serialization - handle CollectionSyncError objects
           let errorMessage: string;
-          const errorDetails: Record<string, unknown> = {};
+          const errorDetails: Record = {};
 
           if (error instanceof Error) {
             errorMessage = error.message;
@@ -296,7 +292,7 @@ export class MultiSourceOrchestrator {
             const structuredError = error as {
               message: string;
               type?: string;
-              details?: Record<string, unknown>;
+              details?: Record;
               originalError?: Error;
             };
             errorMessage = structuredError.message;
@@ -399,7 +395,7 @@ export class MultiSourceOrchestrator {
       // If createPlaceholdersForMissing disabled: deletes all placeholder records
       try {
         // Collect all tmdbIds from ALL sources (both items that exist in Plex and missing items)
-        const allSourceTmdbIds = new Set<number>();
+        const allSourceTmdbIds = new Set();
 
         // Add tmdbIds from items that exist in Plex
         for (const item of combinedItems) {
@@ -426,9 +422,8 @@ export class MultiSourceOrchestrator {
         );
 
         // Import helper function that handles both enabled/disabled cases
-        const { handlePlaceholderCleanup } = await import(
-          '@server/lib/placeholders/services/PlaceholderCleanup'
-        );
+        const { handlePlaceholderCleanup } =
+          await import('@server/lib/placeholders/services/PlaceholderCleanup');
 
         // Run cleanup or deletion based on setting
         await handlePlaceholderCleanup(
@@ -583,7 +578,7 @@ export class MultiSourceOrchestrator {
     plexClient: PlexAPI,
     libraryCache?: LibraryItemsCache,
     options?: CollectionSyncOptions
-  ): Promise<{ items: CollectionItem[]; missingItems?: MissingItem[] }> {
+  ): Promise {
     // Create temporary single-source config
     const tempConfig = this.createTempConfig(source, parentConfig);
 
@@ -630,9 +625,8 @@ export class MultiSourceOrchestrator {
         try {
           // Use PlaceholderCreation service for unified placeholder creation
           // This works for any source type, not just Coming Soon
-          const { processPlaceholdersForMissingItems } = await import(
-            '@server/lib/placeholders/services/PlaceholderCreation'
-          );
+          const { processPlaceholdersForMissingItems } =
+            await import('@server/lib/placeholders/services/PlaceholderCreation');
 
           const newPlaceholderItems = await processPlaceholdersForMissingItems(
             missingItems,
@@ -679,7 +673,7 @@ export class MultiSourceOrchestrator {
     } catch (error) {
       // Proper error serialization - handle CollectionSyncError objects
       let errorMessage: string;
-      const errorDetails: Record<string, unknown> = {};
+      const errorDetails: Record = {};
 
       if (error instanceof Error) {
         errorMessage = error.message;
@@ -695,7 +689,7 @@ export class MultiSourceOrchestrator {
         const structuredError = error as {
           message: string;
           type?: string;
-          details?: Record<string, unknown>;
+          details?: Record;
           originalError?: Error;
         };
         errorMessage = structuredError.message;
@@ -797,9 +791,7 @@ export class MultiSourceOrchestrator {
   /**
    * Get or create sync service for the specified source type
    */
-  private getSyncService(
-    sourceType: string
-  ): BaseCollectionSync<CollectionSource> {
+  private getSyncService(sourceType: string): BaseCollectionSync {
     if (!this.syncServices.has(sourceType)) {
       switch (sourceType) {
         case 'trakt':
@@ -983,7 +975,7 @@ export class MultiSourceOrchestrator {
             }
             return acc;
           },
-          { seen: new Set<string>(), items: [] as MissingItem[] }
+          { seen: new Set(), items: [] as MissingItem[] }
         ).items;
 
         logger.debug(
@@ -1011,7 +1003,7 @@ export class MultiSourceOrchestrator {
     collectionRatingKey: string,
     currentContainsEpisodes: boolean,
     mediaType: 'movie' | 'tv'
-  ): Promise<boolean> {
+  ): Promise {
     // Only need to check TV collections (movies can't have episode content)
     if (mediaType !== 'tv') {
       return false;
@@ -1019,9 +1011,8 @@ export class MultiSourceOrchestrator {
 
     try {
       // Get current collection items to analyze their type
-      const currentItemRatingKeys = await plexClient.getCollectionItems(
-        collectionRatingKey
-      );
+      const currentItemRatingKeys =
+        await plexClient.getCollectionItems(collectionRatingKey);
 
       // For empty collections, we need to check the collection's inherent type
       // Unfortunately, Plex doesn't directly expose this, but we can infer it by
@@ -1235,8 +1226,8 @@ export class MultiSourceOrchestrator {
     config: MultiSourceCollectionConfig,
     plexClient: PlexAPI,
     allCollections: PlexCollection[],
-    processedCollectionKeys?: Set<string>
-  ): Promise<{ created: number; updated: number }> {
+    processedCollectionKeys?: Set
+  ): Promise {
     const mediaType = getMediaTypeFromLibrary(config.libraryId);
     const customLabel = createCollectionLabel(
       'multi-source' as 'overseerr',
@@ -1278,7 +1269,7 @@ export class MultiSourceOrchestrator {
     allCollections: PlexCollection[],
     items: CollectionItem[],
     options: CollectionUpdateOptions
-  ): Promise<{ created: number; updated: number }> {
+  ): Promise {
     const { collectionName, mediaType } = options;
 
     // Validate items first
@@ -1744,14 +1735,12 @@ export class MultiSourceOrchestrator {
           }
         );
 
-        const { overlayLibraryService } = await import(
-          '@server/lib/overlays/OverlayLibraryService'
-        );
+        const { overlayLibraryService } =
+          await import('@server/lib/overlays/OverlayLibraryService');
 
         // Get item rating keys from this specific collection
-        const itemRatingKeys = await plexClient.getCollectionItems(
-          collectionRatingKey
-        );
+        const itemRatingKeys =
+          await plexClient.getCollectionItems(collectionRatingKey);
 
         if (itemRatingKeys && itemRatingKeys.length > 0) {
           logger.info('Applying overlays to collection items', {
@@ -1790,7 +1779,7 @@ export class MultiSourceOrchestrator {
     collectionRatingKey: string,
     options: MetadataUpdateOptions,
     items: CollectionItem[]
-  ): Promise<void> {
+  ): Promise {
     // 1. Add proper Agregarr label (replaces any existing Agregarr labels)
     await plexClient.addLabelToCollection(
       collectionRatingKey,
@@ -1853,9 +1842,8 @@ export class MultiSourceOrchestrator {
       if (wallpaperFilename) {
         try {
           // Get full path to wallpaper file
-          const { getWallpaperPath } = await import(
-            '@server/lib/wallpaperStorage'
-          );
+          const { getWallpaperPath } =
+            await import('@server/lib/wallpaperStorage');
           const wallpaperPath = getWallpaperPath(wallpaperFilename);
 
           // Check if wallpaper needs reapplication using metadata tracking
@@ -1866,9 +1854,8 @@ export class MultiSourceOrchestrator {
           let shouldUploadWallpaper = true;
 
           try {
-            const currentArtUrl = await plexClient.getCurrentArtUrl(
-              collectionRatingKey
-            );
+            const currentArtUrl =
+              await plexClient.getCurrentArtUrl(collectionRatingKey);
 
             const shouldReapply = await metadataService.shouldReapplyWallpaper(
               collectionRatingKey,
@@ -1904,9 +1891,8 @@ export class MultiSourceOrchestrator {
 
             // Get new Plex art URL after upload and record metadata
             try {
-              const newArtUrl = await plexClient.getCurrentArtUrl(
-                collectionRatingKey
-              );
+              const newArtUrl =
+                await plexClient.getCurrentArtUrl(collectionRatingKey);
 
               if (newArtUrl) {
                 await metadataService.recordWallpaperApplication(
@@ -2010,9 +1996,8 @@ export class MultiSourceOrchestrator {
           let shouldUploadTheme = true;
 
           try {
-            const currentThemeUrl = await plexClient.getCurrentThemeUrl(
-              collectionRatingKey
-            );
+            const currentThemeUrl =
+              await plexClient.getCurrentThemeUrl(collectionRatingKey);
 
             const shouldReapply = await metadataService.shouldReapplyTheme(
               collectionRatingKey,
@@ -2048,9 +2033,8 @@ export class MultiSourceOrchestrator {
 
             // Get new Plex theme URL after upload and record metadata
             try {
-              const newThemeUrl = await plexClient.getCurrentThemeUrl(
-                collectionRatingKey
-              );
+              const newThemeUrl =
+                await plexClient.getCurrentThemeUrl(collectionRatingKey);
 
               if (newThemeUrl) {
                 await metadataService.recordThemeApplication(
@@ -2188,7 +2172,7 @@ export class MultiSourceOrchestrator {
     collectionRatingKey: string,
     plexClient: PlexAPI,
     items: CollectionItem[]
-  ): Promise<void> {
+  ): Promise {
     // Check if autoPoster is enabled (default to true for multi-source)
     const shouldGeneratePoster = config.autoPoster ?? true;
     if (!shouldGeneratePoster) {
@@ -2445,8 +2429,8 @@ export class MultiSourceOrchestrator {
     config: MultiSourceCollectionConfig,
     plexClient: PlexAPI,
     allCollections: PlexCollection[],
-    processedCollectionKeys?: Set<string>
-  ): Promise<void> {
+    processedCollectionKeys?: Set
+  ): Promise {
     // Find existing collection
     const existingCollection = allCollections.find(
       (c) => c.title === config.name && c.libraryKey === config.libraryId
@@ -2515,7 +2499,7 @@ export class MultiSourceOrchestrator {
     collectionRatingKey: string,
     collectionName: string,
     config: MultiSourceCollectionConfig
-  ): Promise<void> {
+  ): Promise {
     // Only update sortTitle if we have sortOrderLibrary defined
     if (config.sortOrderLibrary === undefined) {
       return;
@@ -2602,9 +2586,7 @@ export class MultiSourceOrchestrator {
    * For preset lists, use the subtype label
    * For custom lists, fetch the title from the API
    */
-  private async extractTitleFromSource(
-    source: SourceDefinition
-  ): Promise<string | null> {
+  private async extractTitleFromSource(source: SourceDefinition): Promise {
     try {
       // For custom lists, fetch the title from the API using same logic as fetch-title endpoint
       if (source.subtype === 'custom' && source.customUrl) {
@@ -2628,9 +2610,7 @@ export class MultiSourceOrchestrator {
    * Fetch custom list title using API clients directly
    * Based on the /api/v1/collections/fetch-title endpoint logic
    */
-  private async fetchCustomListTitle(
-    source: SourceDefinition
-  ): Promise<string | null> {
+  private async fetchCustomListTitle(source: SourceDefinition): Promise {
     if (!source.customUrl) return null;
 
     try {
@@ -2893,10 +2873,7 @@ export class MultiSourceOrchestrator {
     const subtype = source.subtype;
 
     // Map subtypes to their human-readable titles (first option in dropdown)
-    const titleMappings: Record<
-      string,
-      Record<string, string | ((source: SourceDefinition) => string)>
-    > = {
+    const titleMappings: Record = {
       trakt: {
         trending: 'Trending Now',
         popular: 'Popular',
@@ -3014,7 +2991,7 @@ export class MultiSourceOrchestrator {
    */
   private updateCollectionConfigField(
     configId: string,
-    updateConfig: Partial<MultiSourceCollectionConfig>
+    updateConfig: Partial
   ): void {
     try {
       const settings = getSettings();

--- a/server/lib/collections/services/MultiSourceOrchestrator.ts
+++ b/server/lib/collections/services/MultiSourceOrchestrator.ts
@@ -2,7 +2,6 @@ import type PlexAPI from '@server/api/plexapi';
 import type { LibraryItemsCache } from '@server/lib/collections/core/CollectionUtilities';
 import type {
   CollectionItem,
-  CollectionSource,
   CollectionSyncOptions,
   MissingItem,
   PlexCollection,
@@ -209,8 +208,9 @@ export class MultiSourceOrchestrator {
         sourcesToFetch.length === 1
       ) {
         const activeSource = sourcesToFetch[0];
-        this.dynamicCycleTitle =
-          await this.extractTitleFromSource(activeSource);
+        this.dynamicCycleTitle = await this.extractTitleFromSource(
+          activeSource
+        );
 
         if (this.dynamicCycleTitle) {
           const previousName = config.name;
@@ -422,8 +422,9 @@ export class MultiSourceOrchestrator {
         );
 
         // Import helper function that handles both enabled/disabled cases
-        const { handlePlaceholderCleanup } =
-          await import('@server/lib/placeholders/services/PlaceholderCleanup');
+        const { handlePlaceholderCleanup } = await import(
+          '@server/lib/placeholders/services/PlaceholderCleanup'
+        );
 
         // Run cleanup or deletion based on setting
         await handlePlaceholderCleanup(
@@ -625,8 +626,9 @@ export class MultiSourceOrchestrator {
         try {
           // Use PlaceholderCreation service for unified placeholder creation
           // This works for any source type, not just Coming Soon
-          const { processPlaceholdersForMissingItems } =
-            await import('@server/lib/placeholders/services/PlaceholderCreation');
+          const { processPlaceholdersForMissingItems } = await import(
+            '@server/lib/placeholders/services/PlaceholderCreation'
+          );
 
           const newPlaceholderItems = await processPlaceholdersForMissingItems(
             missingItems,
@@ -1011,8 +1013,9 @@ export class MultiSourceOrchestrator {
 
     try {
       // Get current collection items to analyze their type
-      const currentItemRatingKeys =
-        await plexClient.getCollectionItems(collectionRatingKey);
+      const currentItemRatingKeys = await plexClient.getCollectionItems(
+        collectionRatingKey
+      );
 
       // For empty collections, we need to check the collection's inherent type
       // Unfortunately, Plex doesn't directly expose this, but we can infer it by
@@ -1735,12 +1738,14 @@ export class MultiSourceOrchestrator {
           }
         );
 
-        const { overlayLibraryService } =
-          await import('@server/lib/overlays/OverlayLibraryService');
+        const { overlayLibraryService } = await import(
+          '@server/lib/overlays/OverlayLibraryService'
+        );
 
         // Get item rating keys from this specific collection
-        const itemRatingKeys =
-          await plexClient.getCollectionItems(collectionRatingKey);
+        const itemRatingKeys = await plexClient.getCollectionItems(
+          collectionRatingKey
+        );
 
         if (itemRatingKeys && itemRatingKeys.length > 0) {
           logger.info('Applying overlays to collection items', {
@@ -1842,8 +1847,9 @@ export class MultiSourceOrchestrator {
       if (wallpaperFilename) {
         try {
           // Get full path to wallpaper file
-          const { getWallpaperPath } =
-            await import('@server/lib/wallpaperStorage');
+          const { getWallpaperPath } = await import(
+            '@server/lib/wallpaperStorage'
+          );
           const wallpaperPath = getWallpaperPath(wallpaperFilename);
 
           // Check if wallpaper needs reapplication using metadata tracking
@@ -1854,8 +1860,9 @@ export class MultiSourceOrchestrator {
           let shouldUploadWallpaper = true;
 
           try {
-            const currentArtUrl =
-              await plexClient.getCurrentArtUrl(collectionRatingKey);
+            const currentArtUrl = await plexClient.getCurrentArtUrl(
+              collectionRatingKey
+            );
 
             const shouldReapply = await metadataService.shouldReapplyWallpaper(
               collectionRatingKey,
@@ -1891,8 +1898,9 @@ export class MultiSourceOrchestrator {
 
             // Get new Plex art URL after upload and record metadata
             try {
-              const newArtUrl =
-                await plexClient.getCurrentArtUrl(collectionRatingKey);
+              const newArtUrl = await plexClient.getCurrentArtUrl(
+                collectionRatingKey
+              );
 
               if (newArtUrl) {
                 await metadataService.recordWallpaperApplication(
@@ -1996,8 +2004,9 @@ export class MultiSourceOrchestrator {
           let shouldUploadTheme = true;
 
           try {
-            const currentThemeUrl =
-              await plexClient.getCurrentThemeUrl(collectionRatingKey);
+            const currentThemeUrl = await plexClient.getCurrentThemeUrl(
+              collectionRatingKey
+            );
 
             const shouldReapply = await metadataService.shouldReapplyTheme(
               collectionRatingKey,
@@ -2033,8 +2042,9 @@ export class MultiSourceOrchestrator {
 
             // Get new Plex theme URL after upload and record metadata
             try {
-              const newThemeUrl =
-                await plexClient.getCurrentThemeUrl(collectionRatingKey);
+              const newThemeUrl = await plexClient.getCurrentThemeUrl(
+                collectionRatingKey
+              );
 
               if (newThemeUrl) {
                 await metadataService.recordThemeApplication(

--- a/server/lib/overlays/LocalPosterFolderService.ts
+++ b/server/lib/overlays/LocalPosterFolderService.ts
@@ -381,9 +381,21 @@ class LocalPosterFolderService {
           const response = await axios.get(downloadPath, {
             responseType: 'arraybuffer',
             timeout: 30000,
+            maxContentLength: 50 * 1024 * 1024,
+            validateStatus: (status) => status === 200,
           });
 
+          // Validate content type is an image
+          const contentType = response.headers['content-type'] || '';
+          if (!contentType.startsWith('image/')) {
+            throw new Error(`Invalid content type: ${contentType}`);
+          }
+
           const posterBuffer = Buffer.from(response.data);
+          if (posterBuffer.length > 50 * 1024 * 1024) {
+            throw new Error(`Poster too large: ${posterBuffer.length} bytes`);
+          }
+
           await fs.writeFile(posterPath, posterBuffer);
 
           stats.downloaded++;

--- a/server/lib/overlays/LocalPosterFolderService.ts
+++ b/server/lib/overlays/LocalPosterFolderService.ts
@@ -107,7 +107,7 @@ class LocalPosterFolderService {
     plexApi: PlexAPI,
     libraryId: string,
     libraryName: string
-  ): Promise<{ created: number; skipped: number; failed: number }> {
+  ): Promise {
     logger.info('Generating folder structure for library', {
       label: 'LocalPosterFolderService',
       libraryId,
@@ -204,7 +204,7 @@ class LocalPosterFolderService {
   /**
    * Generate empty folder structure for all configured libraries
    */
-  async generateFolderStructureForAllLibraries(): Promise<void> {
+  async generateFolderStructureForAllLibraries(): Promise {
     if (this.running) {
       logger.warn('Folder generation already running', {
         label: 'LocalPosterFolderService',
@@ -222,9 +222,8 @@ class LocalPosterFolderService {
       });
 
       // Get admin user
-      const { getAdminUser } = await import(
-        '@server/lib/collections/core/CollectionUtilities'
-      );
+      const { getAdminUser } =
+        await import('@server/lib/collections/core/CollectionUtilities');
       const admin = await getAdminUser();
       if (!admin) {
         throw new Error('No admin user found');
@@ -277,7 +276,7 @@ class LocalPosterFolderService {
     plexApi: PlexAPI,
     libraryId: string,
     libraryName: string
-  ): Promise<{ downloaded: number; skipped: number; failed: number }> {
+  ): Promise {
     logger.info('Populating folders with Plex posters for library', {
       label: 'LocalPosterFolderService',
       libraryId,
@@ -429,7 +428,7 @@ class LocalPosterFolderService {
   /**
    * Populate local folders with Plex posters for all configured libraries
    */
-  async populateFromPlexForAllLibraries(): Promise<void> {
+  async populateFromPlexForAllLibraries(): Promise {
     if (this.running) {
       logger.warn('Plex poster population already running', {
         label: 'LocalPosterFolderService',
@@ -447,9 +446,8 @@ class LocalPosterFolderService {
       });
 
       // Get admin user
-      const { getAdminUser } = await import(
-        '@server/lib/collections/core/CollectionUtilities'
-      );
+      const { getAdminUser } =
+        await import('@server/lib/collections/core/CollectionUtilities');
       const admin = await getAdminUser();
       if (!admin) {
         throw new Error('No admin user found');

--- a/server/lib/overlays/LocalPosterFolderService.ts
+++ b/server/lib/overlays/LocalPosterFolderService.ts
@@ -222,8 +222,9 @@ class LocalPosterFolderService {
       });
 
       // Get admin user
-      const { getAdminUser } =
-        await import('@server/lib/collections/core/CollectionUtilities');
+      const { getAdminUser } = await import(
+        '@server/lib/collections/core/CollectionUtilities'
+      );
       const admin = await getAdminUser();
       if (!admin) {
         throw new Error('No admin user found');
@@ -446,8 +447,9 @@ class LocalPosterFolderService {
       });
 
       // Get admin user
-      const { getAdminUser } =
-        await import('@server/lib/collections/core/CollectionUtilities');
+      const { getAdminUser } = await import(
+        '@server/lib/collections/core/CollectionUtilities'
+      );
       const admin = await getAdminUser();
       if (!admin) {
         throw new Error('No admin user found');

--- a/server/lib/placeholders/placeholderManager.ts
+++ b/server/lib/placeholders/placeholderManager.ts
@@ -2,7 +2,7 @@ import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import fs from 'fs/promises';
 import path from 'path';
-import type { PlaceholderOptions, PlaceholderResult } from './types';
+import type { PlaceholderOptions } from './types';
 
 /**
  * Sanitize filename to remove invalid characters

--- a/server/lib/placeholders/placeholderManager.ts
+++ b/server/lib/placeholders/placeholderManager.ts
@@ -1,4 +1,5 @@
 import logger from '@server/logger';
+import { getSettings } from '@server/lib/settings';
 import fs from 'fs/promises';
 import path from 'path';
 import type { PlaceholderOptions, PlaceholderResult } from './types';
@@ -175,6 +176,46 @@ export async function removePlaceholder(
   mediaType: 'movie' | 'tv'
 ): Promise<void> {
   try {
+    // Security: Validate path is within configured library roots
+    const settings = getSettings();
+    const libraryRoot =
+      mediaType === 'movie'
+        ? settings.main.placeholderMovieRootFolder
+        : settings.main.placeholderTVRootFolder;
+
+    if (!libraryRoot) {
+      throw new Error(
+        `Placeholder ${mediaType} library root not configured`
+      );
+    }
+
+    // Use fs.realpath to resolve symlinks - prevents symlink escape attacks
+    let realPath: string;
+    let realRoot: string;
+
+    try {
+      realPath = await fs.realpath(placeholderPath);
+    } catch {
+      realPath = path.resolve(placeholderPath);
+    }
+
+    try {
+      realRoot = await fs.realpath(libraryRoot);
+    } catch {
+      realRoot = path.resolve(libraryRoot);
+    }
+
+    if (!realPath.startsWith(realRoot + path.sep)) {
+      logger.error('Path traversal attempt detected', {
+        label: 'Coming Soon Placeholder',
+        requestedPath: placeholderPath,
+        realPath,
+        libraryRoot: realRoot,
+        mediaType,
+      });
+      throw new Error('Invalid placeholder path - outside library root');
+    }
+
     // Safety check: Verify path contains placeholder marker (supports both old and new format)
     if (
       !placeholderPath.includes('{edition-Trailer}') &&

--- a/server/lib/placeholders/placeholderManager.ts
+++ b/server/lib/placeholders/placeholderManager.ts
@@ -1,5 +1,5 @@
-import logger from '@server/logger';
 import { getSettings } from '@server/lib/settings';
+import logger from '@server/logger';
 import fs from 'fs/promises';
 import path from 'path';
 import type { PlaceholderOptions, PlaceholderResult } from './types';
@@ -17,9 +17,7 @@ function sanitizeFilename(filename: string): string {
 /**
  * Create placeholder file for movie
  */
-async function createMoviePlaceholder(
-  options: PlaceholderOptions
-): Promise<PlaceholderResult> {
+async function createMoviePlaceholder(options: PlaceholderOptions): Promise {
   const { title, year, tmdbId, libraryPath, trailerPath } = options;
 
   // Folder format: MovieName (Year)
@@ -76,9 +74,7 @@ async function createMoviePlaceholder(
 /**
  * Create placeholder file for TV show
  */
-async function createTVPlaceholder(
-  options: PlaceholderOptions
-): Promise<PlaceholderResult> {
+async function createTVPlaceholder(options: PlaceholderOptions): Promise {
   const { title, year, libraryPath, trailerPath } = options;
 
   // Directory format: ShowName (Year)/Season 00/S00E00.Trailer.mp4
@@ -146,9 +142,7 @@ async function createTVPlaceholder(
 /**
  * Create placeholder file in Plex library
  */
-export async function createPlaceholder(
-  options: PlaceholderOptions
-): Promise<PlaceholderResult> {
+export async function createPlaceholder(options: PlaceholderOptions): Promise {
   const { mediaType } = options;
 
   try {
@@ -174,7 +168,7 @@ export async function createPlaceholder(
 export async function removePlaceholder(
   placeholderPath: string,
   mediaType: 'movie' | 'tv'
-): Promise<void> {
+): Promise {
   try {
     // Security: Validate path is within configured library roots
     const settings = getSettings();
@@ -184,9 +178,7 @@ export async function removePlaceholder(
         : settings.main.placeholderTVRootFolder;
 
     if (!libraryRoot) {
-      throw new Error(
-        `Placeholder ${mediaType} library root not configured`
-      );
+      throw new Error(`Placeholder ${mediaType} library root not configured`);
     }
 
     // Use fs.realpath to resolve symlinks - prevents symlink escape attacks
@@ -318,9 +310,7 @@ export interface DiscoveredMarker extends PlaceholderMarker {
  * Scan a library directory for .comingsoon marker files
  * Returns all discovered markers with their file paths
  */
-export async function scanForMarkerFiles(
-  libraryPath: string
-): Promise<DiscoveredMarker[]> {
+export async function scanForMarkerFiles(libraryPath: string): Promise {
   const markers: DiscoveredMarker[] = [];
 
   try {
@@ -398,7 +388,7 @@ export async function upgradeMarkerFile(
   markerPath: string,
   tmdbId: number,
   tvdbId?: number
-): Promise<void> {
+): Promise {
   try {
     // Read existing marker
     const markerContent = await fs.readFile(markerPath, 'utf-8');
@@ -452,9 +442,7 @@ export interface DiscoveredMoviePlaceholder {
  * Movies use {edition-Trailer} and {tmdb-12345} in filename - no marker file needed
  * Returns all discovered movie placeholders with extracted metadata
  */
-export async function scanForMoviePlaceholders(
-  libraryPath: string
-): Promise<DiscoveredMoviePlaceholder[]> {
+export async function scanForMoviePlaceholders(libraryPath: string): Promise {
   const placeholders: DiscoveredMoviePlaceholder[] = [];
 
   try {


### PR DESCRIPTION
## The Problem

While reviewing the codebase, I found several security issues that could leak sensitive information or cause crashes:

1. **API keys in logs**: When Overseerr API calls fail, the error interceptor logs the full request headers - including `X-Api-Key`. Anyone with log access can see credentials.

2. **Unhandled promise rejection**: The rolling cache in `ExternalAPI` fires off a background fetch without a `.catch()`. If the network fails, Node crashes in strict mode.

3. **Path traversal via symlinks**: The placeholder deletion function checks if a path is inside the library root, but uses `path.resolve()` which doesn't follow symlinks. An attacker could create `/library/evil -> /etc` and bypass the check.

4. **Division by zero**: In `MultiSourceOrchestrator`, if a `cycle_lists` collection has an empty sources array, we hit `counter % 0` which produces NaN and crashes downstream.

5. **Unbounded fetch**: The anime ID mapping fetch has no timeout or size limit. A malicious/slow endpoint could hang the server or exhaust memory with a multi-GB response.

6. **Unvalidated downloads**: Poster downloads don't check HTTP status or content-type. A 500 error page could be written as a "poster" and corrupt the cache.

## What This PR Does

**1. Redact sensitive headers in Overseerr logging**

Before logging request headers, we now delete `X-Api-Key`, `Authorization`, and their lowercase variants. Also truncate `responseData` to 500 chars since servers sometimes echo credentials in error responses.

**2. Add catch handler to rolling cache**

The background refresh now has a `.catch()` that logs the failure and moves on. Stale cache is acceptable for a background refresh - we don't need to crash over it.

**3. Use fs.realpath for symlink-safe path validation**

```typescript
const realPath = await fs.realpath(placeholderPath);
const realRoot = await fs.realpath(libraryRoot);
if (!realPath.startsWith(realRoot + path.sep)) {
  throw new Error('Path traversal detected');
}
```

This follows symlinks before checking containment, so `/library/evil -> /etc/passwd` would resolve to `/etc/passwd` and fail the check.

**4. Validate non-empty sources before cycle_lists**

Added an early return with error logging if `config.sources` is empty. No point trying to cycle through nothing.

**5. Streaming fetch with size enforcement**

Instead of `res.text()` which buffers the entire response before we can check size, we now use `ReadableStream` with a running byte counter:

```typescript
const reader = res.body?.getReader();
let totalBytes = 0;
while (true) {
  const { done, value } = await reader.read();
  if (done) break;
  totalBytes += value.length;
  if (totalBytes > MAX_SIZE) {
    controller.abort();
    throw new Error('Response too large');
  }
  chunks.push(value);
}
```

Also added 30-second timeout via AbortController.

**6. Validate poster downloads**

Added `validateStatus: (status) => status === 200` and content-type check for `image/*`. If we get an HTML error page, we throw instead of caching garbage.

## Test Plan

- [ ] Trigger an Overseerr API error - check logs don't contain API key
- [ ] Kill network during rolling cache refresh - server shouldn't crash
- [ ] Try deleting placeholder with path containing symlink outside root
- [ ] Create cycle_lists collection with no sources - should log error, not crash
- [ ] Mock slow/large response from anime IDs endpoint - should timeout/abort
- [ ] Mock 500 response from Plex poster endpoint - should throw, not save