### PR TITLE
fix(placeholders): check *arr download status for placeholder lifecycle

### DIFF
--- a/server/lib/collections/services/CollectionSyncService.ts
+++ b/server/lib/collections/services/CollectionSyncService.ts
@@ -159,10 +159,8 @@ export class CollectionSyncService {
         let titleFixFailures = 0;
 
         for (const { plexItem, needsTitleFix, marker } of tv) {
-          if (!plexItem) {
-            continue; // Not found in Plex
-          }
-
+          // Cleanup triggers when needsTitleFix is false (real content detected via Plex OR *arr)
+          // This works even without a plexItem (content downloaded to different library)
           if (!needsTitleFix && marker.tmdbId) {
             // Real content detected - clean up placeholder
             await cleanupPlaceholderForRealContent(
@@ -171,8 +169,8 @@ export class CollectionSyncService {
               'tv'
             );
             cleanedUp++;
-          } else if (needsTitleFix) {
-            // Still a placeholder - fix episode title
+          } else if (needsTitleFix && plexItem) {
+            // Still a placeholder with Plex item - fix episode title
             const fixed = await ensurePlaceholderEpisodeTitle(
               plexClient,
               plexItem.ratingKey,
@@ -285,7 +283,9 @@ export class CollectionSyncService {
         let labelsFixed = 0;
 
         for (const { plexItem, needsCleanup, movie } of movies) {
-          if (plexItem && needsCleanup) {
+          // Cleanup triggers when needsCleanup is true (real content detected via Plex OR *arr)
+          // This works even without a plexItem (content downloaded to different library)
+          if (needsCleanup) {
             // Real content detected - clean up placeholder
             await cleanupPlaceholderForRealContent(
               movie.tmdbId,

--- a/server/lib/placeholders/services/PlaceholderContextService.ts
+++ b/server/lib/placeholders/services/PlaceholderContextService.ts
@@ -502,6 +502,118 @@ export class PlaceholderContextService {
   }
 
   /**
+   * Batch fetch download status from Radarr/Sonarr for multiple items
+   * Fetches libraries once and builds lookup maps for efficient querying
+   * Returns maps keyed by tmdbId (movies) and tvdbId (TV)
+   */
+  async batchCheckDownloadStatus(
+    items: {
+      tmdbId: number;
+      tvdbId?: number;
+      mediaType: 'movie' | 'tv';
+    }[]
+  ): Promise<{
+    moviesByTmdbId: Map<number, { downloaded: boolean; inRadarr: boolean }>;
+    showsByTvdbId: Map<number, { downloaded: boolean; inSonarr: boolean }>;
+  }> {
+    const settings = getSettings();
+    const moviesByTmdbId = new Map<
+      number,
+      { downloaded: boolean; inRadarr: boolean }
+    >();
+    const showsByTvdbId = new Map<
+      number,
+      { downloaded: boolean; inSonarr: boolean }
+    >();
+
+    // Check if we have any movies or TV items to look up
+    const hasMovies = items.some((i) => i.mediaType === 'movie');
+    const hasTV = items.some((i) => i.mediaType === 'tv');
+
+    // Fetch Radarr libraries once
+    if (hasMovies && settings.radarr) {
+      for (const radarrInstance of settings.radarr) {
+        try {
+          const radarrClient = new RadarrAPI({
+            url: `${radarrInstance.useSsl ? 'https' : 'http'}://${
+              radarrInstance.hostname
+            }:${radarrInstance.port}${radarrInstance.baseUrl || ''}/api/v3`,
+            apiKey: radarrInstance.apiKey,
+          });
+
+          const movies = await radarrClient.getMovies();
+
+          for (const movie of movies) {
+            if (movie.tmdbId) {
+              const existing = moviesByTmdbId.get(movie.tmdbId);
+              // OR downloaded status across instances - if ANY instance has it, it's downloaded
+              moviesByTmdbId.set(movie.tmdbId, {
+                downloaded:
+                  existing?.downloaded || false || movie.hasFile || false,
+                inRadarr: true,
+              });
+            }
+          }
+
+          logger.debug('Fetched Radarr library for batch download check', {
+            label: 'PlaceholderContextService',
+            instance: radarrInstance.hostname,
+            movieCount: movies.length,
+          });
+        } catch (error) {
+          logger.warn('Failed to fetch Radarr library for batch check', {
+            label: 'PlaceholderContextService',
+            instance: radarrInstance.hostname,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+
+    // Fetch Sonarr libraries once
+    if (hasTV && settings.sonarr) {
+      for (const sonarrInstance of settings.sonarr) {
+        try {
+          const sonarrClient = new SonarrAPI({
+            url: `${sonarrInstance.useSsl ? 'https' : 'http'}://${
+              sonarrInstance.hostname
+            }:${sonarrInstance.port}${sonarrInstance.baseUrl || ''}/api/v3`,
+            apiKey: sonarrInstance.apiKey,
+          });
+
+          const shows = await sonarrClient.getSeries();
+
+          for (const show of shows) {
+            if (show.tvdbId) {
+              const existing = showsByTvdbId.get(show.tvdbId);
+              const hasEpisodes = (show.statistics?.episodeFileCount || 0) > 0;
+              // OR downloaded status across instances - if ANY instance has it, it's downloaded
+              showsByTvdbId.set(show.tvdbId, {
+                downloaded: existing?.downloaded || false || hasEpisodes,
+                inSonarr: true,
+              });
+            }
+          }
+
+          logger.debug('Fetched Sonarr library for batch download check', {
+            label: 'PlaceholderContextService',
+            instance: sonarrInstance.hostname,
+            showCount: shows.length,
+          });
+        } catch (error) {
+          logger.warn('Failed to fetch Sonarr library for batch check', {
+            label: 'PlaceholderContextService',
+            instance: sonarrInstance.hostname,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+
+    return { moviesByTmdbId, showsByTvdbId };
+  }
+
+  /**
    * Check monitoring status in Radarr/Sonarr
    * Returns whether item is in *arr, monitored, and has files
    */

--- a/server/lib/placeholders/services/PlaceholderCreation.ts
+++ b/server/lib/placeholders/services/PlaceholderCreation.ts
@@ -187,10 +187,86 @@ export async function processPlaceholdersForMissingItems(
     tmdbIdsWithSourceData.has(item.tmdbId)
   );
 
+  // Check *arr download status before creating placeholders
+  // This prevents re-creating placeholders when content has been downloaded
+  // but Plex hasn't scanned it yet (race condition fix for issue #390)
+  // Uses batch lookup to fetch *arr libraries once instead of per-item
+  const { placeholderContextService } = await import(
+    '@server/lib/placeholders/services/PlaceholderContextService'
+  );
+
+  // Batch fetch download status from *arr (fetches libraries once)
+  const { moviesByTmdbId, showsByTvdbId } =
+    await placeholderContextService.batchCheckDownloadStatus(
+      filteredMissingItems.map((item) => ({
+        tmdbId: item.tmdbId,
+        tvdbId: item.tvdbId,
+        mediaType: item.mediaType,
+      }))
+    );
+
+  const itemsNotDownloaded: MissingItem[] = [];
+  let skippedAlreadyDownloaded = 0;
+
+  for (const item of filteredMissingItems) {
+    let isDownloaded = false;
+
+    if (item.mediaType === 'movie') {
+      const radarrStatus = moviesByTmdbId.get(item.tmdbId);
+      isDownloaded = radarrStatus?.downloaded ?? false;
+    } else if (item.mediaType === 'tv' && item.tvdbId) {
+      const sonarrStatus = showsByTvdbId.get(item.tvdbId);
+      isDownloaded = sonarrStatus?.downloaded ?? false;
+    }
+
+    if (isDownloaded) {
+      skippedAlreadyDownloaded++;
+      logger.debug(
+        'Skipping placeholder creation - content already downloaded in *arr',
+        {
+          label: 'PlaceholderService',
+          title: item.title,
+          tmdbId: item.tmdbId,
+          mediaType: item.mediaType,
+        }
+      );
+    } else {
+      itemsNotDownloaded.push(item);
+    }
+  }
+
+  if (skippedAlreadyDownloaded > 0) {
+    logger.info(
+      'Skipped placeholder creation for items already downloaded in *arr',
+      {
+        label: 'PlaceholderService',
+        configName: config.name,
+        skippedCount: skippedAlreadyDownloaded,
+        remainingCount: itemsNotDownloaded.length,
+      }
+    );
+  }
+
+  if (itemsNotDownloaded.length === 0) {
+    logger.info('No items need placeholders after *arr download check', {
+      label: 'PlaceholderService',
+      configName: config.name,
+      originalCount: missingItems.length,
+      skippedAlreadyDownloaded,
+    });
+    return [];
+  }
+
+  // Filter sourceData to match remaining items
+  const remainingTmdbIds = new Set(itemsNotDownloaded.map((i) => i.tmdbId));
+  const remainingSourceData = filteredSourceData.filter((s) =>
+    remainingTmdbIds.has(s.tmdbId)
+  );
+
   // Call the internal placeholder creation logic
   return createPlaceholders(
-    filteredMissingItems,
-    filteredSourceData,
+    itemsNotDownloaded,
+    remainingSourceData,
     config,
     plexClient
   );

--- a/server/lib/placeholders/services/PlaceholderDiscovery.ts
+++ b/server/lib/placeholders/services/PlaceholderDiscovery.ts
@@ -135,12 +135,31 @@ export async function discoverPlaceholdersFromMarkers(
       libraryId
     );
 
+    // Batch check *arr download status for all markers
+    // This catches cases where content is downloaded but in a different Plex library
+    const arrLookups = tier1Markers
+      .filter((m) => m.tmdbId !== undefined)
+      .map((m) => ({
+        tmdbId: m.tmdbId as number,
+        tvdbId: m.tvdbId,
+        mediaType: 'tv' as const,
+      }));
+
+    const { showsByTvdbId } =
+      await placeholderContextService.batchCheckDownloadStatus(arrLookups);
+
     for (const marker of tier1Markers) {
       if (!marker.tmdbId) {
         continue;
       }
 
       const plexItem = plexMatches.get(`${marker.tmdbId}-tv`);
+
+      // Check if *arr reports content as downloaded (works even if content is in different Plex library)
+      const arrStatus = marker.tvdbId
+        ? showsByTvdbId.get(marker.tvdbId)
+        : undefined;
+      const isDownloadedInArr = arrStatus?.downloaded === true;
 
       // Verify it's still a placeholder (check if real content was added)
       let needsTitleFix = false;
@@ -151,7 +170,8 @@ export async function discoverPlaceholdersFromMarkers(
         );
         const isStillPlaceholder =
           placeholderContextService.isPlaceholderItem(plexMetadata);
-        needsTitleFix = isStillPlaceholder;
+        // Only needs title fix if Plex still shows placeholder AND *arr hasn't downloaded
+        needsTitleFix = isStillPlaceholder && !isDownloadedInArr;
 
         if (!isStillPlaceholder) {
           logger.info('Placeholder has real content now - skipping title fix', {
@@ -159,7 +179,30 @@ export async function discoverPlaceholdersFromMarkers(
             title: marker.title,
             ratingKey: plexItem.ratingKey,
           });
+        } else if (isDownloadedInArr) {
+          logger.info(
+            'Placeholder has content downloaded in Sonarr - triggering cleanup',
+            {
+              label: 'PlaceholderService',
+              title: marker.title,
+              tvdbId: marker.tvdbId,
+            }
+          );
         }
+      } else if (isDownloadedInArr) {
+        // No Plex item found but *arr says downloaded - still trigger cleanup
+        logger.info(
+          'No Plex item but content downloaded in Sonarr - triggering cleanup',
+          {
+            label: 'PlaceholderService',
+            title: marker.title,
+            tvdbId: marker.tvdbId,
+          }
+        );
+        // needsTitleFix stays false, which triggers cleanup
+      } else {
+        // No Plex item and *arr doesn't confirm downloaded - keep placeholder
+        needsTitleFix = true;
       }
 
       discovered.push({
@@ -204,6 +247,20 @@ export async function discoverPlaceholdersFromMarkers(
 
         const plexItem = plexMatches.get(`${dbRecord.tmdbId}-tv`);
 
+        // Check *arr download status
+        const arrStatus = dbRecord.tvdbId
+          ? (
+              await placeholderContextService.batchCheckDownloadStatus([
+                {
+                  tmdbId: dbRecord.tmdbId,
+                  tvdbId: dbRecord.tvdbId,
+                  mediaType: 'tv',
+                },
+              ])
+            ).showsByTvdbId.get(dbRecord.tvdbId)
+          : undefined;
+        const isDownloadedInArr = arrStatus?.downloaded === true;
+
         // Verify it's still a placeholder (check if real content was added)
         let needsTitleFix = false;
         if (plexItem) {
@@ -213,7 +270,8 @@ export async function discoverPlaceholdersFromMarkers(
           );
           const isStillPlaceholder =
             placeholderContextService.isPlaceholderItem(plexMetadata);
-          needsTitleFix = isStillPlaceholder;
+          // Only needs title fix if Plex still shows placeholder AND *arr hasn't downloaded
+          needsTitleFix = isStillPlaceholder && !isDownloadedInArr;
 
           if (!isStillPlaceholder) {
             logger.info(
@@ -224,7 +282,29 @@ export async function discoverPlaceholdersFromMarkers(
                 ratingKey: plexItem.ratingKey,
               }
             );
+          } else if (isDownloadedInArr) {
+            logger.info(
+              'Tier 2: Content downloaded in Sonarr - triggering cleanup',
+              {
+                label: 'PlaceholderService',
+                title: marker.title,
+                tvdbId: dbRecord.tvdbId,
+              }
+            );
           }
+        } else if (isDownloadedInArr) {
+          // No Plex item but *arr says downloaded - trigger cleanup
+          logger.info(
+            'Tier 2: No Plex item but content downloaded - triggering cleanup',
+            {
+              label: 'PlaceholderService',
+              title: marker.title,
+              tvdbId: dbRecord.tvdbId,
+            }
+          );
+        } else {
+          // No Plex item and *arr doesn't confirm downloaded - keep placeholder
+          needsTitleFix = true;
         }
 
         discovered.push({
@@ -418,9 +498,23 @@ export async function discoverMoviePlaceholdersFromFilenames(
     libraryId
   );
 
+  // Batch check *arr download status for all movies
+  // This catches cases where content is downloaded but in a different Plex library
+  const arrLookups = movies.map((m) => ({
+    tmdbId: m.tmdbId,
+    mediaType: 'movie' as const,
+  }));
+
+  const { moviesByTmdbId } =
+    await placeholderContextService.batchCheckDownloadStatus(arrLookups);
+
   // Step 3: Match filesystem placeholders to Plex items and verify they're still placeholders
   for (const movie of movies) {
     const plexItem = plexMatches.get(`${movie.tmdbId}-movie`);
+
+    // Check if *arr reports content as downloaded (works even if content is in different Plex library)
+    const arrStatus = moviesByTmdbId.get(movie.tmdbId);
+    const isDownloadedInArr = arrStatus?.downloaded === true;
 
     // Verify it's still a placeholder (check if real movie was added)
     let needsCleanup = false;
@@ -439,7 +533,28 @@ export async function discoverMoviePlaceholdersFromFilenames(
           ratingKey: plexItem.ratingKey,
         });
         needsCleanup = true; // Mark for cleanup - real movie exists
+      } else if (isDownloadedInArr) {
+        logger.info(
+          'Movie placeholder has content downloaded in Radarr - triggering cleanup',
+          {
+            label: 'PlaceholderService',
+            title: movie.title,
+            tmdbId: movie.tmdbId,
+          }
+        );
+        needsCleanup = true; // Mark for cleanup - Radarr has the file
       }
+    } else if (isDownloadedInArr) {
+      // No Plex item found but *arr says downloaded - still trigger cleanup
+      logger.info(
+        'No Plex item but content downloaded in Radarr - triggering cleanup',
+        {
+          label: 'PlaceholderService',
+          title: movie.title,
+          tmdbId: movie.tmdbId,
+        }
+      );
+      needsCleanup = true;
     }
 
     discovered.push({


### PR DESCRIPTION
## Summary

Placeholders now check Sonarr/Radarr download status during both creation and cleanup. This fixes cases where placeholders are incorrectly created or not cleaned up when content exists in *arr but Plex hasn't scanned yet.

## Problem

Two related issues:
1. **Creation:** When content was downloaded but Plex hadn't scanned, sync would see it as "missing" and create a new placeholder
2. **Cleanup:** When content downloaded to a different Plex library, cleanup never triggered because it only checked the placeholder library

## Solution

Added `batchCheckDownloadStatus()` to `PlaceholderContextService` that efficiently queries Radarr/Sonarr libraries once per sync.

### Creation prevention (`PlaceholderCreation.ts`)
- Before creating placeholders, batch check *arr download status
- Skip placeholder creation if *arr already has the content downloaded

### Cleanup detection (`PlaceholderDiscovery.ts`)
- During discovery, check *arr status in addition to Plex metadata
- Trigger cleanup if *arr reports downloaded, even if:
  - Plex item still appears to be a placeholder
  - No Plex item exists in the placeholder library

### Sync service (`CollectionSyncService.ts`)
- Allow cleanup without requiring a Plex item match

### Multi-instance support (`PlaceholderContextService.ts`)
- Content is considered downloaded if present in any *arr instance

## Edge case: No Plex item

When a placeholder has no corresponding Plex item:
- If *arr confirms downloaded: trigger cleanup
- If *arr doesn't confirm: keep placeholder (might be valid, Plex just hasn't scanned)

## Scope Clarification

This handles **placeholder cleanup** (Agregarr's internal trailer files), not real media deletion. Per #384, real media pruning should be handled by Maintainerr.

## Known Limitations

1. **TV requires `tvdbId`:** Sonarr lookup uses TVDB IDs. Markers without `tvdbId` won't benefit from *arr status checking.

2. **Tier-2 not batched:** Placeholder markers come in three tiers:
   - **Tier 1 (current format):** Marker file contains `tmdbId`/`tvdbId` - these are batched efficiently
   - **Tier 2 (legacy):** Old marker files without IDs, but database has the record - requires per-marker lookup
   - **Tier 3 (orphaned):** No IDs anywhere - uses title search fallback

   Tier-2 markers call `batchCheckDownloadStatus()` per marker (fetching full *arr libraries each time). This is suboptimal but acceptable because Tier-2 markers are legacy from older Agregarr versions. They get upgraded to Tier-1 format on each sync, so most users will have few or no Tier-2 markers after a few scans.

Fixes #390