### PR TITLE
fix(placeholders): trigger Plex scan after cleanup to remove ghost entries

### DIFF
--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -2109,6 +2109,34 @@ class PlexAPI {
     }
   }
 
+  /**
+   * Empty trash for a Plex library section
+   * Removes items that Plex has detected as missing/unavailable
+   * @param libraryId - The library section ID to empty trash for
+   */
+  public async emptyTrash(libraryId: string): Promise<void> {
+    try {
+      logger.debug('Emptying Plex library trash', {
+        label: 'Plex API',
+        libraryId,
+      });
+
+      await this.safePutQuery(`/library/sections/${libraryId}/emptyTrash`);
+
+      logger.info('Plex library trash emptied', {
+        label: 'Plex API',
+        libraryId,
+      });
+    } catch (error) {
+      logger.error('Failed to empty Plex library trash', {
+        label: 'Plex API',
+        libraryId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
   // PLEX.TV METHODS - Delegated to PlexTvAPI
 
   /**

--- a/server/lib/collections/services/CollectionSyncService.ts
+++ b/server/lib/collections/services/CollectionSyncService.ts
@@ -186,6 +186,45 @@ export class CollectionSyncService {
           cleanedUp,
           titlesFixes,
         });
+
+        // Trigger Plex library scan + empty trash to remove ghost entries (fire-and-forget)
+        if (cleanedUp > 0 && tvLibraryId) {
+          const libraryId = tvLibraryId;
+          logger.info(
+            'Triggering Plex scan to clean up deleted TV placeholders',
+            {
+              label: 'Collection Sync Service',
+              libraryId,
+              placeholdersDeleted: cleanedUp,
+            }
+          );
+          // Fire-and-forget: don't block sync while Plex processes
+          const autoEmptyTrash = getSettings().plex.autoEmptyTrash !== false;
+          void (async () => {
+            try {
+              await plexClient.scanLibrary(libraryId);
+              if (autoEmptyTrash) {
+                // Brief delay for scan to detect missing files
+                await new Promise((resolve) => setTimeout(resolve, 3000));
+                await plexClient.emptyTrash(libraryId);
+              }
+              logger.info('Plex placeholder cleanup complete', {
+                label: 'Collection Sync Service',
+                libraryId,
+                trashedEmptied: autoEmptyTrash,
+              });
+            } catch (cleanupError) {
+              logger.warn('Failed to complete Plex placeholder cleanup', {
+                label: 'Collection Sync Service',
+                libraryId,
+                error:
+                  cleanupError instanceof Error
+                    ? cleanupError.message
+                    : String(cleanupError),
+              });
+            }
+          })();
+        }
       } catch (error) {
         logger.warn('Failed to run global TV placeholder discovery', {
           label: 'Collection Sync Service',
@@ -246,6 +285,45 @@ export class CollectionSyncService {
           label: 'Collection Sync Service',
           cleanedUp: moviesCleanedUp,
         });
+
+        // Trigger Plex library scan + empty trash to remove ghost entries (fire-and-forget)
+        if (moviesCleanedUp > 0 && movieLibraryId) {
+          const libraryId = movieLibraryId;
+          logger.info(
+            'Triggering Plex scan to clean up deleted movie placeholders',
+            {
+              label: 'Collection Sync Service',
+              libraryId,
+              placeholdersDeleted: moviesCleanedUp,
+            }
+          );
+          // Fire-and-forget: don't block sync while Plex processes
+          const autoEmptyTrash = getSettings().plex.autoEmptyTrash !== false;
+          void (async () => {
+            try {
+              await plexClient.scanLibrary(libraryId);
+              if (autoEmptyTrash) {
+                // Brief delay for scan to detect missing files
+                await new Promise((resolve) => setTimeout(resolve, 3000));
+                await plexClient.emptyTrash(libraryId);
+              }
+              logger.info('Plex placeholder cleanup complete', {
+                label: 'Collection Sync Service',
+                libraryId,
+                trashedEmptied: autoEmptyTrash,
+              });
+            } catch (cleanupError) {
+              logger.warn('Failed to complete Plex placeholder cleanup', {
+                label: 'Collection Sync Service',
+                libraryId,
+                error:
+                  cleanupError instanceof Error
+                    ? cleanupError.message
+                    : String(cleanupError),
+              });
+            }
+          })();
+        }
       } catch (error) {
         logger.warn('Failed to run global movie placeholder discovery', {
           label: 'Collection Sync Service',

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -401,6 +401,7 @@ export interface PlexSettings {
   hubConfigs?: PlexHubConfig[]; // Plex built-in hub configurations
   preExistingCollectionConfigs?: PreExistingCollectionConfig[]; // Pre-existing Plex collections discovered by hub discovery
   usersHomeUnlocked?: boolean; // Secret unlock for Users Home collections
+  autoEmptyTrash?: boolean; // Auto-empty Plex trash after placeholder cleanup (default: true)
 }
 
 export interface TraktSettings {

--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -62,6 +62,9 @@ const messages = defineMessages({
   webAppUrl: '<WebAppLink>Web App</WebAppLink> URL',
   webAppUrlTip:
     'Optionally direct users to the web app on your server instead of the "hosted" web app',
+  autoEmptyTrash: 'Auto Empty Trash',
+  autoEmptyTrashTip:
+    'Automatically empty Plex library trash after placeholder cleanup to remove ghost entries',
 });
 
 interface Library {
@@ -246,6 +249,7 @@ const SettingsPlex = ({ onComplete }: SettingsPlexProps) => {
           useSsl: data?.useSsl,
           selectedPreset: undefined,
           webAppUrl: data?.webAppUrl,
+          autoEmptyTrash: data?.autoEmptyTrash !== false,
         }}
         validationSchema={PlexSettingsSchema}
         onSubmit={async (values) => {
@@ -266,6 +270,7 @@ const SettingsPlex = ({ onComplete }: SettingsPlexProps) => {
               port: Number(values.port),
               useSsl: values.useSsl,
               webAppUrl: values.webAppUrl,
+              autoEmptyTrash: values.autoEmptyTrash,
             } as PlexSettings);
 
             syncLibraries();
@@ -474,6 +479,25 @@ const SettingsPlex = ({ onComplete }: SettingsPlexProps) => {
                     typeof errors.webAppUrl === 'string' && (
                       <div className="error">{errors.webAppUrl}</div>
                     )}
+                </div>
+              </div>
+              <div className="form-row">
+                <label htmlFor="autoEmptyTrash" className="checkbox-label">
+                  {intl.formatMessage(messages.autoEmptyTrash)}
+                  <SettingsBadge badgeType="advanced" className="ml-2" />
+                  <span className="label-tip">
+                    {intl.formatMessage(messages.autoEmptyTrashTip)}
+                  </span>
+                </label>
+                <div className="form-input-area">
+                  <Field
+                    type="checkbox"
+                    id="autoEmptyTrash"
+                    name="autoEmptyTrash"
+                    onChange={() => {
+                      setFieldValue('autoEmptyTrash', !values.autoEmptyTrash);
+                    }}
+                  />
                 </div>
               </div>
               <div className="actions">


### PR DESCRIPTION
## Summary

Placeholder cleanup wasn't notifying Plex, so ghost entries (Season 0, trailers) stayed visible even after real content arrived and the placeholder files were deleted.

- Added `emptyTrash()` to PlexAPI
- After placeholder cleanup, triggers scan + empty trash (fire-and-forget so sync isn't blocked)
- New `autoEmptyTrash` setting in Plex settings (default: on)

## Test plan

- [ ] Create a placeholder for an upcoming show
- [ ] Download the real content
- [ ] Run collection sync
- [ ] Verify placeholder is removed from Plex
- [ ] Test with autoEmptyTrash toggled off