### PR TITLE
fix(placeholders): handle Jellyfin trickplay directories during cleanup

### DIFF
--- a/server/lib/placeholders/placeholderManager.ts
+++ b/server/lib/placeholders/placeholderManager.ts
@@ -202,6 +202,24 @@ export async function removePlaceholder(
     // Delete the file
     await fs.unlink(placeholderPath);
 
+    // Clean up associated .trickplay directory (Jellyfin creates these for video thumbnails)
+    // Pattern: "Movie {tmdb-123} {edition-Trailer}.mp4" -> "Movie {tmdb-123} {edition-Trailer}.trickplay"
+    if (placeholderPath.endsWith('.mp4')) {
+      const trickplayPath = placeholderPath.replace(/\.mp4$/, '.trickplay');
+      try {
+        const trickplayStat = await fs.stat(trickplayPath);
+        if (trickplayStat.isDirectory()) {
+          await fs.rm(trickplayPath, { recursive: true });
+          logger.debug('Removed associated trickplay directory', {
+            label: 'Coming Soon Placeholder',
+            path: trickplayPath,
+          });
+        }
+      } catch {
+        // Trickplay directory doesn't exist, that's fine
+      }
+    }
+
     // Clean up parent directories if empty
     if (mediaType === 'movie') {
       const movieDir = path.dirname(placeholderPath);

--- a/server/lib/placeholders/services/PlaceholderCleanup.ts
+++ b/server/lib/placeholders/services/PlaceholderCleanup.ts
@@ -319,6 +319,14 @@ export async function cleanupOrphanedPlaceholderFiles(): Promise<number> {
                 if (!file.includes('{edition-Trailer}')) continue;
 
                 const filePath = path.join(folderPath, file);
+
+                // Skip directories (Plex creates .trickplay folders with same base name)
+                try {
+                  const fileStat = await fs.stat(filePath);
+                  if (!fileStat.isFile()) continue;
+                } catch {
+                  continue; // Can't stat, skip
+                }
                 const relativePath = path.join(folder, file);
 
                 // Check if any DB record references this file


### PR DESCRIPTION
## Summary

- Skip directories when scanning for orphaned placeholder files (fixes `EISDIR` error)
- Remove associated `.trickplay` directories when deleting placeholder files

## Problem

Jellyfin creates `.trickplay` directories alongside video files for video thumbnail scrubbing. These directories inherit the placeholder filename pattern (e.g., `Movie {tmdb-123} {edition-Trailer}.trickplay`).

When the orphaned placeholder cleanup ran, it matched these directories because they contain `{edition-Trailer}` in the path, then failed with `EISDIR: illegal operation on a directory, unlink` when attempting `fs.unlink()`.

Additionally, when placeholders were successfully deleted, the `.trickplay` directories were left orphaned.

## Solution

1. Added `fs.stat().isFile()` check to skip directories during orphaned file cleanup scan
2. Added cleanup of `.trickplay` directories in `removePlaceholder()` using `fs.rm()` with recursive option

## Test plan

- [ ] Create a placeholder that Jellyfin has scanned (creates `.trickplay` directory)
- [ ] Run placeholder cleanup
- [ ] Verify no `EISDIR` errors in logs
- [ ] Verify `.trickplay` directory is removed along with placeholder