### PR TITLE
fix(security): harden API clients and file operations

### DIFF
--- a/server/api/animeIds.ts
+++ b/server/api/animeIds.ts
@@ -38,46 +38,107 @@ export function getAllValues<T>(value: T | T[] | undefined): T[] {
   return normalizeToArray(value);
 }
 
+// Maximum allowed response size (50MB - the mapping file is typically ~10-20MB)
+const MAX_RESPONSE_SIZE = 50 * 1024 * 1024;
+// Request timeout (30 seconds)
+const FETCH_TIMEOUT_MS = 30000;
+
 export async function loadAnimeIds(
   url = 'https://raw.githubusercontent.com/eliasbenb/PlexAniBridge-Mappings/refs/heads/v2/mappings.json'
 ): Promise<void> {
-  const res = await fetch(url, {
-    headers: { Accept: 'application/json' },
-    // be explicit that we want fresh-ish
-    cache: 'no-store' as RequestCache,
-  });
-  if (!res.ok) throw new Error(`Anime-IDs fetch failed: ${res.status}`);
-  const json = (await res.json()) as RawAnimeIds;
+  // Create abort controller for timeout
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
-  const byAniList = new Map<number, AnimeIdsRow>();
-  const byAniDB = new Map<number, AnimeIdsRow>();
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      // be explicit that we want fresh-ish
+      cache: 'no-store' as RequestCache,
+      signal: controller.signal,
+    });
 
