### PR TITLE
fix(api): pass options to ExternalAPI constructor correctly

### DIFF
--- a/server/api/flixpatrol.ts
+++ b/server/api/flixpatrol.ts
@@ -61,29 +61,33 @@ export enum FlixPatrolPlatform {
  */
 class FlixPatrolAPI extends ExternalAPI {
   constructor() {
-    super('https://flixpatrol.com', {
-      headers: {
-        // Override the default JSON headers that trigger bot detection
-        'Content-Type': undefined, // Remove the application/json content-type
-        Accept:
-          'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
-        'User-Agent':
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-        'Accept-Language': 'en-US,en;q=0.9',
-        'Cache-Control': 'no-cache',
-        Pragma: 'no-cache',
-        'Sec-Ch-Ua':
-          '"Not_A Brand";v="8", "Chromium";v="120", "Google Chrome";v="120"',
-        'Sec-Ch-Ua-Mobile': '?0',
-        'Sec-Ch-Ua-Platform': '"macOS"',
-        'Sec-Fetch-Dest': 'document',
-        'Sec-Fetch-Mode': 'navigate',
-        'Sec-Fetch-Site': 'none',
-        'Sec-Fetch-User': '?1',
-        'Upgrade-Insecure-Requests': '1',
-      },
-      nodeCache: cacheManager.getCache('flixpatrol').data,
-    });
+    super(
+      'https://flixpatrol.com',
+      {}, // URL params
+      {
+        headers: {
+          // Override the default JSON headers that trigger bot detection
+          'Content-Type': undefined, // Remove the application/json content-type
+          Accept:
+            'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+          'User-Agent':
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+          'Accept-Language': 'en-US,en;q=0.9',
+          'Cache-Control': 'no-cache',
+          Pragma: 'no-cache',
+          'Sec-Ch-Ua':
+            '"Not_A Brand";v="8", "Chromium";v="120", "Google Chrome";v="120"',
+          'Sec-Ch-Ua-Mobile': '?0',
+          'Sec-Ch-Ua-Platform': '"macOS"',
+          'Sec-Fetch-Dest': 'document',
+          'Sec-Fetch-Mode': 'navigate',
+          'Sec-Fetch-Site': 'none',
+          'Sec-Fetch-User': '?1',
+          'Upgrade-Insecure-Requests': '1',
+        },
+        nodeCache: cacheManager.getCache('flixpatrol').data,
+      }
+    );
   }
 
   /**

--- a/server/api/imdbRatings.ts
+++ b/server/api/imdbRatings.ts
@@ -19,13 +19,17 @@ export interface ImdbRatingResponse {
  */
 class ImdbRatingsAPI extends ExternalAPI {
   constructor() {
-    super('https://api.agregarr.org', {
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-      nodeCache: cacheManager.getCache('imdb').data,
-    });
+    super(
+      'https://api.agregarr.org',
+      {}, // URL params
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        nodeCache: cacheManager.getCache('imdb').data,
+      }
+    );
   }
 
   /**


### PR DESCRIPTION
`ImdbRatingsAPI` and `FlixPatrolAPI` were passing headers and `nodeCache` as the second argument (params) instead of the third argument (options). This meant `nodeCache` was being treated as URL query params rather than cache configuration, so responses were never cached.

Fixed by passing empty object for params and moving options to third argument.