### PR TITLE
fix: multi-source label regex for collection matching

### DIFF
--- a/server/lib/collections/core/CollectionUtilities.ts
+++ b/server/lib/collections/core/CollectionUtilities.ts
@@ -322,7 +322,11 @@ export function createCollectionLabel(
  */
 export function parseConfigIdFromLabel(label: string): string | null {
   // Match pattern: Agregarr[Source][ConfigId] or Agregarr[Source][ConfigId]user[UserId]
-  const match = label.match(/^Agregarr([A-Za-z]+)([a-f0-9-]+)(?:user\d+)?$/i);
+  // Source can contain hyphens/underscores (e.g., multi-source, filtered_hub)
+  // ConfigId starts with a digit (numeric ID or UUID)
+  const match = label.match(
+    /^Agregarr([A-Za-z]+(?:[-_][A-Za-z]+)*)([0-9][a-f0-9-]*)(?:user\d+)?$/i
+  );
   return match ? match[2] : null;
 }
 


### PR DESCRIPTION
## Summary

`parseConfigIdFromLabel()` regex didn't handle source names containing hyphens or underscores (`multi-source`, `filtered_hub`). This caused multi-source collections (including `DYNAMIC_CYCLE_TITLE`) to create new Plex collections on each sync instead of updating the existing one.

- Old regex: `/^Agregarr([A-Za-z]+)([a-f0-9-]+)(?:user\d+)?$/i`
- `[A-Za-z]+` stops at hyphen, so `Agregarrmulti-source10213` fails to match
- Falls back to name matching, which fails when collection title changes
- Result: orphaned collections on Plex Home

Updated regex allows hyphens/underscores in source names while ensuring configId capture starts at the first digit.

Fixes #227