### PR TITLE
fix(overlay): move IMDb rating position out of conflict with top banner tiles

### DIFF
--- a/server/lib/overlays/PresetTemplates.ts
+++ b/server/lib/overlays/PresetTemplates.ts
@@ -576,7 +576,7 @@ export const PRESET_TEMPLATES: {
           layerOrder: 0,
           type: 'svg',
           x: 0,
-          y: 310.50617627005715,
+          y: 466,
           width: 163,
           height: 77,
           properties: {
@@ -611,7 +611,7 @@ export const PRESET_TEMPLATES: {
           layerOrder: 0,
           type: 'tile',
           x: -5.5246784801583,
-          y: 390.50433315836005,
+          y: 546,
           width: 169,
           height: 85,
           properties: {
@@ -628,7 +628,7 @@ export const PRESET_TEMPLATES: {
           layerOrder: 1,
           type: 'raster',
           x: 5.9753215198417,
-          y: 384.50433315836005,
+          y: 540,
           width: 146,
           height: 97,
           properties: {

--- a/server/lib/overlays/PresetTemplates.ts
+++ b/server/lib/overlays/PresetTemplates.ts
@@ -34,7 +34,7 @@ export const PRESET_TEMPLATES: {
           layerOrder: 0,
           type: 'tile',
           x: 0,
-          y: 0,
+          y: 311,
           width: 162,
           height: 155,
           properties: {
@@ -52,7 +52,7 @@ export const PRESET_TEMPLATES: {
           layerOrder: 1,
           type: 'variable',
           x: 16,
-          y: 59,
+          y: 369,
           width: 127,
           height: 108,
           properties: {
@@ -70,7 +70,7 @@ export const PRESET_TEMPLATES: {
           layerOrder: 2,
           type: 'svg',
           x: 16,
-          y: -18,
+          y: 292,
           width: 130,
           height: 130,
           properties: {


### PR DESCRIPTION
#### Description

The default Overlay template for IMDd rating conflicts/overlaps with any template that creates 'header' or 'top of poster' banners. Screenshot examples below.

This moves the IMDB rating 1 pixel below the rotten tomatoes rating and out of conflict with other known overlays. This change shifts HDR and Dolby Vision down 155px to make room.

#### Screenshot (if UI-related)

Before (with default placement):
<img width="577" height="187" alt="image" src="https://github.com/user-attachments/assets/d4621594-82e4-4e4c-b0cc-a33463c1d3ab" />


After:
<img width="542" height="351" alt="image" src="https://github.com/user-attachments/assets/176b28f2-149b-4e89-9856-4d2ef814f258" />