-  // Build indices - keys are now AniList IDs directly!
-  for (const [anilistIdStr, row] of Object.entries(json)) {
-    // Skip metadata keys like "$includes"
-    if (anilistIdStr.startsWith('$')) continue;
+    if (!res.ok) throw new Error(`Anime-IDs fetch failed: ${res.status}`);
 
-    const anilistId = parseInt(anilistIdStr);
-    if (!anilistId || !Number.isFinite(anilistId)) continue;
-
-    // Store the row as-is (already well-structured)
-    const normalized: AnimeIdsRow = {
-      ...row,
-      anilist_id: anilistId, // Add the key as a field for completeness
-    };
-
-    // Store by AniList ID (primary key)
-    byAniList.set(anilistId, normalized);
-
-    // Also index by AniDB ID if present
-    if (row.anidb_id) {
-      byAniDB.set(row.anidb_id, normalized);
+    // Check content-length if provided to reject obviously oversized responses
+    const contentLength = res.headers.get('content-length');
+    if (contentLength && parseInt(contentLength, 10) > MAX_RESPONSE_SIZE) {
+      throw new Error(
+        `Anime-IDs response too large: ${contentLength} bytes (max: ${MAX_RESPONSE_SIZE})`
+      );
     }
-  }
 
-  _byAniList = byAniList;
-  _byAniDB = byAniDB;
-  _loadedAt = Date.now();
+    // Stream response with size enforcement to prevent memory exhaustion
+    const reader = res.body?.getReader();
+    if (!reader) {
+      throw new Error('Anime-IDs response body is not readable');
+    }
+
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+
+    try {
+      // eslint-disable-next-line no-constant-condition -- standard streaming read pattern
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        totalBytes += value.length;
+        if (totalBytes > MAX_RESPONSE_SIZE) {
+          controller.abort();
+          throw new Error(
+            `Anime-IDs response too large: exceeded ${MAX_RESPONSE_SIZE} bytes during download`
+          );
+        }
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    // Combine chunks and decode as UTF-8
+    const combined = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      combined.set(chunk, offset);
+      offset += chunk.length;
+    }
+    const text = new TextDecoder().decode(combined);
+
+    const json = JSON.parse(text) as RawAnimeIds;
+
+    const byAniList = new Map<number, AnimeIdsRow>();
+    const byAniDB = new Map<number, AnimeIdsRow>();
+
+    // Build indices - keys are now AniList IDs directly!
+    for (const [anilistIdStr, row] of Object.entries(json)) {
+      // Skip metadata keys like "$includes"
+      if (anilistIdStr.startsWith('$')) continue;
+
+      const anilistId = parseInt(anilistIdStr);
+      if (!anilistId || !Number.isFinite(anilistId)) continue;
+
+      // Store the row as-is (already well-structured)
+      const normalized: AnimeIdsRow = {
+        ...row,
+        anilist_id: anilistId, // Add the key as a field for completeness
+      };
+
+      // Store by AniList ID (primary key)
+      byAniList.set(anilistId, normalized);
+
+      // Also index by AniDB ID if present
+      if (row.anidb_id) {
+        byAniDB.set(row.anidb_id, normalized);
+      }
+    }
+
+    _byAniList = byAniList;
+    _byAniDB = byAniDB;
+    _loadedAt = Date.now();
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 export async function ensureAnimeIdsLoaded(

--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -1,3 +1,4 @@
+import logger from '@server/logger';
 import type { AxiosInstance, AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 import rateLimit from 'axios-rate-limit';
@@ -109,9 +110,19 @@ class ExternalAPI {
         keyTtl - (ttl ?? DEFAULT_TTL) * 1000 <
         Date.now() - DEFAULT_ROLLING_BUFFER
       ) {
-        this.axios.get<T>(endpoint, config).then((response) => {
-          this.cache?.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
-        });
+        this.axios
+          .get<T>(endpoint, config)
+          .then((response) => {
+            this.cache?.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
+          })
+          .catch((error) => {
+            // Log but don't throw - background refresh failure is acceptable
+            logger.warn('Rolling cache background refresh failed', {
+              label: 'ExternalAPI',
+              endpoint,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          });
       }
       return cachedItem;
     }

--- a/server/api/overseerr.ts
+++ b/server/api/overseerr.ts
@@ -154,21 +154,113 @@ class OverseerrAPI {
       timeout: 30000,
     });
 
-    // Add response/error logging
+    // Add response/error logging (with sensitive data redacted)
     this.axios.interceptors.response.use(
       (response) => {
         return response;
       },
       (error) => {
+        // Sanitize URL - strip sensitive query parameters
+        let safeUrl: string | undefined;
+        if (error.config?.url) {
+          try {
+            const url = new URL(
+              error.config.url,
+              error.config.baseURL || 'http://localhost'
+            );
+            // Remove sensitive query params
+            const sensitiveParams = [
+              'api_key',
+              'apikey',
+              'token',
+              'key',
+              'secret',
+              'password',
+              'X-Plex-Token',
+            ];
+            sensitiveParams.forEach((param) => {
+              url.searchParams.delete(param);
+              url.searchParams.delete(param.toLowerCase());
+            });
+            safeUrl = url.pathname + (url.search || '');
+          } catch {
+            // If URL parsing fails, just use the path portion or redact entirely
+            safeUrl = error.config.url.split('?')[0] + '?[params redacted]';
+          }
+        }
+
+        // Redact sensitive headers using whitelist approach (safer than blacklist)
+        // Only log headers we explicitly know are safe
+        const safeHeaderKeys = [
+          'content-type',
+          'accept',
+          'user-agent',
+          'content-length',
+        ];
+        const safeHeaders: Record<string, unknown> = {};
+        if (error.config?.headers) {
+          // Flatten any nested header structures (Axios can nest headers)
+          const flatHeaders =
+            typeof error.config.headers.toJSON === 'function'
+              ? error.config.headers.toJSON()
+              : error.config.headers;
+
+          Object.entries(flatHeaders).forEach(([key, value]) => {
+            if (safeHeaderKeys.includes(key.toLowerCase())) {
+              safeHeaders[key] = value;
+            }
+          });
+        }
+
+        // Sanitize response data with try/catch to handle circular refs and large payloads
+        let safeResponseData: string | undefined;
+        if (error.response?.data) {
+          try {
+            let dataStr: string;
+            if (typeof error.response.data === 'string') {
+              // Pre-truncate strings to avoid processing huge payloads
+              dataStr =
+                error.response.data.length > 2000
+                  ? error.response.data.substring(0, 2000)
+                  : error.response.data;
+            } else if (Buffer.isBuffer(error.response.data)) {
+              dataStr = '[Binary data]';
+            } else {
+              // Limit stringify to avoid memory issues with large objects
+              const limited = JSON.stringify(error.response.data, null, 0);
+              dataStr =
+                limited.length > 2000 ? limited.substring(0, 2000) : limited;
+            }
+            // Redact common sensitive patterns
+            const redacted = dataStr
+              .replace(/[Bb]earer\s+[^\s"']+/g, 'Bearer [REDACTED]')
+              .replace(
+                /["']?[Aa]pi[_-]?[Kk]ey["']?\s*[=:]\s*["']?[^"'\s,}]+["']?/gi,
+                'apiKey=[REDACTED]'
+              )
+              .replace(
+                /["']?[Tt]oken["']?\s*[=:]\s*["']?[^"'\s,}]+["']?/gi,
+                'token=[REDACTED]'
+              );
+            // Final truncate for logs
+            safeResponseData =
+              redacted.length > 500
+                ? redacted.substring(0, 500) + '... [truncated]'
+                : redacted;
+          } catch {
+            safeResponseData = '[Unable to serialize response data]';
+          }
+        }
+
         logger.error(`Overseerr API Error: ${error.message}`, {
           label: 'OverseerrAPI',
-          url: error.config?.url,
+          url: safeUrl,
           method: error.config?.method?.toUpperCase(),
           status: error.response?.status,
           statusText: error.response?.statusText,
-          responseData: error.response?.data,
-          requestHeaders: error.config?.headers,
-          requestData: error.config?.data,
+          responseData: safeResponseData,
+          requestHeaders: safeHeaders,
+          // requestData omitted entirely to prevent PII leaks
         });
         throw error;
       }

--- a/server/lib/collections/services/MultiSourceOrchestrator.ts
+++ b/server/lib/collections/services/MultiSourceOrchestrator.ts
@@ -151,10 +151,23 @@ export class MultiSourceOrchestrator {
       logger.info(`Processing multi-source collection: ${config.name}`, {
         label: 'Multi-Source Orchestrator',
         configId: config.id,
-        sourceCount: config.sources.length,
+        sourceCount: config.sources?.length ?? 0,
         combineMode: config.combineMode,
         isActive: timeRestrictionResult.isActive,
       });
+
+      // Validate sources array is not empty (prevents division by zero in cycle_lists mode)
+      if (!config.sources || config.sources.length === 0) {
+        logger.error(
+          `Multi-source collection ${config.name} has no sources configured`,
+          {
+            label: 'Multi-Source Orchestrator',
+            configId: config.id,
+            combineMode: config.combineMode,
+          }
+        );
+        return { created: 0, updated: 0 };
+      }
 
       // Increment sync counter for cycle_lists mode
       if (config.combineMode === 'cycle_lists') {

--- a/server/lib/overlays/LocalPosterFolderService.ts
+++ b/server/lib/overlays/LocalPosterFolderService.ts
@@ -381,9 +381,27 @@ class LocalPosterFolderService {
           const response = await axios.get(downloadPath, {
             responseType: 'arraybuffer',
             timeout: 30000,
+            maxContentLength: 50 * 1024 * 1024, // 50MB max poster size
+            validateStatus: (status) => status === 200, // Only accept 200 OK
           });
 
+          // Validate content type is an image
+          const contentType = response.headers['content-type'] || '';
+          if (!contentType.startsWith('image/')) {
+            throw new Error(
+              `Invalid content type for poster: ${contentType} (expected image/*)`
+            );
+          }
+
           const posterBuffer = Buffer.from(response.data);
+
+          // Additional size check (in case maxContentLength wasn't honored)
+          if (posterBuffer.length > 50 * 1024 * 1024) {
+            throw new Error(
+              `Poster too large: ${posterBuffer.length} bytes (max: 50MB)`
+            );
+          }
+
           await fs.writeFile(posterPath, posterBuffer);
 
           stats.downloaded++;

--- a/server/lib/placeholders/placeholderManager.ts
+++ b/server/lib/placeholders/placeholderManager.ts
@@ -1,3 +1,4 @@
+import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import fs from 'fs/promises';
 import path from 'path';
@@ -175,6 +176,76 @@ export async function removePlaceholder(
   mediaType: 'movie' | 'tv'
 ): Promise<void> {
   try {
+    // Security: Validate path is within configured library roots to prevent path traversal
+    const settings = getSettings();
+    const libraryRoot =
+      mediaType === 'movie'
+        ? settings.main.placeholderMovieRootFolder
+        : settings.main.placeholderTVRootFolder;
+
+    if (!libraryRoot) {
+      throw new Error(
+        `Placeholder ${mediaType} library root not configured - cannot safely delete`
+      );
+    }
+
+    // Resolve both paths to real paths (following symlinks) to prevent symlink escape attacks
+    // This ensures even if an attacker creates a symlink inside the library pointing outside,
+    // we check the actual destination, not the symlink path
+    // NOTE: We fail hard on realpath errors - no unsafe fallback to path.resolve()
+    let realPath: string;
+    let realRoot: string;
+
+    try {
+      realPath = await fs.realpath(placeholderPath);
+    } catch (realpathError) {
+      // File doesn't exist or can't be resolved - this is a security issue, fail hard
+      logger.error('Cannot resolve real path for placeholder deletion', {
+        label: 'Coming Soon Placeholder',
+        requestedPath: placeholderPath,
+        error:
+          realpathError instanceof Error
+            ? realpathError.message
+            : String(realpathError),
+      });
+      throw new Error(
+        'Cannot resolve placeholder path - file may not exist or permissions denied'
+      );
+    }
+
+    try {
+      realRoot = await fs.realpath(libraryRoot);
+    } catch (rootRealpathError) {
+      logger.error('Cannot resolve library root path', {
+        label: 'Coming Soon Placeholder',
+        libraryRoot,
+        error:
+          rootRealpathError instanceof Error
+            ? rootRealpathError.message
+            : String(rootRealpathError),
+      });
+      throw new Error(
+        'Cannot resolve library root path - check placeholder folder configuration'
+      );
+    }
+
+    // Validate the resolved path is within the library root
+    if (!realPath.startsWith(realRoot + path.sep) && realPath !== realRoot) {
+      logger.error(
+        'Path traversal attempt detected - refusing to delete file outside library root',
+        {
+          label: 'Coming Soon Placeholder',
+          requestedPath: placeholderPath,
+          realPath,
+          libraryRoot: realRoot,
+          mediaType,
+        }
+      );
+      throw new Error(
+        'Invalid placeholder path - path traversal detected, file is outside library root'
+      );
+    }
+
     // Safety check: Verify path contains placeholder marker (supports both old and new format)
     if (
       !placeholderPath.includes('{edition-Trailer}') &&


### PR DESCRIPTION
## The Problem

While reviewing error logs, I noticed API credentials were being logged in plain text - API keys in headers, tokens in URLs, and sensitive data in response bodies. There's also no timeout or size limits on external fetches, no error handling on background cache refreshes, and the placeholder deletion path isn't validated against directory traversal.

None of these are actively being exploited, but they're the kind of issues that cause problems down the line.

## What This PR Does

**1. Credential redaction in error logs (overseerr.ts)**

The axios error interceptor was logging `error.config.headers` and `error.config.url` directly. This included X-Api-Key headers, Authorization headers, and query params like `?X-Plex-Token=...`. 

Changed to a whitelist approach - only log headers we know are safe (content-type, accept, user-agent, content-length). URLs get query params stripped. Response data gets Bearer tokens and API keys redacted before truncation.

**2. Unhandled promise rejection (externalapi.ts)**

The rolling cache does a background fetch without a `.catch()`. If the API fails during background refresh, it throws an unhandled rejection. Added catch handler that logs and swallows - background refresh failure is fine, we have the cached value.

**3. Timeout and size limits (animeIds.ts)**

The anime IDs fetch had no timeout or size limit. Added 30s timeout via AbortController and 50MB size limit with streaming enforcement. Checks content-length header first, then counts bytes during download and aborts if exceeded.

**4. Division by zero prevention (MultiSourceOrchestrator.ts)**

In cycle_lists mode, the code does `syncCounter % config.sources.length`. If sources array is empty, that's a division by zero. Added validation that returns early.

**5. Poster download validation (LocalPosterFolderService.ts)**

Poster downloads had no content-type validation - could download anything. Added maxContentLength (50MB), status validation (200 only), and content-type must start with "image/".

**6. Path traversal prevention (placeholderManager.ts)**

The `removePlaceholder` function takes a path and deletes it. There was a check for placeholder markers in the filename, but no validation that the path is actually inside the configured library root. Added fs.realpath() resolution to follow symlinks, then validate the resolved path starts with the library root. Fails hard on realpath errors - no fallback to path.resolve() which doesn't follow symlinks.

## Testing

- `yarn typecheck` - passed
- `yarn lint` - passed  
- `npx prettier --check` - passed