### PR TITLE
fix(cleanup): prevent auto-franchise collections from being deleted when custom sync is enabled 

### DIFF
--- a/server/lib/collections/services/CollectionCleanupService.ts
+++ b/server/lib/collections/services/CollectionCleanupService.ts
@@ -502,12 +502,13 @@ export class CollectionCleanupService {
     const labels = Array.isArray(collection.labels) ? collection.labels : [];
 
     // Check if this collection has any of our managed labels
-    const managedLabel = labels.find((label: string | PlexLabel) => {
-      const labelText = typeof label === 'string' ? label : label.tag;
-      return labelText.toLowerCase().startsWith('agregarr');
-    });
+    const managedLabels = labels
+      .map((label: string | PlexLabel) =>
+        typeof label === 'string' ? label : label.tag
+      )
+      .filter((labelText) => labelText.toLowerCase().startsWith('agregarr'));
 
-    if (!managedLabel) {
+    if (managedLabels.length === 0) {
       return { shouldDelete: false, reason: 'not managed' };
     }
 
@@ -515,9 +516,6 @@ export class CollectionCleanupService {
     if (processedCollectionKeys.has(collection.ratingKey)) {
       return { shouldDelete: false, reason: 'already processed' };
     }
-
-    const managedLabelText =
-      typeof managedLabel === 'string' ? managedLabel : managedLabel.tag;
 
     // First, try to match by ratingKey (works for all types except user collections)
     const matchingConfig = currentConfigs.find(
@@ -529,9 +527,12 @@ export class CollectionCleanupService {
     }
 
     // Special case for user collections - they don't store ratingKeys, use user validation instead
-    if (managedLabelText.toLowerCase().startsWith('agregarroverseerruser')) {
+    const overseerrUserLabel = managedLabels.find((labelText) =>
+      labelText.toLowerCase().startsWith('agregarroverseerruser')
+    );
+    if (overseerrUserLabel) {
       // Extract user Plex ID from collection labels
-      const userPlexId = managedLabelText.replace(
+      const userPlexId = overseerrUserLabel.replace(
         /^AgregarrOverseerrUser/i,
         ''
       );
@@ -568,9 +569,12 @@ export class CollectionCleanupService {
 
     // Special case for auto franchise collections - they don't store ratingKeys on configs
     // (one config generates multiple Plex collections). Match by label prefix instead.
-    if (managedLabelText.toLowerCase().startsWith('agregarrautofranchise-')) {
+    const autoFranchiseLabel = managedLabels.find((labelText) =>
+      labelText.toLowerCase().startsWith('agregarrautofranchise-')
+    );
+    if (autoFranchiseLabel) {
       // Extract configId from label format: AgregarrAutoFranchise-{configId}-{franchiseId}
-      const parts = managedLabelText.split('-');
+      const parts = autoFranchiseLabel.split('-');
       const configId = parts.length >= 2 ? parts[1] : undefined;
 
       if (!configId) {

--- a/server/lib/collections/sources/comingsoon.ts
+++ b/server/lib/collections/sources/comingsoon.ts
@@ -233,9 +233,10 @@ export class ComingSoonCollectionSync extends BaseCollectionSync<'comingsoon'> {
         processedCollectionKeys
       );
 
-      if (result.collectionRatingKey && missingItems.length > 0) {
+      const missingItemsToStore = missingItems ?? [];
+      if (result.collectionRatingKey && missingItemsToStore.length > 0) {
         await this.storeCollectionMissingItems(
-          missingItems,
+          missingItemsToStore,
           result.collectionRatingKey,
           config.libraryId,
           config.id

--- a/server/lib/collections/sources/comingsoon.ts
+++ b/server/lib/collections/sources/comingsoon.ts
@@ -2,6 +2,7 @@ import type PlexAPI from '@server/api/plexapi';
 import type { ComingSoonItem } from '@server/entity/ComingSoonItem';
 import { BaseCollectionSync } from '@server/lib/collections/core/BaseCollectionSync';
 import {
+  applyCollectionExclusions,
   findPlexItemsByTmdbIds,
   getCollectionMediaType,
   type LibraryItemsCache,
@@ -181,17 +182,70 @@ export class ComingSoonCollectionSync extends BaseCollectionSync<'comingsoon'> {
         return { created: 0, updated: 0 };
       }
 
-      // Use the media type processing strategy
-      return await this.processWithMediaTypeStrategy(
-        sortedItems,
+      const mediaType = getCollectionMediaType(config);
+      let filteredItems = sortedItems.filter((item) => item.type === mediaType);
+
+      if (filteredItems.length === 0) {
+        logger.debug(`No ${mediaType} items found for collection`, {
+          label: 'Coming Soon Collections',
+          configName: config.name,
+          mediaType,
+          totalItems: sortedItems.length,
+        });
+        return { created: 0, updated: 0 };
+      }
+
+      filteredItems = await applyCollectionExclusions(
+        filteredItems,
         config,
         plexClient,
-        allCollections,
-        processedCollectionKeys,
-        undefined,
-        libraryCache,
-        missingItems
+        this.source
       );
+
+      if (filteredItems.length === 0) {
+        logger.info(
+          `All ${mediaType} items were excluded from collection "${config.name}" based on mutual exclusion rules`,
+          {
+            label: 'Coming Soon Collections',
+            configName: config.name,
+            mediaType,
+          }
+        );
+        return { created: 0, updated: 0 };
+      }
+
+      const collectionName =
+        (await this.generateCollectionNameWithCustom?.(
+          config,
+          mediaType,
+          libraryCache
+        )) ||
+        config.template ||
+        config.name;
+
+      const result = await this.createCollection(
+        filteredItems,
+        mediaType,
+        collectionName,
+        plexClient,
+        allCollections,
+        config,
+        processedCollectionKeys
+      );
+
+      if (result.collectionRatingKey && missingItems.length > 0) {
+        await this.storeCollectionMissingItems(
+          missingItems,
+          result.collectionRatingKey,
+          config.libraryId,
+          config.id
+        );
+      }
+
+      return {
+        created: result.created || 0,
+        updated: result.updated || 0,
+      };
     } catch (error) {
       logger.error('Coming Soon collection processing failed', {
         label: 'Coming Soon Collections',
@@ -257,6 +311,29 @@ export class ComingSoonCollectionSync extends BaseCollectionSync<'comingsoon'> {
 
       // Update config with rating key if we got one
       this.updateConfigWithRatingKey(config, result.collectionRatingKey);
+
+      // Set collection mode if hideIndividualItems is enabled
+      const collectionRatingKey = result.collectionRatingKey;
+      if (collectionRatingKey && config.hideIndividualItems) {
+        try {
+          await plexClient.updateCollectionMode(collectionRatingKey, 1);
+          logger.debug(
+            `Set collectionMode=1 (hide items) for Coming Soon collection: ${collectionName}`,
+            {
+              label: 'Coming Soon Collections',
+              collectionRatingKey,
+            }
+          );
+        } catch (error) {
+          logger.warn(
+            `Failed to set collection mode for ${collectionName}, continuing`,
+            {
+              label: 'Coming Soon Collections',
+              error: error instanceof Error ? error.message : String(error),
+            }
+          );
+        }
+      }
 
       return {
         created: result.created,

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -238,7 +238,7 @@ export interface CollectionConfig {
   readonly autoPoster?: boolean; // Auto-generate poster during sync (only available for Overseerr user collections)
   readonly autoPosterTemplate?: number | null; // Template ID for auto-generated posters (null for default template)
   readonly useTmdbFranchisePoster?: boolean; // Use TMDB franchise poster instead of auto-generated poster (only for TMDB auto_franchise collections)
-  readonly hideIndividualItems?: boolean; // Hide individual items, show collection (collectionMode = 1, only for TMDB auto_franchise collections)
+  readonly hideIndividualItems?: boolean; // Hide individual items, show collection (collectionMode = 1, supported for Coming Soon and TMDB auto_franchise collections)
   // Wallpaper, summary, and theme settings
   readonly customWallpaper?: string | Record<string, string>; // Path to custom wallpaper (art) image file, or per-library wallpaper mapping
   readonly customSummary?: string; // Custom summary/description text for the collection

--- a/src/components/Collections/FormSections/PosterUploadSection.tsx
+++ b/src/components/Collections/FormSections/PosterUploadSection.tsx
@@ -25,7 +25,7 @@ const messages = defineMessages({
     'Use the official TMDB franchise poster instead of auto-generating. This setting overrules the above auto-poster option if a collection poster is available from TMDB.',
   hideIndividualItems: 'Hide Individual Items in Collection',
   hideIndividualItemsHelp:
-    'Hide the individual movies in this franchise collection. Only the collection itself will be shown in the Library tab. If an item appears in another collection it will still be visible in the Library tab.',
+    'Hide individual items from the Library tab and show only the collection. If an item appears in another collection it may still be visible there.',
   selectLibrariesForPosters: 'Select libraries first to upload custom posters.',
 });
 
@@ -319,33 +319,35 @@ const PosterUploadSection = ({
         </div>
       )}
 
-      {/* TMDB Franchise Poster Toggle - only for TMDB auto_franchise collections */}
+      {/* TMDB Franchise options + Collection Mode toggle (Coming Soon + TMDB auto_franchise) */}
       {isAgregarrCollection &&
-        values.type === 'tmdb' &&
-        values.subtype === 'auto_franchise' && (
+        ((values.type === 'tmdb' && values.subtype === 'auto_franchise') ||
+          values.type === 'comingsoon') && (
           <>
-            <div className="mb-6">
-              <div className="flex items-center">
-                <input
-                  type="checkbox"
-                  id="useTmdbFranchisePoster"
-                  checked={values.useTmdbFranchisePoster ?? false}
-                  onChange={(e) =>
-                    setFieldValue('useTmdbFranchisePoster', e.target.checked)
-                  }
-                  className="form-checkbox"
-                />
-                <label
-                  htmlFor="useTmdbFranchisePoster"
-                  className="ml-2 text-sm text-gray-300"
-                >
-                  {intl.formatMessage(messages.useTmdbFranchisePoster)}
-                </label>
+            {values.type === 'tmdb' && values.subtype === 'auto_franchise' && (
+              <div className="mb-6">
+                <div className="flex items-center">
+                  <input
+                    type="checkbox"
+                    id="useTmdbFranchisePoster"
+                    checked={values.useTmdbFranchisePoster ?? false}
+                    onChange={(e) =>
+                      setFieldValue('useTmdbFranchisePoster', e.target.checked)
+                    }
+                    className="form-checkbox"
+                  />
+                  <label
+                    htmlFor="useTmdbFranchisePoster"
+                    className="ml-2 text-sm text-gray-300"
+                  >
+                    {intl.formatMessage(messages.useTmdbFranchisePoster)}
+                  </label>
+                </div>
+                <div className="label-tip">
+                  {intl.formatMessage(messages.useTmdbFranchisePosterHelp)}
+                </div>
               </div>
-              <div className="label-tip">
-                {intl.formatMessage(messages.useTmdbFranchisePosterHelp)}
-              </div>
-            </div>
+            )}
 
             <div className="mb-6">
               <div className="flex items-center">

--- a/src/types/collections/index.ts
+++ b/src/types/collections/index.ts
@@ -409,7 +409,7 @@ export interface CollectionFormConfig {
   readonly autoPoster?: boolean; // Auto-generate poster during sync (only available for Overseerr user collections)
   readonly autoPosterTemplate?: number | null; // Template ID for auto-generated posters (null for default template)
   readonly useTmdbFranchisePoster?: boolean; // Use TMDB franchise poster instead of auto-generated poster (only for TMDB auto_franchise collections)
-  readonly hideIndividualItems?: boolean; // Hide individual items, show collection (collectionMode = 1, only for TMDB auto_franchise collections)
+  readonly hideIndividualItems?: boolean; // Hide individual items, show collection (collectionMode = 1, supported for Coming Soon and TMDB auto_franchise collections)
   // Wallpaper, summary, and theme settings
   readonly customWallpaper?: string | Record<string, string>; // Path to custom wallpaper (art) image file, or per-library wallpaper mapping
   readonly customSummary?: string; // Custom summary/description text for the collection
@@ -604,7 +604,7 @@ export interface CollectionConfigCreateRequest {
   readonly autoPoster?: boolean; // Auto-generate poster during sync (only available for Overseerr user collections)
   readonly autoPosterTemplate?: number | null; // Template ID for auto-generated posters (null for default template)
   readonly useTmdbFranchisePoster?: boolean; // Use TMDB franchise poster instead of auto-generated poster (only for TMDB auto_franchise collections)
-  readonly hideIndividualItems?: boolean; // Hide individual items, show collection (collectionMode = 1, only for TMDB auto_franchise collections)
+  readonly hideIndividualItems?: boolean; // Hide individual items, show collection (collectionMode = 1, supported for Coming Soon and TMDB auto_franchise collections)
   // Wallpaper, summary, and theme settings
   readonly customWallpaper?: string | Record<string, string>; // Path to custom wallpaper (art) image file, or per-library wallpaper mapping
   readonly customSummary?: string; // Custom summary/description text for the collection


### PR DESCRIPTION
#### Description

When TMDB auto_franchise is on custom sync timing, those collections can get deleted by mistake.
- Global sync skips custom-scheduled configs, cleanup can end up checking the wrong Agregarr label and miss the AgregarrAutoFranchise-* label. Then existing franchise collections are treated like orphans, removed from Plex, and Agregarr shows them as missing/needs cleanup. 

#### Issues Fixed or Closed

- Updated 'CollectionCleanupService' so deletion checks look at all Agregarr labels on a collection, instead of only the first one. 