### PR TITLE
fix: persist applyOverlaysDuringSync for pre-existing collections

### DIFF
--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -439,6 +439,7 @@ export interface PreExistingCollectionConfig {
   enableCustomWallpaper?: boolean; // Enable custom wallpaper sync to Plex
   enableCustomSummary?: boolean; // Enable custom summary sync to Plex
   enableCustomTheme?: boolean; // Enable custom theme sync to Plex
+  applyOverlaysDuringSync?: boolean; // Apply item overlays during sync
 }
 
 export interface PlexSettings {

--- a/src/components/Collections/Views/All/AllCollectionsView.tsx
+++ b/src/components/Collections/Views/All/AllCollectionsView.tsx
@@ -498,6 +498,9 @@ const AllCollectionsView: React.FC = () => {
         ...(preExistingConfig.enableCustomTheme !== undefined && {
           enableCustomTheme: preExistingConfig.enableCustomTheme,
         }),
+        ...(preExistingConfig.applyOverlaysDuringSync !== undefined && {
+          applyOverlaysDuringSync: preExistingConfig.applyOverlaysDuringSync,
+        }),
       };
       await axios.put(`/api/v1/preexisting/${config.id}/settings`, payload);
       // Revalidate data


### PR DESCRIPTION
The "Apply item overlays during sync" checkbox in the pre-existing collection edit form wasn't saving. The UI displayed and toggled the value correctly, but it wasn't persisted because:

1. `PreExistingCollectionConfig` type was missing the field
2. The save payload in `AllCollectionsView.tsx` didn't include it

Added `applyOverlaysDuringSync` to the type definition and save payload.

Fixes #438