### PR TITLE
fix(workflow): improve release workflow with version check and discord notifications

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -6,14 +6,11 @@ on:
       - latest
 
 jobs:
-  semantic-release:
-    name: Tag and release latest version
+  version-check:
+    name: Check for new version
     runs-on: ubuntu-22.04
     permissions:
       contents: write
-      issues: write
-      pull-requests: write
-      packages: write
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
@@ -31,17 +28,19 @@ jobs:
         env:
           HUSKY: 0
         run: yarn
-      - name: Release
+      - name: Check version (dry-run)
         id: semantic
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          dry_run: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
 
   build_and_push:
     name: Build ${{ matrix.platform }}
     runs-on: ${{ matrix.runner }}
-    needs: semantic-release
-    if: needs.semantic-release.outputs.new_release_published == 'true'
+    needs: version-check
+    if: needs.version-check.outputs.new_release_published == 'true'
     permissions:
       packages: write
       contents: read
@@ -95,7 +94,7 @@ jobs:
     name: Create multi-platform manifest
     runs-on: ubuntu-22.04
     needs:
-      - semantic-release
+      - version-check
       - build_and_push
     permissions:
       packages: write
@@ -129,7 +128,7 @@ jobs:
         run: |
           docker buildx imagetools create \
             -t ghcr.io/agregarr/agregarr:latest \
-            -t ghcr.io/agregarr/agregarr:v${{ needs.semantic-release.outputs.new_release_version }} \
+            -t ghcr.io/agregarr/agregarr:v${{ needs.version-check.outputs.new_release_version }} \
             $(printf 'ghcr.io/agregarr/agregarr@sha256:%s ' *)
 
       - name: Install regctl
@@ -140,9 +139,62 @@ jobs:
       - name: Copy to Docker Hub
         run: |
           /tmp/regctl image copy ghcr.io/agregarr/agregarr:latest agregarr/agregarr:latest
-          /tmp/regctl image copy ghcr.io/agregarr/agregarr:v${{ needs.semantic-release.outputs.new_release_version }} agregarr/agregarr:v${{ needs.semantic-release.outputs.new_release_version }}
+          /tmp/regctl image copy ghcr.io/agregarr/agregarr:v${{ needs.version-check.outputs.new_release_version }} agregarr/agregarr:v${{ needs.version-check.outputs.new_release_version }}
 
       - name: Inspect images
         run: |
           docker buildx imagetools inspect ghcr.io/agregarr/agregarr:latest
           docker buildx imagetools inspect agregarr/agregarr:latest
+
+  release:
+    name: Create release
+    runs-on: ubuntu-22.04
+    needs:
+      - version-check
+      - merge
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - name: Install dependencies
+        env:
+          HUSKY: 0
+        run: yarn
+      - name: Release
+        uses: cycjimmy/semantic-release-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  discord:
+    name: Discord Notification
+    runs-on: ubuntu-22.04
+    needs:
+      - version-check
+      - release
+    steps:
+      - name: Send Discord Notification
+        run: |
+          curl -H "Content-Type: application/json" \
+            -d '{
+              "content": "@everyone",
+              "embeds": [{
+                "title": "🎉 Agregarr v${{ needs.version-check.outputs.new_release_version }} Released!",
+                "description": "A new version of Agregarr is now available!\n\n**[📝 View Release Notes](${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ needs.version-check.outputs.new_release_version }})**",
+                "color": 15105570,
+                "fields": [
+                  {"name": "🐳 Update your Docker image", "value": "```docker pull agregarr/agregarr:latest```", "inline": false}
+                ],
+                "thumbnail": {"url": "https://raw.githubusercontent.com/agregarr/agregarr/develop/public/android-chrome-512x512.png"}
+              }]
+            }' \
+            ${{ secrets.DISCORD_WEBHOOK_LATEST }}


### PR DESCRIPTION
## Summary
- Split semantic-release into `version-check` (dry-run) and `release` jobs so Docker images build before the actual release is created
- Use `cycjimmy/semantic-release-action@v4` for better output handling
- Add Discord notification job to announce new releases to users

## Test plan
- [x] Tested on test repo (samohtxotom/test-agregarr) with v2.2.1 release
- [ ] Verify workflow runs correctly on next release to `latest` branch