### PR TITLE
fix(placeholders): preserve placeholders for released content in non-Coming Soon collections

### DIFF
--- a/server/lib/collections/sources/comingsoon/comingSoonFetch.ts
+++ b/server/lib/collections/sources/comingsoon/comingSoonFetch.ts
@@ -1063,14 +1063,20 @@ export async function fetchTmdbComingSoonShows(
 }
 
 /**
- * Enrich items with TMDB release dates and filter out already-released items
+ * Enrich items with TMDB release dates and optionally filter out already-released items
  * Adds 3-month estimate for items with only theatrical releases
- * Filters out items where the earliest digital/physical release has already passed
+ * When filterReleased is true (default), filters out items where the release date
+ * has already passed or is too far in the future
  * Modifies the array in place
+ *
+ * @param items - Array of items to enrich
+ * @param maxDaysAway - Maximum days in future to include (default 360)
+ * @param filterReleased - When true, filter out already-released items (default true for Coming Soon behaviour)
  */
 export async function enrichWithTMDBReleaseDates(
   items: ComingSoonSourceData[],
-  maxDaysAway = 360
+  maxDaysAway = 360,
+  filterReleased = true
 ): Promise<void> {
   const TmdbAPI = (await import('@server/api/themoviedb')).default;
   const tmdbClient = new TmdbAPI();
@@ -1164,29 +1170,32 @@ export async function enrichWithTMDBReleaseDates(
           }
 
           // Filter: only include if release date is in the future and within window
-          const earliestReleaseDate = releaseDateResult
-            ? new Date(releaseDateResult.releaseDate)
-            : extracted.earliestReleaseDate || null;
+          // Skip filtering if filterReleased is false (for non-Coming Soon collections)
+          if (filterReleased) {
+            const earliestReleaseDate = releaseDateResult
+              ? new Date(releaseDateResult.releaseDate)
+              : extracted.earliestReleaseDate || null;
 
-          if (
-            !earliestReleaseDate ||
-            earliestReleaseDate < today ||
-            earliestReleaseDate > maxDate
-          ) {
-            logger.debug(
-              'Filtering out movie (already released, no date, or too far away)',
-              {
-                label: 'Coming Soon Collections',
-                title: item.title,
-                earliestReleaseDate: earliestReleaseDate?.toISOString(),
-                reason: !earliestReleaseDate
-                  ? 'no date'
-                  : earliestReleaseDate < today
-                  ? 'already released'
-                  : 'too far away',
-              }
-            );
-            return { index, shouldRemove: true };
+            if (
+              !earliestReleaseDate ||
+              earliestReleaseDate < today ||
+              earliestReleaseDate > maxDate
+            ) {
+              logger.debug(
+                'Filtering out movie (already released, no date, or too far away)',
+                {
+                  label: 'Coming Soon Collections',
+                  title: item.title,
+                  earliestReleaseDate: earliestReleaseDate?.toISOString(),
+                  reason: !earliestReleaseDate
+                    ? 'no date'
+                    : earliestReleaseDate < today
+                    ? 'already released'
+                    : 'too far away',
+                }
+              );
+              return { index, shouldRemove: true };
+            }
           }
         } else if (item.mediaType === 'tv') {
           // Only enrich airDate if not already set (Sonarr already provides season-specific dates)
@@ -1236,25 +1245,28 @@ export async function enrichWithTMDBReleaseDates(
           }
 
           // Filter TV shows: check if air date is in the future and within window (timezone-aware)
-          if (item.airDate) {
-            if (!isDateWithinDays(item.airDate, maxDaysAway)) {
-              logger.debug(
-                'Filtering out TV show (already aired or too far away)',
-                {
-                  label: 'Coming Soon Collections',
-                  title: item.title,
-                  airDate: item.airDate,
-                }
-              );
+          // Skip filtering if filterReleased is false (for non-Coming Soon collections)
+          if (filterReleased) {
+            if (item.airDate) {
+              if (!isDateWithinDays(item.airDate, maxDaysAway)) {
+                logger.debug(
+                  'Filtering out TV show (already aired or too far away)',
+                  {
+                    label: 'Coming Soon Collections',
+                    title: item.title,
+                    airDate: item.airDate,
+                  }
+                );
+                return { index, shouldRemove: true };
+              }
+            } else {
+              // No air date found, filter out
+              logger.debug('Filtering out TV show (no air date)', {
+                label: 'Coming Soon Collections',
+                title: item.title,
+              });
               return { index, shouldRemove: true };
             }
-          } else {
-            // No air date found, filter out
-            logger.debug('Filtering out TV show (no air date)', {
-              label: 'Coming Soon Collections',
-              title: item.title,
-            });
-            return { index, shouldRemove: true };
           }
         }
 

--- a/server/lib/collectionsQuickSync.ts
+++ b/server/lib/collectionsQuickSync.ts
@@ -391,33 +391,56 @@ class CollectionsQuickSync {
         continue;
       }
 
-      // Real content detected - delete placeholder for ALL collections
-      logger.info(
-        'Real content detected - deleting placeholder(s) for all collections',
-        {
-          label: 'Collections Quick Sync',
-          title: recentItem.title,
-          tmdbId,
-          placeholderCount: matchedPlaceholders.length,
-        }
-      );
+      // Real content detected - delete placeholders for THIS LIBRARY only
+      // Scope deletion to configIds to avoid cross-library deletion
+      // Also filter by mediaType to prevent movie/TV ID collisions
 
-      // Get ALL placeholder records for this TMDB ID across all collections
-      const allPlaceholderRecords = await placeholderRepository.find({
-        where: { tmdbId },
-      });
+      // Get placeholder records for this TMDB ID scoped to this library's configs
+      const mediaType = recentItem.type === 'movie' ? 'movie' : 'tv';
+      const scopedPlaceholderRecords = await placeholderRepository
+        .createQueryBuilder('placeholder')
+        .where('placeholder.tmdbId = :tmdbId', { tmdbId })
+        .andWhere('placeholder.configId IN (:...configIds)', { configIds })
+        .andWhere('placeholder.mediaType = :mediaType', { mediaType })
+        .getMany();
 
-      if (allPlaceholderRecords.length === 0) {
+      if (scopedPlaceholderRecords.length === 0) {
+        logger.debug(
+          'Real content detected but no placeholders to remove for this library',
+          {
+            label: 'Collections Quick Sync',
+            title: recentItem.title,
+            tmdbId,
+            libraryId,
+          }
+        );
         continue;
       }
 
-      // Get the placeholder file path (should be same for all records)
-      const placeholderPath = allPlaceholderRecords[0].placeholderPath;
-      const mediaType = allPlaceholderRecords[0].mediaType;
+      logger.info('Real content detected - cleaning up placeholders', {
+        label: 'Collections Quick Sync',
+        title: recentItem.title,
+        tmdbId,
+        recordsToDelete: scopedPlaceholderRecords.length,
+        configIds: scopedPlaceholderRecords.map((r) => r.configId),
+      });
 
-      // Delete the placeholder file once
+      // Get the placeholder file path
+      const placeholderPath = scopedPlaceholderRecords[0].placeholderPath;
+
+      // Check if other libraries/configs still need this placeholder file
+      // Only delete the file if no other records exist for this TMDB ID
+      const otherRecordsCount = await placeholderRepository
+        .createQueryBuilder('placeholder')
+        .where('placeholder.tmdbId = :tmdbId', { tmdbId })
+        .andWhere('placeholder.mediaType = :mediaType', { mediaType })
+        .andWhere('placeholder.configId NOT IN (:...configIds)', { configIds })
+        .getCount();
+
       let fileDeleted = false;
-      if (placeholderPath) {
+      const shouldDeleteFile = otherRecordsCount === 0;
+
+      if (placeholderPath && shouldDeleteFile) {
         const { getPlaceholderRootFolder } = await import(
           '@server/lib/placeholders/helpers/placeholderPathHelpers'
         );
@@ -444,7 +467,6 @@ class CollectionsQuickSync {
             label: 'Collections Quick Sync',
             title: recentItem.title,
             path: placeholderPath,
-            affectedCollections: allPlaceholderRecords.length,
           });
         } catch (error) {
           if (error instanceof Error && error.message.includes('ENOENT')) {
@@ -468,25 +490,31 @@ class CollectionsQuickSync {
             continue; // Keep ALL database records if file deletion failed
           }
         }
+      } else if (!shouldDeleteFile) {
+        // File preserved for other libraries/configs
+        fileDeleted = true; // Proceed with deleting DB records for this library only
+        logger.debug('Keeping placeholder file for other libraries/configs', {
+          label: 'Collections Quick Sync',
+          title: recentItem.title,
+          otherRecordsCount,
+        });
       } else {
         fileDeleted = true; // No file to delete
       }
 
-      // Delete ALL database records for this placeholder across ALL collections
-      if (fileDeleted) {
+      // Delete database records for this library's configs only
+      if (fileDeleted && scopedPlaceholderRecords.length > 0) {
         try {
-          await placeholderRepository.remove(allPlaceholderRecords);
-          deletedCount += allPlaceholderRecords.length;
-          logger.info(
-            'Deleted placeholder records for all collections (real content exists)',
-            {
-              label: 'Collections Quick Sync',
-              title: recentItem.title,
-              tmdbId,
-              recordsDeleted: allPlaceholderRecords.length,
-              collections: allPlaceholderRecords.map((r) => r.configId),
-            }
-          );
+          await placeholderRepository.remove(scopedPlaceholderRecords);
+          deletedCount += scopedPlaceholderRecords.length;
+          logger.info('Deleted placeholder records (real content exists)', {
+            label: 'Collections Quick Sync',
+            title: recentItem.title,
+            tmdbId,
+            recordsDeleted: scopedPlaceholderRecords.length,
+            otherLibraryRecords: otherRecordsCount,
+            deletedConfigIds: scopedPlaceholderRecords.map((r) => r.configId),
+          });
         } catch (error) {
           logger.error('Failed to delete placeholder database records', {
             label: 'Collections Quick Sync',

--- a/server/lib/collectionsQuickSync.ts
+++ b/server/lib/collectionsQuickSync.ts
@@ -188,14 +188,20 @@ class CollectionsQuickSync {
 
           // Fetch full metadata for each item to get external GUIDs (TMDB, IMDB, TVDB)
           // The recentlyAdded endpoint only returns internal Plex GUIDs
+          // For TV shows, include children metadata so isPlaceholderItem() can check
+          // if only Season 00 exists (placeholder detection)
           logger.debug('Fetching full metadata for external GUIDs...', {
             label: 'Collections Quick Sync',
             libraryName: library.name,
           });
           const itemsWithMetadata: PlexLibraryItem[] = [];
+          const isShowLibrary = library.type === 'show';
           for (const item of recentItems) {
             try {
-              const fullMetadata = await plexClient.getMetadata(item.ratingKey);
+              const fullMetadata = await plexClient.getMetadata(
+                item.ratingKey,
+                { includeChildren: isShowLibrary }
+              );
               itemsWithMetadata.push(fullMetadata);
             } catch (error) {
               logger.warn('Failed to fetch metadata for item, skipping', {

--- a/server/lib/placeholders/services/PlaceholderCreation.ts
+++ b/server/lib/placeholders/services/PlaceholderCreation.ts
@@ -64,14 +64,27 @@ export async function processPlaceholdersForMissingItems(
     '@server/lib/collections/sources/comingsoon/comingSoonFetch'
   );
   const daysAhead = getDaysAhead(config);
-  await enrichWithTMDBReleaseDates(sourceData, daysAhead);
+  // Only filter out already-released items for Coming Soon collections
+  // Other collection types (MDBlist, IMDb, etc.) should keep placeholders for released content
+  await enrichWithTMDBReleaseDates(
+    sourceData,
+    daysAhead,
+    isComingSoonCollection
+  );
 
   // Filter by days ahead - only create placeholders for items releasing within the configured window
+  // For non-Coming Soon collections, skip the date filter to allow placeholders for released content
   const { isDateWithinDays, determineReleaseDate } = await import(
     '@server/utils/dateHelpers'
   );
 
   const filteredSourceData = sourceData.filter((item) => {
+    // For non-Coming Soon collections, skip the date filtering entirely
+    // These collections want placeholders for content they don't have, regardless of release date
+    if (!isComingSoonCollection) {
+      return true;
+    }
+
     // Determine the effective release date to check
     let releaseDateToCheck: string | undefined;
 


### PR DESCRIPTION
Non-Coming Soon collections (MDBlist, IMDb, Trakt, Letterboxd) were incorrectly filtering out released content during placeholder creation. The `enrichWithTMDBReleaseDates` function was removing items that had already been released, but this behavior should only apply to Coming Soon collections.

- Added `filterReleased` param to `enrichWithTMDBReleaseDates` (default true for backward compatibility)
- `PlaceholderCreation` passes `isComingSoonCollection` to skip filtering for other collection types
- Skip date window filter in `PlaceholderCreation` for non-Coming Soon collections

Fixes #336