### PR TITLE
fix(filtered-hub): use episode air date for TV recently released

### DIFF
--- a/server/lib/collections/plex/PlexSmartCollectionManager.ts
+++ b/server/lib/collections/plex/PlexSmartCollectionManager.ts
@@ -329,10 +329,10 @@ class PlexSmartCollectionManager {
           )}`;
         }
       } else if (subtype === 'recently_released') {
-        // Recently Released: Sort by Release Date (originallyAvailableAt), exclude placeholders
+        // Recently Released: Sort by Release Date, exclude placeholders
         if (mediaType === 'tv') {
-          // TV Shows (Episodes): Sort by air date, filter out "Trailer (Placeholder)"
-          const sortParam = 'originallyAvailableAt:desc';
+          // TV Shows: Sort by most recent episode air date, filter out "Trailer (Placeholder)"
+          const sortParam = 'episode.originallyAvailableAt:desc';
           const titleFilter = encodeURIComponent('Trailer (Placeholder)');
           filterUri = `/library/sections/${libraryKey}/all?type=${type}&sort=${sortParam}&episode.title!=${titleFilter}`;
         } else {
@@ -703,10 +703,10 @@ class PlexSmartCollectionManager {
           )}`;
         }
       } else if (subtype === 'recently_released') {
-        // Recently Released: Sort by Release Date (originallyAvailableAt), exclude placeholders
+        // Recently Released: Sort by Release Date, exclude placeholders
         if (mediaType === 'tv') {
-          // TV Shows (Episodes): Sort by air date, filter out "Trailer (Placeholder)"
-          const sortParam = 'originallyAvailableAt:desc';
+          // TV Shows: Sort by most recent episode air date, filter out "Trailer (Placeholder)"
+          const sortParam = 'episode.originallyAvailableAt:desc';
           const titleFilter = encodeURIComponent('Trailer (Placeholder)');
           filterUri = `/library/sections/${libraryKey}/all?type=${type}&sort=${sortParam}&episode.title!=${titleFilter}`;
         } else {


### PR DESCRIPTION
TV "Recently Released" filtered hubs sorted by `originallyAvailableAt` on show items (`type=2`), which is the show's premiere date. Long-running shows with new episodes (e.g. The Rookie, premiered 2018) wouldn't appear near the top even when new episodes just aired.

Changed the sort to `episode.originallyAvailableAt:desc`, which sorts shows by their most recent episode's air date.

Verified against Plex API that `episode.originallyAvailableAt` is a supported sort field for `type=2` smart collections.

Fixes #442