### PR TITLE
fix(localposterfolderservice): fix pagination and library filtering f…

### DIFF
--- a/server/lib/overlays/LocalPosterFolderService.ts
+++ b/server/lib/overlays/LocalPosterFolderService.ts
@@ -1,6 +1,4 @@
-import PlexAPI from '@server/api/plexapi';
-import { getRepository } from '@server/datasource';
-import { OverlayLibraryConfig } from '@server/entity/OverlayLibraryConfig';
+import PlexAPI, { type PlexLibraryItem } from '@server/api/plexapi';
 import logger from '@server/logger';
 import { sanitizeForFilename } from '@server/utils/fileSystemHelpers';
 import fs from 'fs/promises';
@@ -114,8 +112,24 @@ class LocalPosterFolderService {
       libraryName,
     });
 
-    const libraryContents = await plexApi.getLibraryContents(libraryId);
-    const items = libraryContents.items;
+    let allItems: PlexLibraryItem[] = [];
+    let offset = 0;
+    const pageSize = 50;
+    let hasMore = true;
+
+    while (hasMore) {
+      const response = await plexApi.getLibraryContents(libraryId, {
+        offset,
+        size: pageSize,
+      });
+      allItems = allItems.concat(response.items);
+      if (offset + pageSize >= response.totalSize) {
+        hasMore = false;
+      }
+      offset += pageSize;
+    }
+
+    const items = allItems;
     const stats = { created: 0, skipped: 0, failed: 0 };
 
     // Initialize progress tracking
