### PR TITLE
fix: support Maintainerr v3 API (mediaServerId rename)

### DIFF
--- a/server/api/maintainerr.ts
+++ b/server/api/maintainerr.ts
@@ -6,7 +6,8 @@ import axios from 'axios';
 export interface MaintainerrMedia {
   id: number;
   collectionId: number;
-  plexId: number;
+  plexId?: number; // v2 field
+  mediaServerId?: string; // v3 field (renamed from plexId)
   tmdbId: number;
   addDate: string; // ISO 8601 date string
   image_path: string;
@@ -15,7 +16,8 @@ export interface MaintainerrMedia {
 
 export interface MaintainerrCollection {
   id: number;
-  plexId: number;
+  plexId?: number; // v2 field
+  mediaServerId?: string; // v3 field (renamed from plexId)
   libraryId: number;
   title: string;
   description: string;

--- a/server/lib/overlays/OverlayContextBuilder.ts
+++ b/server/lib/overlays/OverlayContextBuilder.ts
@@ -748,9 +748,10 @@ export async function buildRenderContext(
       }[] = [];
 
       for (const collection of maintainerrCollections) {
-        const mediaItem = collection.media.find(
-          (m) => m.plexId === Number(item.ratingKey)
-        );
+        const mediaItem = collection.media.find((m) => {
+          const id = m.mediaServerId || m.plexId?.toString();
+          return id === item.ratingKey;
+        });
 
         if (mediaItem && collection.deleteAfterDays) {
           // Calculate days since item was added to collection


### PR DESCRIPTION
Maintainerr v3 renamed `plexId` (number) to `mediaServerId` (string) in their
collection media API response. The overlay context builder compared against the
old field, so `daysUntilAction` never populated and the "Deleting Soon" overlay
silently stopped working.

- Updated `MaintainerrMedia` and `MaintainerrCollection` interfaces to include
  both fields (v2 `plexId` and v3 `mediaServerId`)
- Changed the match logic to read `mediaServerId` with fallback to `plexId`,
  comparing as strings to match Plex's `ratingKey` format

Supports both Maintainerr v2 and v3.

Fixes #501