### PR TITLE
fix(collections): sync networksCountry to sources array on change

### DIFF
--- a/src/components/Collections/FormSections/NetworksConfigSection.tsx
+++ b/src/components/Collections/FormSections/NetworksConfigSection.tsx
@@ -89,9 +89,18 @@ const NetworksConfigSection = ({
             const newCountry = e.target.value;
             setFieldValue('networksCountry', newCountry);
 
+            // Also update sources[0].networksCountry if sources exist (for existing collections)
+            if (values.sources && values.sources.length > 0) {
+              setFieldValue('sources[0].networksCountry', newCountry);
+            }
+
             // Reset platform selection when country changes
             if (newCountry !== values.networksCountry) {
               setFieldValue('subtype', '');
+              // Also reset sources[0].subtype if sources exist
+              if (values.sources && values.sources.length > 0) {
+                setFieldValue('sources[0].subtype', '');
+              }
             }
           }}
           disabled={false}


### PR DESCRIPTION
## Summary

When editing an existing Networks collection, changing the country dropdown updated the top-level `networksCountry` but not `sources[0].networksCountry`. The form submits the sources array, so the old value was sent to the API.

- Updated `NetworksConfigSection` to sync country changes to `sources[0].networksCountry`
- Also resets `sources[0].subtype` when country changes

Fixes #296