### PR TITLE
feat(overlays): add date format options for US and UK/AU locales

### DIFF
--- a/server/utils/dateHelpers.ts
+++ b/server/utils/dateHelpers.ts
@@ -227,12 +227,16 @@ export function formatDate(date: Date | string, format: string): string {
       return `${pad(month)}/${pad(day)}/${year}`;
     case 'DD/MM':
       return `${pad(day)}/${pad(month)}`;
+    case 'D/M':
+      return `${day}/${month}`;
     case 'MM/DD':
       return `${pad(month)}/${pad(day)}`;
     case 'M/D':
       return `${month}/${day}`;
     case 'DDD DD/MM':
       return `${dayName} ${pad(day)}/${pad(month)}`;
+    case 'DDD D/M':
+      return `${dayName} ${day}/${month}`;
     case 'DDD MM/DD':
       return `${dayName} ${pad(month)}/${pad(day)}`;
     case 'DDD M/D':

--- a/server/utils/dateHelpers.ts
+++ b/server/utils/dateHelpers.ts
@@ -229,10 +229,18 @@ export function formatDate(date: Date | string, format: string): string {
       return `${pad(day)}/${pad(month)}`;
     case 'MM/DD':
       return `${pad(month)}/${pad(day)}`;
+    case 'M/D':
+      return `${month}/${day}`;
     case 'DDD DD/MM':
       return `${dayName} ${pad(day)}/${pad(month)}`;
+    case 'DDD MM/DD':
+      return `${dayName} ${pad(month)}/${pad(day)}`;
+    case 'DDD M/D':
+      return `${dayName} ${month}/${day}`;
     case 'DDDD':
       return dayNameFull;
+    case 'DDD':
+      return dayName;
     case 'MMM DD':
       return `${monthName} ${pad(day)}`;
     case 'DD MMM':

--- a/src/components/OverlayEditor/OverlayLayerPanel.tsx
+++ b/src/components/OverlayEditor/OverlayLayerPanel.tsx
@@ -1283,10 +1283,14 @@ export const OverlayLayerPanel: React.FC<OverlayLayerPanelProps> = ({
                               <option value="DD-MM-YYYY">20-12-2025</option>
                               <option value="DD/MM">20/12</option>
                               <option value="MM/DD">12/20</option>
+                              <option value="M/D">1/5</option>
                             </optgroup>
                             <optgroup label="With Weekday">
                               <option value="DDD DD/MM">MON 20/12</option>
+                              <option value="DDD MM/DD">MON 12/20</option>
+                              <option value="DDD M/D">MON 1/5</option>
                               <option value="DDDD">MONDAY</option>
+                              <option value="DDD">MON</option>
                             </optgroup>
                           </select>
                         </div>

--- a/src/components/OverlayEditor/OverlayLayerPanel.tsx
+++ b/src/components/OverlayEditor/OverlayLayerPanel.tsx
@@ -1282,11 +1282,13 @@ export const OverlayLayerPanel: React.FC<OverlayLayerPanelProps> = ({
                               <option value="DD/MM/YYYY">20/12/2025</option>
                               <option value="DD-MM-YYYY">20-12-2025</option>
                               <option value="DD/MM">20/12</option>
+                              <option value="D/M">5/1</option>
                               <option value="MM/DD">12/20</option>
                               <option value="M/D">1/5</option>
                             </optgroup>
                             <optgroup label="With Weekday">
                               <option value="DDD DD/MM">MON 20/12</option>
+                              <option value="DDD D/M">MON 5/1</option>
                               <option value="DDD MM/DD">MON 12/20</option>
                               <option value="DDD M/D">MON 1/5</option>
                               <option value="DDDD">MONDAY</option>

--- a/src/components/OverlayEditor/OverlayLayerPanel.tsx
+++ b/src/components/OverlayEditor/OverlayLayerPanel.tsx
@@ -1282,15 +1282,15 @@ export const OverlayLayerPanel: React.FC<OverlayLayerPanelProps> = ({
                               <option value="DD/MM/YYYY">20/12/2025</option>
                               <option value="DD-MM-YYYY">20-12-2025</option>
                               <option value="DD/MM">20/12</option>
-                              <option value="D/M">5/1</option>
+                              <option value="D/M">5/12</option>
                               <option value="MM/DD">12/20</option>
-                              <option value="M/D">1/5</option>
+                              <option value="M/D">12/5</option>
                             </optgroup>
                             <optgroup label="With Weekday">
                               <option value="DDD DD/MM">MON 20/12</option>
-                              <option value="DDD D/M">MON 5/1</option>
+                              <option value="DDD D/M">MON 5/12</option>
                               <option value="DDD MM/DD">MON 12/20</option>
-                              <option value="DDD M/D">MON 1/5</option>
+                              <option value="DDD M/D">MON 12/5</option>
                               <option value="DDDD">MONDAY</option>
                               <option value="DDD">MON</option>
                             </optgroup>

--- a/src/components/OverlayEditor/VariableElement.tsx
+++ b/src/components/OverlayEditor/VariableElement.tsx
@@ -117,12 +117,16 @@ export const VariableElement: React.FC<VariableElementComponentProps> = ({
         return `${pad(month)}/${pad(day)}/${year}`;
       case 'DD/MM':
         return `${pad(day)}/${pad(month)}`;
+      case 'D/M':
+        return `${day}/${month}`;
       case 'MM/DD':
         return `${pad(month)}/${pad(day)}`;
       case 'M/D':
         return `${month}/${day}`;
       case 'DDD DD/MM':
         return `${dayName} ${pad(day)}/${pad(month)}`;
+      case 'DDD D/M':
+        return `${dayName} ${day}/${month}`;
       case 'DDD MM/DD':
         return `${dayName} ${pad(month)}/${pad(day)}`;
       case 'DDD M/D':

--- a/src/components/OverlayEditor/VariableElement.tsx
+++ b/src/components/OverlayEditor/VariableElement.tsx
@@ -119,10 +119,18 @@ export const VariableElement: React.FC<VariableElementComponentProps> = ({
         return `${pad(day)}/${pad(month)}`;
       case 'MM/DD':
         return `${pad(month)}/${pad(day)}`;
+      case 'M/D':
+        return `${month}/${day}`;
       case 'DDD DD/MM':
         return `${dayName} ${pad(day)}/${pad(month)}`;
+      case 'DDD MM/DD':
+        return `${dayName} ${pad(month)}/${pad(day)}`;
+      case 'DDD M/D':
+        return `${dayName} ${month}/${day}`;
       case 'DDDD':
         return dayNameFull;
+      case 'DDD':
+        return dayName;
       case 'MMM DD':
         return `${monthName} ${pad(day)}`;
       case 'DD MMM':


### PR DESCRIPTION
Adds new date format options for overlay templates:

**Without leading zeros:**
- `D/M` - UK/AU format (5/12)
- `M/D` - US format (12/5)

**With weekday:**
- `DDD D/M` - MON 5/12
- `DDD M/D` - MON 12/5
- `DDD MM/DD` - MON 12/20

**Standalone:**
- `DDD` - MON (abbreviated weekday only)

Fixes #430