### PR TITLE
fix: TV placeholders leaking into filtered hubs

### DIFF
--- a/server/lib/placeholders/services/PlaceholderCreation.ts
+++ b/server/lib/placeholders/services/PlaceholderCreation.ts
@@ -1039,16 +1039,28 @@ async function createPlaceholders(
       leafCount?: number;
     };
 
-    const isPlaceholder = placeholderContextService.isPlaceholderItem({
-      type: itemExtended.type,
-      guid: itemExtended.guid,
-      editionTitle: itemExtended.editionTitle,
-      Guid: itemExtended.Guid,
-      childCount: itemExtended.childCount,
-      Children: itemExtended.Children,
-      seasonCount: itemExtended.seasonCount,
-      leafCount: itemExtended.leafCount,
-    });
+    const isPlaceholder =
+      await placeholderContextService.isPlaceholderItemAsync(
+        {
+          type: itemExtended.type,
+          guid: itemExtended.guid,
+          editionTitle: itemExtended.editionTitle,
+          Guid: itemExtended.Guid,
+          childCount: itemExtended.childCount,
+          Children: itemExtended.Children,
+          seasonCount: itemExtended.seasonCount,
+          leafCount: itemExtended.leafCount,
+          ratingKey: item.ratingKey,
+        },
+        plexClient['plexClient'] as {
+          query: (path: string) => Promise<{
+            MediaContainer?: {
+              Directory?: unknown[];
+              Metadata?: unknown[];
+            };
+          }>;
+        }
+      );
 
     if (!isPlaceholder) {
       continue;

--- a/server/lib/placeholders/services/PlaceholderDiscovery.ts
+++ b/server/lib/placeholders/services/PlaceholderDiscovery.ts
@@ -142,24 +142,12 @@ export async function discoverPlaceholdersFromMarkers(
 
       const plexItem = plexMatches.get(`${marker.tmdbId}-tv`);
 
-      // Verify it's still a placeholder (check if real content was added)
+      // Marker file on disk proves this is an Agregarr-created placeholder.
+      // Don't re-verify via isPlaceholderItem — returns false for TV shows
+      // when Children metadata is missing from the Plex API response.
       let needsTitleFix = false;
       if (plexItem) {
-        const plexMetadata = await plexClient.getMetadata(
-          plexItem.ratingKey.toString(),
-          { includeChildren: true }
-        );
-        const isStillPlaceholder =
-          placeholderContextService.isPlaceholderItem(plexMetadata);
-        needsTitleFix = isStillPlaceholder;
-
-        if (!isStillPlaceholder) {
-          logger.info('Placeholder has real content now - skipping title fix', {
-            label: 'PlaceholderService',
-            title: marker.title,
-            ratingKey: plexItem.ratingKey,
-          });
-        }
+        needsTitleFix = true;
       }
 
       discovered.push({
@@ -204,27 +192,13 @@ export async function discoverPlaceholdersFromMarkers(
 
         const plexItem = plexMatches.get(`${dbRecord.tmdbId}-tv`);
 
-        // Verify it's still a placeholder (check if real content was added)
+        // Marker file on disk proves this is an Agregarr-created placeholder.
+        // Don't re-verify via isPlaceholderItem — returns false for TV shows
+        // when Children metadata is missing from the Plex API response.
+        // Only *arr download status determines cleanup vs title-fix.
         let needsTitleFix = false;
         if (plexItem) {
-          const plexMetadata = await plexClient.getMetadata(
-            plexItem.ratingKey.toString(),
-            { includeChildren: true }
-          );
-          const isStillPlaceholder =
-            placeholderContextService.isPlaceholderItem(plexMetadata);
-          needsTitleFix = isStillPlaceholder;
-
-          if (!isStillPlaceholder) {
-            logger.info(
-              'Placeholder has real content now - skipping title fix',
-              {
-                label: 'PlaceholderService',
-                title: marker.title,
-                ratingKey: plexItem.ratingKey,
-              }
-            );
-          }
+          needsTitleFix = true;
         }
 
         discovered.push({

--- a/server/lib/placeholders/services/PlaceholderTitleFixer.ts
+++ b/server/lib/placeholders/services/PlaceholderTitleFixer.ts
@@ -82,8 +82,17 @@ export async function ensurePlaceholderEpisodeTitle(
         return false;
       }
 
-      // Get the first episode (should be S00E00)
-      const episode = episodesData[0];
+      // Find S00E00 by index rather than assuming array order
+      const episode = episodesData.find((ep) => ep.index === 0);
+
+      if (!episode) {
+        logger.debug('No E00 found in Season 00 - cannot fix title', {
+          label: 'PlaceholderService',
+          title: showTitle,
+          episodeIndexes: episodesData.map((ep) => ep.index),
+        });
+        return false;
+      }
 
       // Check if title is already correct
       if (episode.title === 'Trailer (Placeholder)') {


### PR DESCRIPTION
PlaceholderDiscovery re-verified TV items via `isPlaceholderItem()` during the
periodic title re-fix. This returns `false` for TV shows during library-level
scans because the Plex API response doesn't include `Children` metadata at that
level. The marker file on disk already proves it's an Agregarr-created
placeholder, so trust that instead of re-checking.

- Removed `isPlaceholderItem()` gate in Tier 1 and Tier 2 discovery -- marker
  file existence is sufficient proof
- PlaceholderTitleFixer now finds S00E00 by episode index rather than assuming
  array position
- Orphan scan in PlaceholderCreation uses `isPlaceholderItemAsync()` which
  fetches children metadata for definitive TV placeholder detection

Fixes #414