### PR TITLE
feat(imdb): add Top 250 English Movies collection type

### DIFF
--- a/server/api/imdb.ts
+++ b/server/api/imdb.ts
@@ -36,6 +36,7 @@ export interface ImdbList {
  */
 export enum ImdbTopList {
   TOP_250_MOVIES = 'top250movies',
+  TOP_250_ENGLISH_MOVIES = 'top250englishmovies',
   TOP_250_TV = 'top250tv',
   POPULAR_MOVIES = 'popularmovies',
   POPULAR_TV = 'populartv',
@@ -98,6 +99,10 @@ class ImdbAPI extends ExternalAPI {
       switch (listType) {
         case ImdbTopList.TOP_250_MOVIES:
           url = '/chart/top/';
+          expectedType = 'movie';
+          break;
+        case ImdbTopList.TOP_250_ENGLISH_MOVIES:
+          url = '/chart/top-english-movies/';
           expectedType = 'movie';
           break;
         case ImdbTopList.TOP_250_TV:
@@ -355,6 +360,8 @@ class ImdbAPI extends ExternalAPI {
     switch (listType) {
       case ImdbTopList.TOP_250_MOVIES:
         return 'Top 250 Movies';
+      case ImdbTopList.TOP_250_ENGLISH_MOVIES:
+        return 'Top 250 English Movies';
       case ImdbTopList.TOP_250_TV:
         return 'Top 250 TV Shows';
       case ImdbTopList.POPULAR_MOVIES:

--- a/server/lib/collections/sources/imdb.ts
+++ b/server/lib/collections/sources/imdb.ts
@@ -1052,6 +1052,8 @@ export class ImdbCollectionSync extends BaseCollectionSync<'imdb'> {
     switch (subtype) {
       case 'top_250':
         return mediaType === 'tv' ? '/chart/toptv/' : '/chart/top/';
+      case 'top_250_english':
+        return '/chart/top-english-movies/';
       case 'popular':
         return mediaType === 'tv' ? '/chart/tvmeter/' : '/chart/moviemeter/';
       case 'boxoffice':

--- a/server/lib/collections/utils/TemplateEngine.ts
+++ b/server/lib/collections/utils/TemplateEngine.ts
@@ -759,6 +759,8 @@ export class TemplateEngine {
     switch (subtype) {
       case 'top_250':
         return 'Top 250';
+      case 'top_250_english':
+        return 'Top 250 English';
       case 'popular':
         return 'Popular';
       case 'most_popular':

--- a/src/components/Collections/FormSections/CollectionTypeSection.tsx
+++ b/src/components/Collections/FormSections/CollectionTypeSection.tsx
@@ -248,6 +248,12 @@ const CollectionTypeSection = ({
             description: 'Highest rated movies/TV shows on IMDb',
           },
           {
+            value: 'top_250_english',
+            label: 'Top 250 English',
+            description:
+              'Highest rated English-language movies on IMDb (movies only)',
+          },
+          {
             value: 'popular',
             label: 'Popular (Meter)',
             description: 'Most viewed by IMDb users based on page views',
@@ -478,6 +484,9 @@ const CollectionTypeSection = ({
                 setFieldValue('mediaType', 'movie');
               }
               if (values.type === 'imdb' && newSubtype === 'boxoffice') {
+                setFieldValue('mediaType', 'movie');
+              }
+              if (values.type === 'imdb' && newSubtype === 'top_250_english') {
                 setFieldValue('mediaType', 'movie');
               }
 

--- a/src/components/Collections/FormSections/MultiSourceConfigSection.tsx
+++ b/src/components/Collections/FormSections/MultiSourceConfigSection.tsx
@@ -789,6 +789,12 @@ const MultiSourceConfigSection = ({
             description: 'Highest rated movies/TV shows on IMDb',
           },
           {
+            value: 'top_250_english',
+            label: 'Top 250 English',
+            description:
+              'Highest rated English-language movies on IMDb (movies only)',
+          },
+          {
             value: 'popular',
             label: 'Popular (Meter)',
             description: 'Most viewed by IMDb users based on page views',

--- a/src/components/Collections/Forms/titlePresets.tsx
+++ b/src/components/Collections/Forms/titlePresets.tsx
@@ -1044,6 +1044,22 @@ export const getTemplatePresets = (
           },
           { label: 'Custom', value: 'custom' },
         ];
+      case 'top_250_english':
+        return [
+          {
+            label: 'IMDb Top 250 English Movies',
+            value: 'IMDb Top 250 English Movies',
+          },
+          {
+            label: 'Best English Movies',
+            value: 'Best English Movies',
+          },
+          {
+            label: 'Top English Films',
+            value: 'Top English Films',
+          },
+          { label: 'Custom', value: 'custom' },
+        ];
       case 'popular':
         return [
           {

--- a/src/components/Collections/Shared/CollectionBadges.tsx
+++ b/src/components/Collections/Shared/CollectionBadges.tsx
@@ -277,6 +277,8 @@ export const getSubtypeLabel = (type: string, subtype?: string): string => {
       switch (subtype) {
         case 'top_250':
           return 'Top 250';
+        case 'top_250_english':
+          return 'Top 250 English';
         case 'popular':
           return 'Popular';
         case 'most_popular':


### PR DESCRIPTION
Adds support for IMDb's Top 250 English-language movies list as a new collection source.

- Added `TOP_250_ENGLISH_MOVIES` enum value and URL mapping to `/chart/top-english-movies/`
- Added `top_250_english` subtype to collection sources
- Added UI options in single and multi-source collection forms
- Added title presets for the new collection type
- Auto-sets mediaType to 'movie' when selecting this subtype (movies only)

Closes #330