### PR TITLE
fix: re-apply placeholder markers during global discovery

### DIFF
--- a/server/lib/collections/services/CollectionSyncService.ts
+++ b/server/lib/collections/services/CollectionSyncService.ts
@@ -156,6 +156,7 @@ export class CollectionSyncService {
 
         let cleanedUp = 0;
         let titlesFixes = 0;
+        let titleFixFailures = 0;
 
         for (const { plexItem, needsTitleFix, marker } of tv) {
           if (!plexItem) {
@@ -172,12 +173,24 @@ export class CollectionSyncService {
             cleanedUp++;
           } else if (needsTitleFix) {
             // Still a placeholder - fix episode title
-            await ensurePlaceholderEpisodeTitle(
+            const fixed = await ensurePlaceholderEpisodeTitle(
               plexClient,
               plexItem.ratingKey,
               marker.title
             );
-            titlesFixes++;
+            if (fixed) {
+              titlesFixes++;
+            } else {
+              titleFixFailures++;
+              logger.warn(
+                'Failed to fix placeholder episode title during global discovery - may appear in filtered hubs',
+                {
+                  label: 'Collection Sync Service',
+                  title: marker.title,
+                  ratingKey: plexItem.ratingKey,
+                }
+              );
+            }
           }
         }
 
@@ -185,6 +198,7 @@ export class CollectionSyncService {
           label: 'Collection Sync Service',
           cleanedUp,
           titlesFixes,
+          titleFixFailures,
         });
 
         // Trigger Plex library scan + empty trash to remove ghost entries (fire-and-forget)
@@ -268,6 +282,7 @@ export class CollectionSyncService {
         );
 
         let moviesCleanedUp = 0;
+        let labelsFixed = 0;
 
         for (const { plexItem, needsCleanup, movie } of movies) {
           if (plexItem && needsCleanup) {
@@ -278,12 +293,20 @@ export class CollectionSyncService {
               'movie'
             );
             moviesCleanedUp++;
+          } else if (plexItem) {
+            // Still a placeholder - ensure label for filtered hub exclusion
+            await plexClient.addLabelToItem(
+              plexItem.ratingKey,
+              'trailer-placeholder'
+            );
+            labelsFixed++;
           }
         }
 
         logger.info('Global movie placeholder processing complete', {
           label: 'Collection Sync Service',
           cleanedUp: moviesCleanedUp,
+          labelsFixed,
         });
 
         // Trigger Plex library scan + empty trash to remove ghost entries (fire-and-forget)

--- a/server/lib/placeholders/services/PlaceholderCreation.ts
+++ b/server/lib/placeholders/services/PlaceholderCreation.ts
@@ -1627,11 +1627,21 @@ async function createPlaceholders(
       if (sourceItem.mediaType === 'tv') {
         // For TV shows: Need to set title on the episode (S00E00)
         // Use retry logic to handle cases where Plex hasn't fully populated episode metadata yet
-        await ensurePlaceholderEpisodeTitle(
+        const titleSet = await ensurePlaceholderEpisodeTitle(
           plexClient,
           plexItem.ratingKey,
           sourceItem.title
         );
+        if (!titleSet) {
+          logger.warn(
+            'Failed to set placeholder episode title - may appear in filtered hubs',
+            {
+              label: 'PlaceholderService',
+              title: sourceItem.title,
+              ratingKey: plexItem.ratingKey,
+            }
+          );
+        }
       } else if (sourceItem.mediaType === 'movie') {
         // For movies: Add label to the movie item
         await plexClient.addLabelToItem(


### PR DESCRIPTION
Filtered hub collections use Plex smart collection filters to exclude
placeholders (`label!=trailer-placeholder` for movies,
`episode.title!=Trailer (Placeholder)` for TV). These markers are set
during placeholder creation, but two gaps let placeholders leak through.

**Movies:** The `trailer-placeholder` label was only re-applied defensively
by Coming Soon collection syncs. If the initial `addLabelToItem` call failed
(network error, Plex timeout), movie placeholders from other collection types
(Letterboxd, IMDB, Trakt, etc.) permanently passed the filter.

**TV:** `ensurePlaceholderEpisodeTitle()` retries 5 times over 10s for Plex
to index the episode, then returns `false`. The return value was never
checked, so there was no visibility into failures.

- Re-apply `trailer-placeholder` label for all movie placeholders during
  global discovery pass
- Check `ensurePlaceholderEpisodeTitle()` return value and log warnings
  on failure (both during creation and global discovery)
- Track failure counts in discovery summary logs

Fixes #414