### PR TITLE
fix(overlays): return episodeNumber from fetchReleaseDateInfo for countdown overlays

### DIFF
--- a/server/lib/overlays/OverlayContextBuilder.ts
+++ b/server/lib/overlays/OverlayContextBuilder.ts
@@ -556,6 +556,7 @@ export async function fetchReleaseDateInfo(
       nextEpisodeAirDate?: string;
       nextSeasonAirDate?: string;
       seasonNumber?: number;
+      episodeNumber?: number;
     }
   | undefined
 > {
@@ -613,6 +614,7 @@ export async function fetchReleaseDateInfo(
           nextEpisodeAirDate: nextEpisode.air_date,
           nextSeasonAirDate,
           seasonNumber,
+          episodeNumber,
         };
       }
 

--- a/server/lib/overlays/OverlayLibraryService.ts
+++ b/server/lib/overlays/OverlayLibraryService.ts
@@ -683,6 +683,7 @@ class OverlayLibraryService {
             daysUntilNextSeason,
             daysAgoNextSeason,
             seasonNumber: releaseDateInfo.seasonNumber,
+            episodeNumber: releaseDateInfo.episodeNumber,
           };
         }
       }

--- a/server/routes/overlayTest.ts
+++ b/server/routes/overlayTest.ts
@@ -245,6 +245,7 @@ overlayTestRouter.post('/', async (req, res) => {
           daysUntilNextSeason,
           daysAgoNextSeason,
           seasonNumber: releaseDateInfo.seasonNumber,
+          episodeNumber: releaseDateInfo.episodeNumber,
         };
       }
     }


### PR DESCRIPTION
`fetchReleaseDateInfo()` extracts `episodeNumber` from TMDB's `next_episode_to_air` but wasn't including it in the return object. Added it to the return type and wired it through `releaseDateContext`.

Fixes #290