### PR TITLE
fix(collections): surface per-collection sync errors to UI

### DIFF
--- a/server/lib/collections/services/CollectionSyncService.ts
+++ b/server/lib/collections/services/CollectionSyncService.ts
@@ -548,6 +548,22 @@ export class CollectionSyncService {
 
           created += result.created || 0;
           updated += result.updated || 0;
+
+          // Check if the sync returned an error (e.g., from multi-source orchestrator)
+          if (result.error) {
+            logger.warn(
+              `Collection sync returned error for ${config.name}: ${result.error}`,
+              {
+                label: 'Collection Sync Service',
+                configId: config.id,
+              }
+            );
+            // Persist error for UI display
+            settings.setCollectionSyncError(config.id, result.error);
+          } else {
+            // Mark collection as successfully synced (clears any previous error)
+            settings.markCollectionSynced(config.id, 'collection');
+          }
         }
 
         totalCreated += created;
@@ -562,18 +578,20 @@ export class CollectionSyncService {
           );
         }
 
-        // Mark collection as successfully synced
-        settings.markCollectionSynced(config.id, 'collection');
-
         // Update progress count
         processedCount++;
         onProgress?.(processedCount);
       } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
         logger.error(`Failed to process collection ${config.name}: ${error}`, {
           label: 'Collection Sync Service',
           configId: config.id,
-          error: error instanceof Error ? error.message : String(error),
+          error: errorMessage,
         });
+
+        // Persist error for UI display
+        settings.setCollectionSyncError(config.id, errorMessage);
 
         // Still increment counter to avoid getting stuck
         processedCount++;

--- a/server/lib/collections/services/MultiSourceOrchestrator.ts
+++ b/server/lib/collections/services/MultiSourceOrchestrator.ts
@@ -116,7 +116,7 @@ export class MultiSourceOrchestrator {
     processedCollectionKeys?: Set<string>,
     libraryCache?: LibraryItemsCache,
     options?: CollectionSyncOptions
-  ): Promise<{ created: number; updated: number }> {
+  ): Promise<{ created: number; updated: number; error?: string }> {
     let configForSync: MultiSourceCollectionConfig = config;
     let collectionNameForSync = config.name;
 
@@ -541,6 +541,10 @@ export class MultiSourceOrchestrator {
           ? collectionNameForSync
           : config.name;
 
+      // Extract the original error message for surfacing to UI
+      const originalErrorMessage =
+        error instanceof Error ? error.message : String(error);
+
       // 4. Error Handling - use standard pipeline utilities
       const syncError = createSyncError(
         CollectionSyncErrorType.COLLECTION_ERROR,
@@ -553,6 +557,7 @@ export class MultiSourceOrchestrator {
         label: 'Multi-Source Orchestrator',
         configId: config.id,
         error: syncError.details,
+        originalError: originalErrorMessage,
       });
 
       // Call error callback if provided
@@ -560,7 +565,8 @@ export class MultiSourceOrchestrator {
         options.onError(syncError);
       }
 
-      return { created: 0, updated: 0 };
+      // Return error message so callers can persist it for UI display
+      return { created: 0, updated: 0, error: originalErrorMessage };
     }
   }
 

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -80,6 +80,8 @@ export interface CollectionConfig {
   readonly lastSyncedAt?: string; // ISO string timestamp of last successful sync to Plex
   readonly lastModifiedAt?: string; // ISO string timestamp when config was last modified
   readonly needsSync?: boolean; // true if modified since last sync
+  readonly lastSyncError?: string; // Error message from last failed sync (cleared on success)
+  readonly lastSyncErrorAt?: string; // ISO string timestamp of when the sync error occurred
   readonly maxItems: number;
   readonly customDays?: number; // Number of days for Tautulli collections (required for Tautulli type)
   readonly minimumPlays?: number; // Minimum play count for Tautulli collections (defaults to 3 if not set, 1-100)
@@ -1158,7 +1160,7 @@ class Settings {
   }
 
   /**
-   * Mark a collection as successfully synced
+   * Mark a collection as successfully synced (clears any previous error)
    */
   public markCollectionSynced(
     collectionId: string,
@@ -1174,7 +1176,12 @@ class Settings {
             (c) => c.id === collectionId
           );
           if (config) {
-            Object.assign(config, { needsSync: false, lastSyncedAt: now });
+            Object.assign(config, {
+              needsSync: false,
+              lastSyncedAt: now,
+              lastSyncError: undefined,
+              lastSyncErrorAt: undefined,
+            });
           }
         }
         break;
@@ -1205,6 +1212,27 @@ class Settings {
     }
 
     this.save();
+  }
+
+  /**
+   * Set a sync error for a specific collection
+   */
+  public setCollectionSyncError(collectionId: string, error: string): void {
+    const now = new Date().toISOString();
+
+    if (this.data.plex.collectionConfigs) {
+      const config = this.data.plex.collectionConfigs.find(
+        (c) => c.id === collectionId
+      );
+      if (config) {
+        Object.assign(config, {
+          lastSyncError: error,
+          lastSyncErrorAt: now,
+          needsSync: true, // Keep marked as needing sync since it failed
+        });
+        this.save();
+      }
+    }
   }
 
   /**

--- a/server/routes/collections.ts
+++ b/server/routes/collections.ts
@@ -1845,9 +1845,23 @@ collectionsRoutes.post('/:id/sync', isAuthenticated(), async (req, res) => {
           );
         }
 
-        // Mark collection as synced (update needsSync status)
-        settings.markCollectionSynced(id, 'collection');
-        settings.save();
+        // Check if the sync returned an error (e.g., from multi-source orchestrator)
+        if (result.error) {
+          logger.warn(
+            `Individual collection sync returned error for ${collectionConfig.name}: ${result.error}`,
+            {
+              label: 'Individual Collection Sync',
+              collectionId: id,
+            }
+          );
+          // Persist error for UI display
+          settings.setCollectionSyncError(id, result.error);
+          settings.save();
+        } else {
+          // Mark collection as synced (update needsSync status, clears any previous error)
+          settings.markCollectionSynced(id, 'collection');
+          settings.save();
+        }
 
         // Sync Plex collection ordering after collection sync
         const { HubSyncService } = await import(
@@ -1862,19 +1876,25 @@ collectionsRoutes.post('/:id/sync', isAuthenticated(), async (req, res) => {
             label: 'Individual Collection Sync',
             collectionId: id,
             result,
+            hasError: !!result.error,
           }
         );
 
         return result;
       } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
         logger.error(
           `Individual collection sync failed for ${collectionConfig.name}: ${error}`,
           {
             label: 'Individual Collection Sync',
             collectionId: id,
-            error: error instanceof Error ? error.message : String(error),
+            error: errorMessage,
           }
         );
+        // Persist error for UI display
+        settings.setCollectionSyncError(id, errorMessage);
+        settings.save();
         throw error;
       }
     })();


### PR DESCRIPTION
Collection sync errors were being logged server-side but not surfaced to the UI, leaving users with blank error messages when multi-source collections failed to process.

- Added `lastSyncError` and `lastSyncErrorAt` fields to CollectionConfig
- MultiSourceOrchestrator now returns error in sync result
- CollectionSyncService persists errors and doesn't mark failed syncs as successful
- Settings methods to set/clear per-collection errors
- Individual sync route also handles and persists errors

Fixes #299