### PR TITLE
fix(collections): use correct Plex API endpoint for collection title updates

### DIFF
--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -1238,20 +1238,41 @@ class PlexAPI {
 
   public async updateCollectionTitle(
     collectionRatingKey: string,
-    title: string
+    title: string,
+    libraryKey?: string
   ): Promise<void> {
     try {
-      const params = {
-        'title.value': title,
-      };
+      // Use the correct Plex API endpoint for editing collection metadata
+      // Collections require PUT /library/sections/{libraryKey}/all with type=18
+      // The old endpoint /library/metadata/{ratingKey} doesn't reliably update collection titles
+      if (libraryKey) {
+        const editUrl = `/library/sections/${libraryKey}/all?type=18&id=${collectionRatingKey}&title.value=${encodeURIComponent(
+          title
+        )}&title.locked=1`;
+        await this.safePutQuery(editUrl);
+      } else {
+        // Fallback to old method if libraryKey not provided (for backwards compatibility)
+        // This may not work reliably for collections
+        const params = {
+          'title.value': title,
+        };
 
-      const queryString = Object.entries(params)
-        .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
-        .join('&');
+        const queryString = Object.entries(params)
+          .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+          .join('&');
 
-      const editUrl = `/library/metadata/${collectionRatingKey}?${queryString}`;
+        const editUrl = `/library/metadata/${collectionRatingKey}?${queryString}`;
 
-      await this.safePutQuery(editUrl);
+        await this.safePutQuery(editUrl);
+
+        logger.warn(
+          `updateCollectionTitle called without libraryKey - using legacy endpoint which may not work for collections`,
+          {
+            label: 'Plex API',
+            collectionRatingKey,
+          }
+        );
+      }
     } catch (error) {
       logger.error(
         `Error updating title for collection ${collectionRatingKey}`,
@@ -1260,6 +1281,7 @@ class PlexAPI {
           error,
         }
       );
+      throw error; // Re-throw so callers know the update failed
     }
   }
 

--- a/server/lib/collections/core/BaseCollectionSync.ts
+++ b/server/lib/collections/core/BaseCollectionSync.ts
@@ -1905,6 +1905,7 @@ export abstract class BaseCollectionSync<TSource extends CollectionSource>
       isLibraryPromoted,
       customPoster,
       collectionName,
+      libraryKey,
     } = options;
 
     // Add collection label
@@ -1914,7 +1915,8 @@ export abstract class BaseCollectionSync<TSource extends CollectionSource>
     if (collectionName) {
       await plexClient.updateCollectionTitle(
         collectionRatingKey,
-        collectionName
+        collectionName,
+        libraryKey
       );
     }
 

--- a/server/lib/collections/services/MultiSourceOrchestrator.ts
+++ b/server/lib/collections/services/MultiSourceOrchestrator.ts
@@ -81,6 +81,7 @@ interface MetadataUpdateOptions {
   isLibraryPromoted?: boolean;
   customPoster?: string | Record<string, string>;
   config: MultiSourceCollectionConfig;
+  libraryKey: string;
 }
 
 /**
@@ -1568,6 +1569,26 @@ export class MultiSourceOrchestrator {
             options.config.smartCollectionSort?.value,
             options.config.maxItems
           );
+
+          // Update title if it changed (for DYNAMIC_CYCLE_TITLE)
+          if (existingCollection.title !== collectionName) {
+            await plexClient.updateCollectionTitle(
+              collectionRatingKey,
+              collectionName,
+              options.libraryKey
+            );
+            logger.debug(
+              `Updated title for smart multi-source collection: ${existingCollection.title} -> ${collectionName}`,
+              {
+                label: 'Multi-Source Orchestrator',
+                configId: options.config.id,
+                collectionRatingKey,
+                oldTitle: existingCollection.title,
+                newTitle: collectionName,
+              }
+            );
+          }
+
           updated = 1;
         } else {
           // MIGRATION: Old system had a regular collection, delete it
@@ -1712,6 +1733,25 @@ export class MultiSourceOrchestrator {
               collectionRatingKey,
               plexItems
             );
+
+            // Update title if it changed (for DYNAMIC_CYCLE_TITLE)
+            if (existingCollection.title !== collectionName) {
+              await plexClient.updateCollectionTitle(
+                collectionRatingKey,
+                collectionName,
+                options.libraryKey
+              );
+              logger.debug(
+                `Updated title for multi-source collection: ${existingCollection.title} -> ${collectionName}`,
+                {
+                  label: 'Multi-Source Orchestrator',
+                  configId: options.config.id,
+                  collectionRatingKey,
+                  oldTitle: existingCollection.title,
+                  newTitle: collectionName,
+                }
+              );
+            }
 
             // Label items that fell out of the collection as stale
             if (updateResult.removedKeys.length > 0) {
@@ -1916,7 +1956,8 @@ export class MultiSourceOrchestrator {
     if (options.config.name) {
       await plexClient.updateCollectionTitle(
         collectionRatingKey,
-        options.config.name
+        options.config.name,
+        options.libraryKey
       );
     }
 


### PR DESCRIPTION
## Summary
- Fixed dynamic cycle titles not updating in Plex after first sync
- Changed `updateCollectionTitle()` to use `/library/sections/{id}/all?type=18` endpoint
- Collections require this endpoint pattern, not `/library/metadata/{ratingKey}`

## Changes
- Add `libraryKey` parameter to `updateCollectionTitle()`
- Use correct Plex API endpoint for collection metadata updates
- Lock title field to prevent Plex overwriting
- Propagate errors instead of swallowing them

## Test plan
- [x] Create multi-source collection with cycle mode and DYNAMIC_CYCLE_TITLE
- [x] Sync collection (first source title appears in Plex)
- [x] Sync again (second source title should now update in Plex)

Fixes #432