### PR TITLE
fix(overlays): parallelise collection membership check in overlay test

### DIFF
--- a/server/routes/overlayTest.ts
+++ b/server/routes/overlayTest.ts
@@ -302,8 +302,6 @@ overlayTestRouter.post('/', async (req, res) => {
     }
 
     // Build collection membership for condition evaluation
-    // Always build for test route (single item, no performance concern)
-    const collectionIds: string[] = [];
     const allConfigs: { id: string; collectionRatingKey?: string }[] = [
       ...(settings.plex.collectionConfigs || []),
     ];
@@ -313,18 +311,28 @@ overlayTestRouter.post('/', async (req, res) => {
     );
     allConfigs.push(...preExistingCollectionConfigService.getConfigs());
 
-    for (const cfg of allConfigs) {
-      if (cfg.collectionRatingKey) {
-        try {
-          const itemKeys = await plexApi.getCollectionItems(
-            cfg.collectionRatingKey
-          );
-          if (itemKeys.includes(ratingKey)) {
-            collectionIds.push(cfg.id);
+    const collectionsWithKeys = allConfigs.filter(
+      (cfg) => cfg.collectionRatingKey
+    );
+    const collectionIds: string[] = [];
+    const concurrency = 10;
+
+    for (let i = 0; i < collectionsWithKeys.length; i += concurrency) {
+      const batch = collectionsWithKeys.slice(i, i + concurrency);
+      const results = await Promise.all(
+        batch.map(async (cfg) => {
+          try {
+            const itemKeys = await plexApi.getCollectionItems(
+              cfg.collectionRatingKey!
+            );
+            return itemKeys.includes(ratingKey) ? cfg.id : null;
+          } catch {
+            return null;
           }
-        } catch {
-          // Skip collections that fail to fetch
-        }
+        })
+      );
+      for (const id of results) {
+        if (id) collectionIds.push(id);
       }
     }
 


### PR DESCRIPTION
The overlay test endpoint checks every collection for item membership sequentially. With ~150 collections at ~250ms each, the request takes ~37 seconds and the frontend times out.

Batched the `getCollectionItems()` calls with `Promise.all` at concurrency 10, matching the pattern in `OverlayLibraryService`. Brings the check down to ~4 seconds for 150 collections.

Fixes #468