### PR TITLE
fix(ordering): deduplicate hub identifiers to prevent convergence failures

### DIFF
--- a/server/lib/collections/plex/PlexHubManager.ts
+++ b/server/lib/collections/plex/PlexHubManager.ts
@@ -471,10 +471,25 @@ class PlexHubManager {
               }
             } else {
               // Move succeeded - update our tracking of current order
-              const itemToMove = currentOrder.splice(currentPosition, 1)[0];
-              const predecessorNewPosition =
-                currentOrder.indexOf(expectedPredecessor);
-              currentOrder.splice(predecessorNewPosition + 1, 0, itemToMove);
+              if (currentPosition === -1) {
+                // Item not found in tracking array — refresh from actual order
+                logger.warn(
+                  `Item ${currentItem} not found in tracking array, refreshing`,
+                  { label: 'Plex API', sectionId, hubId: currentItem }
+                );
+                const refreshed = await this.getHubManagement(sectionId);
+                currentOrder.length = 0;
+                currentOrder.push(
+                  ...refreshed.MediaContainer.Hub.map(
+                    (h: { identifier: string }) => h.identifier
+                  )
+                );
+              } else {
+                const itemToMove = currentOrder.splice(currentPosition, 1)[0];
+                const predecessorNewPosition =
+                  currentOrder.indexOf(expectedPredecessor);
+                currentOrder.splice(predecessorNewPosition + 1, 0, itemToMove);
+              }
             }
           } catch (error) {
             logger.error(

--- a/server/lib/collections/plex/UnifiedOrderingService.ts
+++ b/server/lib/collections/plex/UnifiedOrderingService.ts
@@ -228,8 +228,21 @@ export async function applyUnifiedOrderingToPlex(
         (a, b) => a.sortOrder - b.sortOrder
       );
 
-      // Extract identifiers in the desired order
-      const orderedIdentifiers = sortedItems.map((item) => item.identifier);
+      // Extract identifiers in the desired order, deduplicating to prevent
+      // convergence failures when the same collection appears in multiple sources
+      const seen = new Set<string>();
+      const orderedIdentifiers: string[] = [];
+      for (const item of sortedItems) {
+        if (seen.has(item.identifier)) {
+          logger.warn(
+            `Dropping duplicate hub identifier ${item.identifier} in library ${libraryId}`,
+            { label: 'Unified Ordering Service', libraryId }
+          );
+          continue;
+        }
+        seen.add(item.identifier);
+        orderedIdentifiers.push(item.identifier);
+      }
 
       // Determine library type from hub identifiers
       const libraryType = sortedItems.some(


### PR DESCRIPTION
Hub ordering builds the desired order from three sources (agregarr collections, plex hubs, pre-existing collections) without deduplication. When the same collection appears in multiple sources, duplicate identifiers cause `indexOf`/`splice` corruption in the reordering loop and length mismatches in verification, always triggering a nuclear reset that scrambles collection order on the Plex home screen.

**Changes:**
- Deduplicate identifiers per library before passing to `reorderHubs()`, keeping first-occurrence order and logging dropped duplicates
- Guard `indexOf === -1` in `reorderHubs()` splice tracking to prevent array corruption from edge cases where an item isn't found in the tracking array

Fixes #489, fixes #458