### PR TITLE
fix(overlays): correct air date today logic for next episode and season

### DIFF
--- a/server/lib/overlays/OverlayLibraryService.ts
+++ b/server/lib/overlays/OverlayLibraryService.ts
@@ -761,7 +761,7 @@ class OverlayLibraryService {
             const daysSince = calculateDaysSince(
               releaseDateInfo.nextEpisodeAirDate
             );
-            if (daysSince < 0) {
+            if (daysSince <= 0) {
               daysUntilNextEpisode = -daysSince;
             }
           }

--- a/server/lib/overlays/OverlayLibraryService.ts
+++ b/server/lib/overlays/OverlayLibraryService.ts
@@ -770,7 +770,7 @@ class OverlayLibraryService {
             const daysSince = calculateDaysSince(
               releaseDateInfo.nextSeasonAirDate
             );
-            if (daysSince < 0) {
+            if (daysSince <= 0) {
               daysUntilNextSeason = -daysSince;
             } else {
               daysAgoNextSeason = daysSince;

--- a/server/routes/overlayTest.ts
+++ b/server/routes/overlayTest.ts
@@ -244,7 +244,7 @@ overlayTestRouter.post('/', async (req, res) => {
           const daysSince = calculateDaysSince(
             releaseDateInfo.nextEpisodeAirDate
           );
-          if (daysSince < 0) {
+          if (daysSince <= 0) {
             daysUntilNextEpisode = -daysSince;
           }
         }

--- a/server/routes/overlayTest.ts
+++ b/server/routes/overlayTest.ts
@@ -253,7 +253,7 @@ overlayTestRouter.post('/', async (req, res) => {
           const daysSince = calculateDaysSince(
             releaseDateInfo.nextSeasonAirDate
           );
-          if (daysSince < 0) {
+          if (daysSince <= 0) {
             daysUntilNextSeason = -daysSince;
           } else {
             daysAgoNextSeason = daysSince;


### PR DESCRIPTION
#### Description
Changed `daysSince < 0` to `daysSince <= 0` so that `daysUntilNextEpisode` and `daysUntilNextSeason` return `0` instead of `undefined` when the air date is today.

#### Screenshot (if UI-related)
N/A

#### Checklist

- [X] Type checking (`yarn typecheck`)
- [X] Build succeeds (`yarn build`)
- [ ] Translation keys extracted (`yarn i18n:extract`) - if new user-facing strings added
- [ ] Database migration included - if schema changes required

**Runs automatically on `git commit`** (If you bypassed husky (`HUSKY=0`), run these manually as well before submitting.):

- [X] Formatting (prettier) (`yarn format`)
- [X] Linting (`yarn lint`)

#### Issues Fixed or Closed

* Fixes #495 
