### PR TITLE
fix(placeholders): skip date filtering for non-Coming-Soon with includeAllReleasedItems

### DIFF
--- a/server/lib/collections/sources/comingsoon/comingSoonFetch.ts
+++ b/server/lib/collections/sources/comingsoon/comingSoonFetch.ts
@@ -1063,15 +1063,21 @@ export async function fetchTmdbComingSoonShows(
 }
 
 /**
- * Enrich items with TMDB release dates and filter out already-released items
+ * Enrich items with TMDB release dates and optionally filter by date window
  * Adds 3-month estimate for items with only theatrical releases
- * Filters out items where the earliest digital/physical release has already passed
+ * When skipDateFilter is false (default), filters out items outside the date window
  * Modifies the array in place
+ *
+ * @param items - Array of items to enrich
+ * @param maxDaysAway - Maximum days in future to include (default 360)
+ * @param releasedDays - Days in past to include (default 0)
+ * @param skipDateFilter - When true, only enrich metadata without filtering (for non-Coming-Soon with includeAllReleasedItems)
  */
 export async function enrichWithTMDBReleaseDates(
   items: ComingSoonSourceData[],
   maxDaysAway = 360,
-  releasedDays = 0
+  releasedDays = 0,
+  skipDateFilter = false
 ): Promise<void> {
   const TmdbAPI = (await import('@server/api/themoviedb')).default;
   const tmdbClient = new TmdbAPI();
@@ -1090,6 +1096,7 @@ export async function enrichWithTMDBReleaseDates(
     itemCount: items.length,
     maxDaysAway,
     releasedDays,
+    skipDateFilter,
   });
 
   // Use SHARED helper functions - import once at the top
@@ -1169,29 +1176,32 @@ export async function enrichWithTMDBReleaseDates(
           }
 
           // Filter: only include if release date is within window (past to future)
-          const earliestReleaseDate = releaseDateResult
-            ? new Date(releaseDateResult.releaseDate)
-            : extracted.earliestReleaseDate || null;
+          // Skip filtering when skipDateFilter is true (non-Coming-Soon with includeAllReleasedItems)
+          if (!skipDateFilter) {
+            const earliestReleaseDate = releaseDateResult
+              ? new Date(releaseDateResult.releaseDate)
+              : extracted.earliestReleaseDate || null;
 
-          if (
-            !earliestReleaseDate ||
-            earliestReleaseDate < minDate ||
-            earliestReleaseDate > maxDate
-          ) {
-            logger.debug(
-              'Filtering out movie (no date, too old, or too far away)',
-              {
-                label: 'PlaceholderService',
-                title: item.title,
-                earliestReleaseDate: earliestReleaseDate?.toISOString(),
-                reason: !earliestReleaseDate
-                  ? 'no date'
-                  : earliestReleaseDate < minDate
-                  ? 'too old (beyond releasedDays window)'
-                  : 'too far away (beyond daysAhead window)',
-              }
-            );
-            return { index, shouldRemove: true };
+            if (
+              !earliestReleaseDate ||
+              earliestReleaseDate < minDate ||
+              earliestReleaseDate > maxDate
+            ) {
+              logger.debug(
+                'Filtering out movie (no date, too old, or too far away)',
+                {
+                  label: 'PlaceholderService',
+                  title: item.title,
+                  earliestReleaseDate: earliestReleaseDate?.toISOString(),
+                  reason: !earliestReleaseDate
+                    ? 'no date'
+                    : earliestReleaseDate < minDate
+                    ? 'too old (beyond releasedDays window)'
+                    : 'too far away (beyond daysAhead window)',
+                }
+              );
+              return { index, shouldRemove: true };
+            }
           }
         } else if (item.mediaType === 'tv') {
           // Only enrich airDate if not already set (Sonarr already provides season-specific dates)
@@ -1241,22 +1251,28 @@ export async function enrichWithTMDBReleaseDates(
           }
 
           // Filter TV shows: check if air date is within window (past to future, timezone-aware)
-          if (item.airDate) {
-            if (!isDateWithinDays(item.airDate, maxDaysAway, releasedDays)) {
-              logger.debug('Filtering out TV show (too old or too far away)', {
+          // Skip filtering when skipDateFilter is true (non-Coming-Soon with includeAllReleasedItems)
+          if (!skipDateFilter) {
+            if (item.airDate) {
+              if (!isDateWithinDays(item.airDate, maxDaysAway, releasedDays)) {
+                logger.debug(
+                  'Filtering out TV show (too old or too far away)',
+                  {
+                    label: 'PlaceholderService',
+                    title: item.title,
+                    airDate: item.airDate,
+                  }
+                );
+                return { index, shouldRemove: true };
+              }
+            } else {
+              // No air date found, filter out
+              logger.debug('Filtering out TV show (no air date)', {
                 label: 'PlaceholderService',
                 title: item.title,
-                airDate: item.airDate,
               });
               return { index, shouldRemove: true };
             }
-          } else {
-            // No air date found, filter out
-            logger.debug('Filtering out TV show (no air date)', {
-              label: 'PlaceholderService',
-              title: item.title,
-            });
-            return { index, shouldRemove: true };
           }
         }
 
@@ -1275,8 +1291,8 @@ export async function enrichWithTMDBReleaseDates(
           tmdbId: item.tmdbId,
           error: error instanceof Error ? error.message : String(error),
         });
-        // Remove items that fail to fetch
-        return { index, shouldRemove: true };
+        // Remove items that fail to fetch, unless skipDateFilter is true (fail-open for non-Coming-Soon)
+        return { index, shouldRemove: !skipDateFilter };
       }
     })
   );

--- a/server/lib/placeholders/services/PlaceholderCreation.ts
+++ b/server/lib/placeholders/services/PlaceholderCreation.ts
@@ -65,14 +65,23 @@ export async function processPlaceholdersForMissingItems(
   );
   const daysAhead = getDaysAhead(config);
   const releasedDays = getReleasedDays(config);
-  await enrichWithTMDBReleaseDates(sourceData, daysAhead, releasedDays);
+  const includeAllReleased = config.includeAllReleasedItems ?? true;
+
+  // Skip date filtering in enrichment when includeAllReleasedItems is true for non-Coming-Soon collections
+  // The filtering will happen below with proper includeAllReleasedItems logic
+  const skipDateFilter = includeAllReleased && !isComingSoonCollection;
+  await enrichWithTMDBReleaseDates(
+    sourceData,
+    daysAhead,
+    releasedDays,
+    skipDateFilter
+  );
 
   // Filter by date window - only create placeholders for items within the configured window
   // When includeAllReleasedItems is true: include all past items, only filter by daysAhead for future
   // When includeAllReleasedItems is false: use window from releasedDays in past to daysAhead in future
   const { isDateWithinDays, isDateWithinFutureDays, determineReleaseDate } =
     await import('@server/utils/dateHelpers');
-  const includeAllReleased = config.includeAllReleasedItems ?? true; // Default true for new configs
 
   const filteredSourceData = sourceData.filter((item) => {
     // Determine the effective release date to check


### PR DESCRIPTION
The date window filtering in `enrichWithTMDBReleaseDates()` was removing items before `includeAllReleasedItems` could preserve them. Added `skipDateFilter` param to bypass filtering when `includeAllReleasedItems` is true for non-Coming-Soon collections.

Fixes #336