### PR TITLE
fix: handle Plex returning TV seasons as Children.Directory

### DIFF
--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -72,8 +72,9 @@ export interface PlexMetadata {
   }[];
   Label?: { tag: string; id?: number }[]; // Item-level labels/tags in Plex
   Children?: {
-    size: 12;
-    Metadata: PlexMetadata[];
+    size: number;
+    Directory?: PlexMetadata[];
+    Metadata?: PlexMetadata[];
   };
   index: number;
   parentIndex?: number;
@@ -414,11 +415,18 @@ class PlexAPI {
   }
 
   public async getChildrenMetadata(key: string): Promise<PlexMetadata[]> {
-    const response = await this.plexClient.query<PlexMetadataResponse>(
-      `/library/metadata/${key}/children`
-    );
+    const response = await this.plexClient.query<{
+      MediaContainer: {
+        Metadata?: PlexMetadata[];
+        Directory?: PlexMetadata[];
+      };
+    }>(`/library/metadata/${key}/children`);
 
-    return response.MediaContainer.Metadata;
+    return (
+      response.MediaContainer.Metadata ||
+      response.MediaContainer.Directory ||
+      []
+    );
   }
 
   /**

--- a/server/lib/collectionsQuickSync.ts
+++ b/server/lib/collectionsQuickSync.ts
@@ -367,7 +367,7 @@ class CollectionsQuickSync {
       // Cast to extended type to access optional properties used by placeholder detection
       const itemExtended = recentItem as PlexLibraryItem & {
         childCount?: number;
-        Children?: { Metadata?: unknown[] };
+        Children?: { Metadata?: unknown[]; Directory?: unknown[] };
         seasonCount?: number;
         leafCount?: number;
       };

--- a/server/lib/overlays/OverlayLibraryService.ts
+++ b/server/lib/overlays/OverlayLibraryService.ts
@@ -687,7 +687,7 @@ class OverlayLibraryService {
         editionTitle?: string;
         Guid?: { id: string }[];
         childCount?: number;
-        Children?: { Metadata?: unknown[] };
+        Children?: { Metadata?: unknown[]; Directory?: unknown[] };
         seasonCount?: number;
         leafCount?: number;
         ratingKey?: string;

--- a/server/lib/placeholders/services/PlaceholderContextService.ts
+++ b/server/lib/placeholders/services/PlaceholderContextService.ts
@@ -74,7 +74,7 @@ export class PlaceholderContextService {
       editionTitle?: string;
       Guid?: { id: string }[];
       childCount?: number;
-      Children?: { Metadata?: unknown[] };
+      Children?: { Metadata?: unknown[]; Directory?: unknown[] };
       seasonCount?: number;
       leafCount?: number;
     }
@@ -130,7 +130,7 @@ export class PlaceholderContextService {
     editionTitle?: string;
     Guid?: { id: string }[];
     childCount?: number;
-    Children?: { Metadata?: unknown[] };
+    Children?: { Metadata?: unknown[]; Directory?: unknown[] };
     seasonCount?: number;
     leafCount?: number;
   }): boolean {
@@ -176,8 +176,10 @@ export class PlaceholderContextService {
       // Real shows will have Season 01+ when content arrives
 
       // Check if children are provided and inspect them
-      if (plexMetadata.Children?.Metadata) {
-        const seasons = plexMetadata.Children.Metadata as {
+      const childSeasons =
+        plexMetadata.Children?.Metadata || plexMetadata.Children?.Directory;
+      if (childSeasons) {
+        const seasons = childSeasons as {
           index?: number;
         }[];
 
@@ -225,7 +227,7 @@ export class PlaceholderContextService {
       editionTitle?: string;
       Guid?: { id: string }[];
       childCount?: number;
-      Children?: { Metadata?: unknown[] };
+      Children?: { Metadata?: unknown[]; Directory?: unknown[] };
       seasonCount?: number;
       leafCount?: number;
       ratingKey?: string;
@@ -277,8 +279,10 @@ export class PlaceholderContextService {
       // TV shows: Check seasons
 
       // If Children metadata is already provided, use it
-      if (plexMetadata.Children?.Metadata) {
-        const seasons = plexMetadata.Children.Metadata as {
+      const childSeasons =
+        plexMetadata.Children?.Metadata || plexMetadata.Children?.Directory;
+      if (childSeasons) {
+        const seasons = childSeasons as {
           index?: number;
         }[];
 
@@ -324,8 +328,10 @@ export class PlaceholderContextService {
             mediaContainerKeys: Object.keys(response?.MediaContainer || {}),
           });
 
-          // Seasons are in Metadata, not Directory
-          const seasons = (response?.MediaContainer?.Metadata || []) as {
+          // Seasons may be in Metadata or Directory depending on Plex version/endpoint
+          const seasons = (response?.MediaContainer?.Metadata ||
+            response?.MediaContainer?.Directory ||
+            []) as {
             index?: number;
           }[];
 
@@ -596,7 +602,7 @@ export class PlaceholderContextService {
       editionTitle?: string;
       Guid?: { id: string }[];
       childCount?: number;
-      Children?: { Metadata?: unknown[] };
+      Children?: { Metadata?: unknown[]; Directory?: unknown[] };
       seasonCount?: number;
       leafCount?: number;
     }

--- a/server/lib/placeholders/services/PlaceholderCreation.ts
+++ b/server/lib/placeholders/services/PlaceholderCreation.ts
@@ -1034,7 +1034,7 @@ async function createPlaceholders(
       editionTitle?: string;
       Guid?: { id: string }[];
       childCount?: number;
-      Children?: { Metadata?: unknown[] };
+      Children?: { Metadata?: unknown[]; Directory?: unknown[] };
       seasonCount?: number;
       leafCount?: number;
     };
@@ -1108,7 +1108,9 @@ async function createPlaceholders(
           } else {
             // Get TV show file path from Season 00 Episode 01
             const fullMetadata = await plexClient.getMetadata(item.ratingKey);
-            const seasons = fullMetadata.Children?.Metadata;
+            const seasons =
+              fullMetadata.Children?.Metadata ||
+              fullMetadata.Children?.Directory;
             const season00 = seasons?.find(
               (s: { index?: number }) => s.index === 0
             );
@@ -1117,7 +1119,8 @@ async function createPlaceholders(
               const seasonMetadata = await plexClient.getMetadata(
                 String(season00.ratingKey)
               );
-              const firstEpisode = seasonMetadata.Children?.Metadata?.[0];
+              const firstEpisode = (seasonMetadata.Children?.Metadata ||
+                seasonMetadata.Children?.Directory)?.[0];
 
               if (firstEpisode && 'ratingKey' in firstEpisode) {
                 const episodeMetadata = await plexClient.getMetadata(
@@ -1236,17 +1239,20 @@ async function createPlaceholders(
           // Show-level items don't have Media/Part, only episodes do
           const fullMetadata = await plexClient.getMetadata(item.ratingKey);
 
-          // Get children (seasons)
-          if (!fullMetadata.Children?.Metadata) {
-            logger.warn('Could not extract file path - no Children.Metadata', {
-              label: 'PlaceholderService',
-              title: item.title,
-              ratingKey: item.ratingKey,
-            });
+          // Get children (seasons) - Plex returns seasons as Directory, not Metadata
+          const seasons =
+            fullMetadata.Children?.Metadata || fullMetadata.Children?.Directory;
+          if (!seasons) {
+            logger.warn(
+              'Could not extract file path - no Children.Metadata or Directory',
+              {
+                label: 'PlaceholderService',
+                title: item.title,
+                ratingKey: item.ratingKey,
+              }
+            );
             continue;
           }
-
-          const seasons = fullMetadata.Children.Metadata;
 
           // Find Season 00
           const season00 = seasons.find(
@@ -1267,10 +1273,10 @@ async function createPlaceholders(
             String(season00.ratingKey)
           );
 
-          if (
-            !seasonMetadata.Children?.Metadata ||
-            seasonMetadata.Children.Metadata.length === 0
-          ) {
+          const episodes =
+            seasonMetadata.Children?.Metadata ||
+            seasonMetadata.Children?.Directory;
+          if (!episodes || episodes.length === 0) {
             logger.warn(
               'Could not extract file path - Season 00 has no episodes',
               {
@@ -1282,7 +1288,7 @@ async function createPlaceholders(
             continue;
           }
 
-          const firstEpisode = seasonMetadata.Children.Metadata[0];
+          const firstEpisode = episodes[0];
 
           if (!('ratingKey' in firstEpisode)) {
             logger.warn(

--- a/server/routes/overlayTest.ts
+++ b/server/routes/overlayTest.ts
@@ -160,7 +160,7 @@ overlayTestRouter.post('/', async (req, res) => {
       editionTitle?: string;
       Guid?: { id: string }[];
       childCount?: number;
-      Children?: { Metadata?: unknown[] };
+      Children?: { Metadata?: unknown[]; Directory?: unknown[] };
       seasonCount?: number;
       leafCount?: number;
       ratingKey?: string;


### PR DESCRIPTION
`isPlaceholderItem()` checks `Children.Metadata` to inspect seasons, but Plex returns TV seasons as `Children.Directory` when using `?includeChildren=1`. The function falls through to the leafCount heuristic and returns `false` for all TV shows, so global discovery never fixes episode titles and placeholder shows leak into filtered hubs.

Added `Metadata || Directory` fallback across all detection paths, plus a `getChildrenMetadata()` helper that handles both response shapes.

Fixes #414