### PR TITLE
fix: resolve Letterboxd items via film page TMDB links

### DIFF
--- a/server/lib/collections/sources/letterboxd.ts
+++ b/server/lib/collections/sources/letterboxd.ts
@@ -234,6 +234,26 @@ export class LetterboxdCollectionSync extends BaseCollectionSync<'letterboxd'> {
       const sourceData: LetterboxdSourceData[] = [];
       const batchSize = 20; // Process 20 items concurrently (well under 40 req/sec limit)
 
+      // Try film page scraping first for exact TMDB IDs
+      logger.info(
+        `Scraping ${letterboxdData.length} Letterboxd film pages for TMDB IDs`,
+        {
+          label: 'Letterboxd Collections',
+          configName: config.name,
+          itemCount: letterboxdData.length,
+        }
+      );
+      const filmPageResults = await this.resolveViaFilmPages(letterboxdData);
+      logger.info(
+        `Film page scraping resolved ${filmPageResults.size}/${letterboxdData.length} items`,
+        {
+          label: 'Letterboxd Collections',
+          configName: config.name,
+          filmPageHits: filmPageResults.size,
+          remaining: letterboxdData.length - filmPageResults.size,
+        }
+      );
+
       // Process items in concurrent batches
       for (let i = 0; i < letterboxdData.length; i += batchSize) {
         const batch = letterboxdData.slice(i, i + batchSize);
@@ -260,6 +280,19 @@ export class LetterboxdCollectionSync extends BaseCollectionSync<'letterboxd'> {
         // Process batch concurrently
         const batchPromises = batch.map(async (item) => {
           try {
+            // Use film page result if available (exact TMDB ID)
+            const filmPageResult = filmPageResults.get(item.letterboxdUrl);
+            if (filmPageResult) {
+              return {
+                title: item.title,
+                year: item.year,
+                letterboxdUrl: item.letterboxdUrl,
+                tmdbId: filmPageResult.tmdbId,
+                mediaType: filmPageResult.mediaType,
+              };
+            }
+
+            // Fallback: TMDB title search with scoring
             // Search movies and TV separately with year, year-1, and year+1
             // TMDB's year param is a hard filter so we search ±1 to handle
             // festival vs theatrical release date differences
@@ -986,6 +1019,93 @@ export class LetterboxdCollectionSync extends BaseCollectionSync<'letterboxd'> {
   }
 
   /**
+   * Fetch the TMDB ID directly from a Letterboxd film page.
+   * Letterboxd embeds a link like: <a data-track-action="TMDb" href="https://www.themoviedb.org/movie/496243/">
+   */
+  private async fetchTmdbIdFromFilmPage(
+    letterboxdUrl: string
+  ): Promise<{ tmdbId: number; mediaType: 'movie' | 'tv' } | null> {
+    if (
+      !letterboxdUrl ||
+      !letterboxdUrl.startsWith('https://letterboxd.com/')
+    ) {
+      return null;
+    }
+
+    try {
+      const { CloudflareSolver } = await import(
+        '@server/lib/collections/utils/CloudflareSolver'
+      );
+      const html = await CloudflareSolver.fetchPage(letterboxdUrl);
+
+      // Match: <a href="https://www.themoviedb.org/movie/412579/" ... data-track-action="TMDB">
+      // Letterboxd uses uppercase "TMDB" and href before data-track-action
+      const tmdbLinkPattern =
+        /<a[^>]*href="[^"]*themoviedb\.org\/(movie|tv)\/(\d+)\/?[^"]*"[^>]*data-track-action="TMDB"/;
+      const tmdbLinkPatternAlt =
+        /<a[^>]*data-track-action="TMDB"[^>]*href="[^"]*themoviedb\.org\/(movie|tv)\/(\d+)\/?[^"]*"/;
+
+      const match =
+        html.match(tmdbLinkPattern) || html.match(tmdbLinkPatternAlt);
+      if (match) {
+        const mediaType = match[1] as 'movie' | 'tv';
+        const tmdbId = parseInt(match[2], 10);
+        if (!isNaN(tmdbId)) {
+          return { tmdbId, mediaType };
+        }
+      }
+
+      return null;
+    } catch (error) {
+      logger.debug(
+        `Film page scrape failed for ${letterboxdUrl}: ${
+          error instanceof Error ? error.message : 'Unknown'
+        }`,
+        { label: 'Letterboxd Collections' }
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Batch-resolve TMDB IDs by scraping individual Letterboxd film pages.
+   * Uses concurrency limit to avoid hammering Letterboxd.
+   */
+  private async resolveViaFilmPages(
+    items: LetterboxdListItem[]
+  ): Promise<Map<string, { tmdbId: number; mediaType: 'movie' | 'tv' }>> {
+    const results = new Map<
+      string,
+      { tmdbId: number; mediaType: 'movie' | 'tv' }
+    >();
+    const concurrency = 5;
+
+    for (let i = 0; i < items.length; i += concurrency) {
+      const batch = items.slice(i, i + concurrency);
+
+      const batchResults = await Promise.all(
+        batch.map(async (item) => {
+          const result = await this.fetchTmdbIdFromFilmPage(item.letterboxdUrl);
+          return { url: item.letterboxdUrl, result };
+        })
+      );
+
+      for (const { url, result } of batchResults) {
+        if (result) {
+          results.set(url, result);
+        }
+      }
+
+      // Small delay between batches to be polite
+      if (i + concurrency < items.length) {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      }
+    }
+
+    return results;
+  }
+
+  /**
    * Find the best TMDB match from search results using intelligent scoring
    * Supports both movies and TV shows from multi-search results
    */
@@ -1103,9 +1223,10 @@ export class LetterboxdCollectionSync extends BaseCollectionSync<'letterboxd'> {
     score += titleScore * 0.6;
 
     // Year matching (30% of score)
-    // ±1 year treated equally to handle festival vs. theatrical release date differences
-    if (tmdbYear && Math.abs(tmdbYear - targetYear) <= 1) {
-      score += 0.3; // Exact or ±1 year match
+    if (tmdbYear && tmdbYear === targetYear) {
+      score += 0.3; // Exact year match
+    } else if (tmdbYear && Math.abs(tmdbYear - targetYear) === 1) {
+      score += 0.2; // ±1 year — festival vs theatrical release
     } else if (tmdbYear && Math.abs(tmdbYear - targetYear) === 2) {
       score += 0.1; // ±2 year match
     } else if (tmdbYear) {
@@ -1132,8 +1253,11 @@ export class LetterboxdCollectionSync extends BaseCollectionSync<'letterboxd'> {
     if (clean1 === clean2) return 1.0;
 
     // Check if one title contains the other (for cases like "Movie" vs "Movie: Subtitle")
-    if (clean1.includes(clean2) || clean2.includes(clean1)) {
-      return 0.9;
+    // Scale by length ratio — "columbus" in "colkatay columbus" scores lower than in "columbus 2017"
+    const shorter = clean1.length <= clean2.length ? clean1 : clean2;
+    const longer = clean1.length <= clean2.length ? clean2 : clean1;
+    if (longer.includes(shorter)) {
+      return (shorter.length / longer.length) * 0.9;
     }
 
     // Simple word-based similarity


### PR DESCRIPTION
Letterboxd film pages embed exact TMDB links (`data-track-action="TMDB"`),
but the current resolution relies entirely on fuzzy title+year search against
TMDB's API. Short or common titles like "Columbus", "Flow", and "Moonlight"
frequently resolve to wrong results because the scoring gives near-identical
scores to partial title matches and off-by-one year differences.

This adds film page scraping as the primary resolution method, with the
existing TMDB search as fallback. Every other tool in this space (Kometa,
letterboxd-list-radarr, letterboxd-jellyfin) uses this approach.

- Scrape individual film pages for TMDB ID before attempting title search
- Batch scraping with concurrency limit (5 concurrent, 200ms between batches)
- Containment scoring now scales by title length ratio instead of flat 0.9
- Year scoring: exact match 0.3, +/-1 year 0.2 (was 0.3 for both)

The scoring fixes also improve fallback accuracy when film page scraping
fails (e.g. Cloudflare blocks).

Fixes #448