### PR TITLE
fix: pass rating filters to multi-source collections

### DIFF
--- a/server/lib/collections/services/CollectionSyncService.ts
+++ b/server/lib/collections/services/CollectionSyncService.ts
@@ -583,8 +583,13 @@ export class CollectionSyncService {
               autoApproveTV: config.autoApproveTV,
               maxSeasonsToRequest: config.maxSeasonsToRequest,
               seasonsPerShowLimit: config.seasonsPerShowLimit,
+              seasonGrabOrder: config.seasonGrabOrder,
               maxPositionToProcess: config.maxPositionToProcess,
               minimumYear: config.minimumYear,
+              minimumImdbRating: config.minimumImdbRating,
+              minimumRottenTomatoesRating: config.minimumRottenTomatoesRating,
+              minimumRottenTomatoesAudienceRating:
+                config.minimumRottenTomatoesAudienceRating,
               filterSettings: config.filterSettings,
               directDownloadRadarrServerId: config.directDownloadRadarrServerId,
               directDownloadRadarrProfileId:


### PR DESCRIPTION
Multi-source config assembly copies most collection config fields but was missing `minimumImdbRating`, `minimumRottenTomatoesRating`, `minimumRottenTomatoesAudienceRating`, and `seasonGrabOrder`. When `filterMissingItems()` receives a config with these fields undefined, it skips the rating check entirely.

Single-source collections are unaffected (they pass the full config object).

- Added the three rating filter fields and `seasonGrabOrder` to the multi-source config assembly in `CollectionSyncService`

Fixes #440