### PR TITLE
Fix path traversal in overlay template export

### DIFF
--- a/server/routes/posters.ts
+++ b/server/routes/posters.ts
@@ -1200,17 +1200,23 @@ router.get('/templates/:id/export', async (req, res, next) => {
             }
           }
         } else {
-          // This might be a raster image path - check in different possible locations
-          const possiblePaths = [
-            path.join(process.cwd(), 'config', 'uploads', assetPath),
-            path.join(process.cwd(), 'config', 'posters', assetPath),
-            path.join(process.cwd(), assetPath),
+          const allowedDirs = [
+            path.join(process.cwd(), 'config', 'uploads'),
+            path.join(process.cwd(), 'config', 'posters'),
           ];
+          const possiblePaths = allowedDirs.map((dir) =>
+            path.join(dir, assetPath)
+          );
 
           for (const possiblePath of possiblePaths) {
-            if (fs.existsSync(possiblePath)) {
+            const resolvedPath = path.resolve(possiblePath);
+            const isContained = allowedDirs.some((dir) =>
+              resolvedPath.startsWith(path.resolve(dir) + path.sep)
+            );
+            if (!isContained) continue;
+            if (fs.existsSync(resolvedPath)) {
               const relativeName = `assets/images/${path.basename(assetPath)}`;
-              archive.file(possiblePath, { name: relativeName });
+              archive.file(resolvedPath, { name: relativeName });
               logger.debug(`Added raster image to archive: ${relativeName}`);
               break;
             }

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -502,15 +502,22 @@ router.get('/overlay-template-export/:id', async (req, res) => {
             }
           }
         } else {
-          const possiblePaths = [
-            path.join(process.cwd(), 'config', 'uploads', assetPath),
-            path.join(process.cwd(), 'config', 'posters', assetPath),
-            path.join(process.cwd(), assetPath),
+          const allowedDirs = [
+            path.join(process.cwd(), 'config', 'uploads'),
+            path.join(process.cwd(), 'config', 'posters'),
           ];
+          const possiblePaths = allowedDirs.map((dir) =>
+            path.join(dir, assetPath)
+          );
 
           for (const possiblePath of possiblePaths) {
-            if (fs.existsSync(possiblePath)) {
-              archive.file(possiblePath, {
+            const resolvedPath = path.resolve(possiblePath);
+            const isContained = allowedDirs.some((dir) =>
+              resolvedPath.startsWith(path.resolve(dir) + path.sep)
+            );
+            if (!isContained) continue;
+            if (fs.existsSync(resolvedPath)) {
+              archive.file(resolvedPath, {
                 name: `assets/images/${path.basename(assetPath)}`,
               });
               logger.debug(


### PR DESCRIPTION
The overlay template export endpoints resolve asset paths with a
fallback to `path.join(cwd, assetPath)`, allowing arbitrary file
reads via crafted asset paths.

- Remove unrestricted cwd fallback from both export endpoints
- Restrict resolution to `config/uploads/` and `config/posters/`
- Add `path.resolve()` containment check

Affects `server/routes/uploads.ts` and `server/routes/posters.ts`.