### PR TITLE
Fix Custom Advanced Filter Issues 

### DIFF
--- a/agregarr-api.yml
+++ b/agregarr-api.yml
@@ -11954,6 +11954,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Keyword'
+  /person/{personId}:
+    get:
+      summary: Get person
+      description: |
+        Returns a single TMDB person in JSON format.
+      tags:
+        - tmdb
+      parameters:
+        - in: path
+          name: personId
+          required: true
+          description: The TMDb person identifier.
+          schema:
+            type: number
+            example: 543530
+      responses:
+        '200':
+          description: Person returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                    example: 543530
+                  name:
+                    type: string
+                    example: Dave Bautista
+                required:
+                  - id
+                  - name
   /missing-items:
     get:
       summary: Get missing item requests

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -663,6 +663,30 @@ router.get('/keyword/:keywordId', async (req, res, next) => {
   }
 });
 
+router.get('/person/:personId', isAuthenticated(), async (req, res, next) => {
+  const tmdb = await createTmdbWithRegionLanguage();
+
+  try {
+    const personId = Number(req.params.personId);
+    if (Number.isNaN(personId)) {
+      return next({ status: 400, message: 'Invalid person ID.' });
+    }
+
+    const person = await tmdb.getPerson({
+      personId,
+      language: await getTmdbLanguage(),
+    });
+
+    return res.status(200).json({ id: person.id, name: person.name });
+  } catch (e) {
+    logger.debug('Something went wrong retrieving person data', {
+      label: 'API',
+      errorMessage: e instanceof Error ? e.message : String(e),
+    });
+    return next({ status: 500, message: 'Unable to retrieve person data.' });
+  }
+});
+
 router.get('/search/person', isAuthenticated(), async (req, res, next) => {
   const tmdb = new TheMovieDb({ originalLanguage: await getTmdbLanguage() });
 

--- a/src/components/Collections/FormSections/TmdbAdvancedFiltersSection.tsx
+++ b/src/components/Collections/FormSections/TmdbAdvancedFiltersSection.tsx
@@ -1018,6 +1018,7 @@ const TmdbAdvancedFiltersSection = ({
   const addFilterGroup = useCallback(() => {
     const newGroup: FilterGroup = {
       id: `group-${Date.now()}`,
+      operator: 'and',
       groupOperator: 'and',
       filters: [
         {
@@ -1431,7 +1432,7 @@ const TmdbAdvancedFiltersSection = ({
                       value={group.groupOperator || group.operator || 'and'}
                       onChange={(e) => {
                         updateFilterGroup(group.id, {
-                          groupOperator: e.target.value as 'and' | 'or',
+                          operator: e.target.value as 'and' | 'or',
                         });
                       }}
                       className="rounded-md border border-stone-500 bg-stone-700 px-2 py-1 text-sm text-white focus:border-orange-500"

--- a/src/components/Collections/FormSections/TmdbSearchSelect.tsx
+++ b/src/components/Collections/FormSections/TmdbSearchSelect.tsx
@@ -36,9 +36,23 @@ const TmdbSearchSelect: React.FC<TmdbSearchSelectProps> = ({
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [nameMap, setNameMap] = useState<Map<string, string>>(new Map());
+  const nameMapRef = useRef<Map<string, string>>(nameMap);
   const containerRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
   const inflightHydrationRef = useRef<Set<string>>(new Set());
+  const hydrationRunIdRef = useRef(0);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    nameMapRef.current = nameMap;
+  }, [nameMap]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -133,6 +147,58 @@ const TmdbSearchSelect: React.FC<TmdbSearchSelectProps> = ({
     setIsOpen(false);
   };
 
+  const getDetailsEndpointBase = useCallback((): string | null => {
+    // Keep saving IDs only; hydrate names for display when editing.
+    if (searchEndpoint.includes('/search/person')) return '/api/v1/person';
+    if (searchEndpoint.includes('/search/company')) return '/api/v1/studio';
+    if (searchEndpoint.includes('/search/keyword')) return '/api/v1/keyword';
+    return null;
+  }, [searchEndpoint]);
+
+  const hydrateIds = useCallback(async (ids: string[], base: string) => {
+    const runId = ++hydrationRunIdRef.current;
+
+    const uniqueIds = Array.from(new Set(ids))
+      .map((v) => v.trim())
+      .filter((v) => /^\d+$/.test(v))
+      .filter((id) => !nameMapRef.current.has(id))
+      .filter((id) => !inflightHydrationRef.current.has(id));
+
+    if (uniqueIds.length === 0) return;
+
+    await Promise.all(
+      uniqueIds.map(async (id) => {
+        if (!isMountedRef.current) return;
+        if (hydrationRunIdRef.current !== runId) return;
+        if (!id) return;
+
+        if (nameMapRef.current.has(id)) return;
+        if (inflightHydrationRef.current.has(id)) return;
+
+        inflightHydrationRef.current.add(id);
+        try {
+          const resp = await fetch(`${base}/${encodeURIComponent(id)}`);
+          if (!resp.ok) return;
+          const data = (await resp.json()) as { name?: string; title?: string };
+          const label = data?.name ?? data?.title;
+          if (!label || !isMountedRef.current) return;
+          if (hydrationRunIdRef.current !== runId) return;
+
+          setNameMap((prev) => {
+            if (prev.get(id) === label) return prev;
+            const next = new Map(prev);
+            next.set(id, label);
+            return next;
+          });
+        } catch {
+          // ignore
+        } finally {
+          inflightHydrationRef.current.delete(id);
+        }
+      })
+    );
+  }, []);
+
   const addRawId = () => {
     const raw = searchTerm.trim();
     if (!raw) return;
@@ -152,9 +218,12 @@ const TmdbSearchSelect: React.FC<TmdbSearchSelectProps> = ({
     if (next.length !== value.length) {
       onChange(next);
     }
-    addedIds.forEach((id) => {
-      void resolveAndSetName(id);
-    });
+    if (addedIds.length > 0) {
+      const base = getDetailsEndpointBase();
+      if (base) {
+        void hydrateIds(addedIds, base);
+      }
+    }
     setSearchTerm('');
     setResults([]);
     setIsOpen(false);
@@ -172,45 +241,6 @@ const TmdbSearchSelect: React.FC<TmdbSearchSelectProps> = ({
     return id;
   };
 
-  const getDetailsEndpointBase = useCallback((): string | null => {
-    // Keep saving IDs only; hydrate names for display when editing.
-    if (searchEndpoint.includes('/search/person')) return '/api/v1/person';
-    if (searchEndpoint.includes('/search/company')) return '/api/v1/studio';
-    if (searchEndpoint.includes('/search/keyword')) return '/api/v1/keyword';
-    return null;
-  }, [searchEndpoint]);
-
-  const resolveAndSetName = useCallback(
-    async (id: string) => {
-      const base = getDetailsEndpointBase();
-      if (!base) return;
-      if (!/^\d+$/.test(id)) return;
-      if (nameMap.has(id)) return;
-      if (inflightHydrationRef.current.has(id)) return;
-
-      inflightHydrationRef.current.add(id);
-      try {
-        const resp = await fetch(`${base}/${encodeURIComponent(id)}`);
-        if (!resp.ok) return;
-        const data = (await resp.json()) as { name?: string; title?: string };
-        const label = data?.name ?? data?.title;
-        if (!label) return;
-
-        setNameMap((prev) => {
-          if (prev.get(id) === label) return prev;
-          const next = new Map(prev);
-          next.set(id, label);
-          return next;
-        });
-      } catch {
-        // ignore
-      } finally {
-        inflightHydrationRef.current.delete(id);
-      }
-    },
-    [getDetailsEndpointBase, nameMap]
-  );
-
   useEffect(() => {
     const base = getDetailsEndpointBase();
     if (!base) return;
@@ -218,47 +248,13 @@ const TmdbSearchSelect: React.FC<TmdbSearchSelectProps> = ({
     const idsToHydrate = Array.from(new Set(value))
       .map((v) => v.trim())
       .filter((v) => /^\d+$/.test(v))
-      .filter((id) => !nameMap.has(id))
+      .filter((id) => !nameMapRef.current.has(id))
       .filter((id) => !inflightHydrationRef.current.has(id));
 
-    if (idsToHydrate.length === 0) return;
-
-    const controller = new AbortController();
-    let cancelled = false;
-
-    const hydrateOne = async (id: string) => {
-      inflightHydrationRef.current.add(id);
-      try {
-        const resp = await fetch(`${base}/${encodeURIComponent(id)}`, {
-          signal: controller.signal,
-        });
-        if (!resp.ok) return;
-        const data = (await resp.json()) as { name?: string; title?: string };
-        const label = data?.name ?? data?.title;
-        if (!label || cancelled) return;
-
-        setNameMap((prev) => {
-          if (prev.get(id) === label) return prev;
-          const next = new Map(prev);
-          next.set(id, label);
-          return next;
-        });
-      } catch {
-        // ignore
-      } finally {
-        inflightHydrationRef.current.delete(id);
-      }
-    };
-
-    idsToHydrate.forEach((id) => {
-      void hydrateOne(id);
-    });
-
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, [value, nameMap, getDetailsEndpointBase]);
+    if (idsToHydrate.length > 0) {
+      void hydrateIds(idsToHydrate, base);
+    }
+  }, [value, getDetailsEndpointBase, hydrateIds]);
 
   // Get thumbnail URL for a search result
   const getThumbnailUrl = (result: SearchResultItem): string | undefined => {

--- a/src/components/Collections/FormSections/TmdbSearchSelect.tsx
+++ b/src/components/Collections/FormSections/TmdbSearchSelect.tsx
@@ -140,16 +140,21 @@ const TmdbSearchSelect: React.FC<TmdbSearchSelectProps> = ({
     // Split on commas, pipes, spaces
     const parts = raw.split(/[\s,|]+/).filter(Boolean);
     const next = [...value];
+    const addedIds: string[] = [];
     for (const part of parts) {
       const match = part.match(/(\d+)/);
       const id = match?.[1];
       if (id && !next.includes(id)) {
         next.push(id);
+        addedIds.push(id);
       }
     }
     if (next.length !== value.length) {
       onChange(next);
     }
+    addedIds.forEach((id) => {
+      void resolveAndSetName(id);
+    });
     setSearchTerm('');
     setResults([]);
     setIsOpen(false);
@@ -174,6 +179,37 @@ const TmdbSearchSelect: React.FC<TmdbSearchSelectProps> = ({
     if (searchEndpoint.includes('/search/keyword')) return '/api/v1/keyword';
     return null;
   }, [searchEndpoint]);
+
+  const resolveAndSetName = useCallback(
+    async (id: string) => {
+      const base = getDetailsEndpointBase();
+      if (!base) return;
+      if (!/^\d+$/.test(id)) return;
+      if (nameMap.has(id)) return;
+      if (inflightHydrationRef.current.has(id)) return;
+
+      inflightHydrationRef.current.add(id);
+      try {
+        const resp = await fetch(`${base}/${encodeURIComponent(id)}`);
+        if (!resp.ok) return;
+        const data = (await resp.json()) as { name?: string; title?: string };
+        const label = data?.name ?? data?.title;
+        if (!label) return;
+
+        setNameMap((prev) => {
+          if (prev.get(id) === label) return prev;
+          const next = new Map(prev);
+          next.set(id, label);
+          return next;
+        });
+      } catch {
+        // ignore
+      } finally {
+        inflightHydrationRef.current.delete(id);
+      }
+    },
+    [getDetailsEndpointBase, nameMap]
+  );
 
   useEffect(() => {
     const base = getDetailsEndpointBase();

--- a/src/components/Collections/FormSections/TmdbSearchSelect.tsx
+++ b/src/components/Collections/FormSections/TmdbSearchSelect.tsx
@@ -38,6 +38,7 @@ const TmdbSearchSelect: React.FC<TmdbSearchSelectProps> = ({
   const [nameMap, setNameMap] = useState<Map<string, string>>(new Map());
   const containerRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const inflightHydrationRef = useRef<Set<string>>(new Set());
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -165,6 +166,63 @@ const TmdbSearchSelect: React.FC<TmdbSearchSelectProps> = ({
     }
     return id;
   };
+
+  const getDetailsEndpointBase = useCallback((): string | null => {
+    // Keep saving IDs only; hydrate names for display when editing.
+    if (searchEndpoint.includes('/search/person')) return '/api/v1/person';
+    if (searchEndpoint.includes('/search/company')) return '/api/v1/studio';
+    if (searchEndpoint.includes('/search/keyword')) return '/api/v1/keyword';
+    return null;
+  }, [searchEndpoint]);
+
+  useEffect(() => {
+    const base = getDetailsEndpointBase();
+    if (!base) return;
+
+    const idsToHydrate = Array.from(new Set(value))
+      .map((v) => v.trim())
+      .filter((v) => /^\d+$/.test(v))
+      .filter((id) => !nameMap.has(id))
+      .filter((id) => !inflightHydrationRef.current.has(id));
+
+    if (idsToHydrate.length === 0) return;
+
+    const controller = new AbortController();
+    let cancelled = false;
+
+    const hydrateOne = async (id: string) => {
+      inflightHydrationRef.current.add(id);
+      try {
+        const resp = await fetch(`${base}/${encodeURIComponent(id)}`, {
+          signal: controller.signal,
+        });
+        if (!resp.ok) return;
+        const data = (await resp.json()) as { name?: string; title?: string };
+        const label = data?.name ?? data?.title;
+        if (!label || cancelled) return;
+
+        setNameMap((prev) => {
+          if (prev.get(id) === label) return prev;
+          const next = new Map(prev);
+          next.set(id, label);
+          return next;
+        });
+      } catch {
+        // ignore
+      } finally {
+        inflightHydrationRef.current.delete(id);
+      }
+    };
+
+    idsToHydrate.forEach((id) => {
+      void hydrateOne(id);
+    });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [value, nameMap, getDetailsEndpointBase]);
 
   // Get thumbnail URL for a search result
   const getThumbnailUrl = (result: SearchResultItem): string | undefined => {

--- a/src/components/Collections/Views/CollectionSettings.tsx
+++ b/src/components/Collections/Views/CollectionSettings.tsx
@@ -1280,6 +1280,9 @@ const CollectionSettings = ({
       // Make single DELETE request - backend handles linked collection deletion
       await axios.delete(`/api/v1/collections/${configId}`);
 
+      // Revalidate collections data to refresh the cache
+      await revalidateCollections();
+
       // If this was the last collection, trigger final sync to clean up Plex
       if (isLastCollection && data) {
         try {

--- a/src/components/Collections/Views/CollectionSettings.tsx
+++ b/src/components/Collections/Views/CollectionSettings.tsx
@@ -595,6 +595,15 @@ const CollectionSettings = ({
           ...(config.filterSettings !== undefined && {
             filterSettings: config.filterSettings,
           }),
+          ...(config.tmdbAdvancedFilters !== undefined && {
+            tmdbAdvancedFilters: config.tmdbAdvancedFilters,
+          }),
+          ...(config.tmdbMovieSortBy !== undefined && {
+            tmdbMovieSortBy: config.tmdbMovieSortBy,
+          }),
+          ...(config.tmdbTvSortBy !== undefined && {
+            tmdbTvSortBy: config.tmdbTvSortBy,
+          }),
           ...(config.excludeFromCollections !== undefined && {
             excludeFromCollections: config.excludeFromCollections,
           }),

--- a/src/components/Collections/Views/CollectionSettings.tsx
+++ b/src/components/Collections/Views/CollectionSettings.tsx
@@ -1280,7 +1280,7 @@ const CollectionSettings = ({
       // Make single DELETE request - backend handles linked collection deletion
       await axios.delete(`/api/v1/collections/${configId}`);
 
-      // Revalidate collections data to refresh the cache
+      // Refresh cached collections list (used for name uniqueness checks, etc.)
       await revalidateCollections();
 
       // If this was the last collection, trigger final sync to clean up Plex


### PR DESCRIPTION
#### Description
Fixes Several Custom Advanced Filter issues, primarily outlined in https://github.com/agregarr/agregarr/issues/462 and a few other i found while testing. All of these fixes should be separate commits if we need to pull anything out too

- Made it so the AND/OR dropdown between the filter groups actually works again, it was stuck on AND
- Made it so that when adding people by ID it will show their name
- Made it so when you save and reopen the builder the ID numbers will also rehydrate the names
  - Right now this is done by regrabbing the names based on ID number (which does work but if you have better ideas for how to do it im all ears). The other way i thought about doing it was save the names in the same way it is saving the ID, but if the name for the ID number is changed/updated you might get stale data, so that probably wounldnt be the best solution. 
  - Created an endpoint for getting the Name from ID
- When you create a new collection and go to edit it, the new settings will be applied when you save  
- Deleting a collection was not freeing that custom Name, it would think you already have a collection named that. Now it works as expected

All yarn commands were ran 

#### Screenshot (if UI-related)

#### Checklist

- [ x] Type checking (`yarn typecheck`)
- [ x] Build succeeds (`yarn build`)
- [ x] Translation keys extracted (`yarn i18n:extract`) - if new user-facing strings added
- [ x] Database migration included - if schema changes required

**Runs automatically on `git commit`** (If you bypassed husky (`HUSKY=0`), run these manually as well before submitting.):

- [ x] Formatting (prettier) (`yarn format`)
- [ x] Linting (`yarn lint`)

#### Issues Fixed or Closed

- Fixes #462 
