### PR TITLE
fix(plex): handle 404 gracefully when deleting hub items

### DIFF
--- a/server/lib/collections/plex/PlexHubManager.ts
+++ b/server/lib/collections/plex/PlexHubManager.ts
@@ -623,11 +623,25 @@ class PlexHubManager {
 
       await this.plexApi['safeDeleteQuery'](url);
     } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      // 404 means hub is already deleted - treat as success
+      if (errorMessage.includes('404')) {
+        logger.debug(
+          `Hub item ${hubId} already deleted from library section ${sectionId}`,
+          {
+            label: 'Plex API',
+            sectionId,
+            hubId,
+          }
+        );
+        return;
+      }
       logger.error(
         `Error deleting hub item ${hubId} from library section ${sectionId}`,
         {
           label: 'Plex API',
-          error: error instanceof Error ? error.message : String(error),
+          error: errorMessage,
           sectionId,
           hubId,
         }


### PR DESCRIPTION
Hub items that no longer exist in Plex were causing error logs during cleanup operations. Now 404 responses are treated as success (hub already deleted) and logged at debug level instead.

This matches the behavior of other delete methods like `removeItemsFromCollection` which also ignore 404 responses.