### PR TITLE
fix(logging): downgrade library mismatch message to debug level

### DIFF
--- a/server/lib/collections/core/CollectionUtilities.ts
+++ b/server/lib/collections/core/CollectionUtilities.ts
@@ -1698,7 +1698,7 @@ export async function findPlexItemsByTmdbIds(
             (lib) => lib.key === targetLibraryId
           );
           if (movieLibraries.length === 0) {
-            logger.warn(
+            logger.debug(
               `Target library ${targetLibraryId} not found or is not a movie library`,
               {
                 label: 'Plex Search',
@@ -1794,7 +1794,7 @@ export async function findPlexItemsByTmdbIds(
             (lib) => lib.key === targetLibraryId
           );
           if (tvLibraries.length === 0) {
-            logger.warn(
+            logger.debug(
               `Target library ${targetLibraryId} not found or is not a TV library`,
               {
                 label: 'Plex Search',


### PR DESCRIPTION
## Summary

The "Target library X not found or is not a movie/TV library" message was logged at warn level, but this is a normal scenario when a collection targets a specific library type (e.g., searching for movies in a TV library). Changed to debug level.

Fixes #265