### PR TITLE
fix: guard splice in arrangeCollectionItemsInOrder

### DIFF
--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -1689,7 +1689,9 @@ class PlexAPI {
           moveCount++;
           // Update in-memory tracking: remove from old position and insert at new position
           const oldIndex = currentOrder.indexOf(itemToMove);
-          currentOrder.splice(oldIndex, 1);
+          if (oldIndex !== -1) {
+            currentOrder.splice(oldIndex, 1);
+          }
           currentOrder.splice(i, 0, itemToMove);
         } else {
           failCount++;


### PR DESCRIPTION
`arrangeCollectionItemsInOrder()` calls `splice(oldIndex, 1)` without checking if `indexOf` returned `-1`. When an item isn't yet visible in Plex, this removes the last element of the tracking array, corrupting subsequent move decisions and scrambling collection order.

Added a guard to skip the removal when the item isn't found in the current order.