### PR TITLE
fix: title fallback for TV placeholders without TMDB GUID

### DIFF
--- a/server/lib/collections/services/CollectionSyncService.ts
+++ b/server/lib/collections/services/CollectionSyncService.ts
@@ -3,6 +3,7 @@ import OverseerrAPI, {
 } from '@server/api/overseerr';
 import type PlexAPI from '@server/api/plexapi';
 import type { BaseCollectionSync } from '@server/lib/collections/core/BaseCollectionSync';
+import type { LibraryItemsCache } from '@server/lib/collections/core/CollectionUtilities';
 import { getCollectionMediaType } from '@server/lib/collections/core/CollectionUtilities';
 import type {
   CollectionSource,
@@ -87,7 +88,8 @@ export class CollectionSyncService {
    */
   private async prefetchPlaceholderDiscovery(
     plexClient: PlexAPI,
-    collectionConfigs: CollectionConfig[]
+    collectionConfigs: CollectionConfig[],
+    libraryCache?: LibraryItemsCache
   ): Promise<{
     tv: DiscoveredPlaceholder[];
     movies: DiscoveredMoviePlaceholder[];
@@ -155,7 +157,8 @@ export class CollectionSyncService {
           const discovered = await discoverPlaceholdersFromMarkers(
             plexClient,
             tvLibraryId,
-            tvLibraryPath
+            tvLibraryPath,
+            libraryCache
           );
 
           logger.info('Global TV placeholder discovery complete', {
@@ -508,7 +511,8 @@ export class CollectionSyncService {
     onProgress?.(0, 'Discovering placeholders...');
     const placeholderDiscovery = await this.prefetchPlaceholderDiscovery(
       plexClient,
-      collectionConfigs
+      collectionConfigs,
+      libraryCache
     );
 
     // Initialize the global sync cache service for use across all sync operations

--- a/server/lib/placeholders/services/PlaceholderDiscovery.ts
+++ b/server/lib/placeholders/services/PlaceholderDiscovery.ts
@@ -4,6 +4,7 @@ import { ComingSoonItem } from '@server/entity/ComingSoonItem';
 import {
   findPlexItemsByTitle,
   findPlexItemsByTmdbIds,
+  type LibraryItemsCache,
 } from '@server/lib/collections/core/CollectionUtilities';
 import logger from '@server/logger';
 
@@ -83,7 +84,8 @@ export interface DiscoveredMoviePlaceholder {
 export async function discoverPlaceholdersFromMarkers(
   plexClient: PlexAPI,
   libraryId: string,
-  libraryPath: string
+  libraryPath: string,
+  libraryCache?: LibraryItemsCache
 ): Promise<DiscoveredPlaceholder[]> {
   const { scanForMarkerFiles, upgradeMarkerFile } = await import(
     '@server/lib/placeholders/placeholderManager'
@@ -132,7 +134,8 @@ export async function discoverPlaceholdersFromMarkers(
     const plexMatches = await findPlexItemsByTmdbIds(
       plexClient,
       tmdbLookups,
-      libraryId
+      libraryId,
+      libraryCache
     );
 
     for (const marker of tier1Markers) {
@@ -140,7 +143,42 @@ export async function discoverPlaceholdersFromMarkers(
         continue;
       }
 
-      const plexItem = plexMatches.get(`${marker.tmdbId}-tv`);
+      let plexItem: { ratingKey: string; title: string } | undefined =
+        plexMatches.get(`${marker.tmdbId}-tv`);
+
+      // Title fallback for items without TMDB GUID in Plex
+      if (!plexItem) {
+        const titleMatches = await findPlexItemsByTitle(
+          plexClient,
+          marker.title,
+          marker.year,
+          libraryId,
+          'tv',
+          libraryCache
+        );
+        // Prefer candidates without TMDB GUID (more likely the unmatched placeholder)
+        const candidate =
+          titleMatches.find((m) => !m.hasTmdbGuid) || titleMatches[0];
+        if (candidate) {
+          const candidateMetadata = await plexClient.getMetadata(
+            candidate.ratingKey.toString(),
+            { includeChildren: true }
+          );
+          if (placeholderContextService.isPlaceholderItem(candidateMetadata)) {
+            plexItem = {
+              ratingKey: candidate.ratingKey,
+              title: candidate.title,
+            };
+            logger.info('Tier 1: Found Plex item by title fallback', {
+              label: 'PlaceholderService',
+              title: marker.title,
+              year: marker.year,
+              ratingKey: candidate.ratingKey,
+              hasTmdbGuid: candidate.hasTmdbGuid,
+            });
+          }
+        }
+      }
 
       // Verify it's still a placeholder (check if real content was added)
       let needsTitleFix = false;
@@ -199,10 +237,47 @@ export async function discoverPlaceholdersFromMarkers(
         const plexMatches = await findPlexItemsByTmdbIds(
           plexClient,
           [{ tmdbId: dbRecord.tmdbId, mediaType: 'tv', title: marker.title }],
-          libraryId
+          libraryId,
+          libraryCache
         );
 
-        const plexItem = plexMatches.get(`${dbRecord.tmdbId}-tv`);
+        let plexItem: { ratingKey: string; title: string } | undefined =
+          plexMatches.get(`${dbRecord.tmdbId}-tv`);
+
+        // Title fallback for items without TMDB GUID in Plex
+        if (!plexItem) {
+          const titleMatches = await findPlexItemsByTitle(
+            plexClient,
+            marker.title,
+            marker.year,
+            libraryId,
+            'tv',
+            libraryCache
+          );
+          const candidate =
+            titleMatches.find((m) => !m.hasTmdbGuid) || titleMatches[0];
+          if (candidate) {
+            const candidateMetadata = await plexClient.getMetadata(
+              candidate.ratingKey.toString(),
+              { includeChildren: true }
+            );
+            if (
+              placeholderContextService.isPlaceholderItem(candidateMetadata)
+            ) {
+              plexItem = {
+                ratingKey: candidate.ratingKey,
+                title: candidate.title,
+              };
+              logger.info('Tier 2: Found Plex item by title fallback', {
+                label: 'PlaceholderService',
+                title: marker.title,
+                year: marker.year,
+                ratingKey: candidate.ratingKey,
+                hasTmdbGuid: candidate.hasTmdbGuid,
+              });
+            }
+          }
+        }
 
         // Verify it's still a placeholder (check if real content was added)
         let needsTitleFix = false;
@@ -264,7 +339,8 @@ export async function discoverPlaceholdersFromMarkers(
       marker.title,
       marker.year,
       libraryId,
-      'tv'
+      'tv',
+      libraryCache
     );
 
     if (titleMatches.length > 0) {


### PR DESCRIPTION
Depends on #491.

When Plex hasn't matched a placeholder show to TMDB, it has no `tmdb://` GUID. `findPlexItemsByTmdbIds()` can't find it, so discovery orphans the item with no title fix. The episode title never gets set to "Trailer (Placeholder)" and the show leaks into filtered hub collections.

Adds a `findPlexItemsByTitle()` fallback in Tier 1 and Tier 2 discovery when the TMDB lookup misses. Candidates are validated with `isPlaceholderItem()` before adoption (prefers items without a TMDB GUID, since those are more likely to be the unmatched placeholder). Also threads the shared library cache through the discovery call chain so the title lookups don't trigger extra API calls.

Fixes #414