@@ -232,26 +246,28 @@ class LocalPosterFolderService {
 
       const plexApi = new PlexAPI({ plexToken: admin.plexToken });
 
-      // Get all library configs
-      const configRepository = getRepository(OverlayLibraryConfig);
-      const configs = await configRepository.find();
+      // Get all movie/show libraries from Plex
+      const libraries = await plexApi.getLibraries();
+      const movieShowLibraries = libraries.filter(
+        (lib) => lib.type === 'movie' || lib.type === 'show'
+      );
 
-      if (configs.length === 0) {
-        logger.info('No library configurations found', {
+      if (movieShowLibraries.length === 0) {
+        logger.info('No movie/show libraries found', {
           label: 'LocalPosterFolderService',
         });
         return;
       }
 
-      for (const config of configs) {
+      for (const lib of movieShowLibraries) {
         if (this.cancelled) {
           break;
         }
 
         await this.generateFolderStructureForLibrary(
           plexApi,
-          config.libraryId,
-          config.libraryName
+          lib.key,
+          lib.title
         );
       }
 
@@ -284,8 +300,24 @@ class LocalPosterFolderService {
       libraryName,
     });
 
-    const libraryContents = await plexApi.getLibraryContents(libraryId);
-    const items = libraryContents.items;
+    let allItems: PlexLibraryItem[] = [];
+    let offset = 0;
+    const pageSize = 50;
+    let hasMore = true;
+
+    while (hasMore) {
+      const response = await plexApi.getLibraryContents(libraryId, {
+        offset,
+        size: pageSize,
+      });
+      allItems = allItems.concat(response.items);
+      if (offset + pageSize >= response.totalSize) {
+        hasMore = false;
+      }
+      offset += pageSize;
+    }
+
+    const items = allItems;
     const stats = { downloaded: 0, skipped: 0, failed: 0 };
 
     // Initialize progress tracking
@@ -463,27 +495,25 @@ class LocalPosterFolderService {
 
       const plexApi = new PlexAPI({ plexToken: admin.plexToken });
 
-      // Get all library configs
-      const configRepository = getRepository(OverlayLibraryConfig);
-      const configs = await configRepository.find();
+      // Get all movie/show libraries from Plex
+      const libraries = await plexApi.getLibraries();
+      const movieShowLibraries = libraries.filter(
+        (lib) => lib.type === 'movie' || lib.type === 'show'
+      );
 
-      if (configs.length === 0) {
-        logger.info('No library configurations found', {
+      if (movieShowLibraries.length === 0) {
+        logger.info('No movie/show libraries found', {
           label: 'LocalPosterFolderService',
         });
         return;
       }
 
-      for (const config of configs) {
+      for (const lib of movieShowLibraries) {
         if (this.cancelled) {
           break;
         }
 
-        await this.populateFromPlexForLibrary(
-          plexApi,
-          config.libraryId,
-          config.libraryName
-        );
+        await this.populateFromPlexForLibrary(plexApi, lib.key, lib.title);
       }
 
       logger.info('Plex poster population complete', {


### PR DESCRIPTION
fix(LocalPosterFolderService): fix pagination and library filtering for local poster folders

Add pagination loop to process all library items instead of only the first 50. Use plexApi.getLibraries() instead of OverlayLibraryConfig so libraries without overlays are included.

#### Description

Two bugs existed in `LocalPosterFolderService`:

1. **Only 50 items processed**: `generateFolderStructureForLibrary()` and `populateFromPlexForLibrary()` called `plexApi.getLibraryContents(libraryId)` without pagination, defaulting to `size=50`. Libraries with more than 50 items were truncated. Added a pagination loop (matching the existing pattern in `OverlayLibraryService` and `PlexBasePosterManager`) to fetch all items.

2. **Libraries without overlays skipped**: `generateFolderStructureForAllLibraries()` and `populateFromPlexForAllLibraries()` iterated over `OverlayLibraryConfig` entries only. Libraries without an overlay configured were excluded. Changed to use `plexApi.getLibraries()` filtered to movie/show types so all libraries are included.

#### Screenshot (if UI-related)

N/A

#### Checklist

- [x] Type checking (`yarn typecheck`)
- [x] Build succeeds (`yarn build`)
- [ ] Translation keys extracted (`yarn i18n:extract`) - if new user-facing strings added
- [ ] Database migration included - if schema changes required

**Runs automatically on `git commit`** (If you bypassed husky (`HUSKY=0`), run these manually as well before submitting.):

- [x] Formatting (prettier) (`yarn format`)
- [x] Linting (`yarn lint`)

#### Issues Fixed or Closed

- Fixes #433

```
2026-02-19T03:27:57.160Z [info[][LocalPosterFolderService]: Folder generation complete for library {"libraryId":"2","created":166,"skipped":1,"failed":0}                                     
2026-02-19T03:27:57.160Z [info[][LocalPosterFolderService]: Folder structure generation complete {"status":{"current":792,"total":792,"failed":0,"skipped":51,"percentage":100}}              
2026-02-19T03:28:30.814Z [debug[][LocalPosterFolderService]: Downloaded and saved Plex poster {"posterPath":"/app/config/plex-base-posters/Movies-1/A Complete Unknown (2024) tmdb-661539/post
2026-02-19T03:30:00.036Z [info[][Collections Quick Sync]: Collections Quick Sync completed {"duration":"0s","itemsMatched":0,"collectionsUpdated":0,"itemsAdded":0,"placeholdersDeleted":0,"ol
2026-02-19T03:30:00.037Z [debug[][Collections Quick Sync]: Quick sync completed                                                                                                               
2026-02-19T03:30:19.574Z [info[][LocalPosterFolderService]: Plex poster population complete for library {"libraryId":"1","downloaded":571,"skipped":50,"failed":0}                            
2026-02-19T03:30:20.271Z [info[][LocalPosterFolderService]: Plex poster population complete for library {"libraryId":"6","downloaded":4,"skipped":0,"failed":0}                               
2026-02-19T03:30:39.509Z [info[][LocalPosterFolderService]: Plex poster population complete for library {"libraryId":"2","downloaded":166,"skipped":1,"failed":0}                             
2026-02-19T03:30:39.509Z [info[][LocalPosterFolderService]: Plex poster population complete {"status":{"current":792,"total":792,"failed":0,"skipped":51,"percentage":100}}  
```