### PR TITLE
Sanitize SVG content on icon upload

### DIFF
--- a/server/lib/iconManager.ts
+++ b/server/lib/iconManager.ts
@@ -16,6 +16,33 @@ const ALLOWED_ICON_TYPES = [
 const MAX_ICON_SIZE = 10 * 1024 * 1024; // 10MB
 const ICON_THUMBNAIL_SIZE = 64; // 64x64 thumbnails
 
+/**
+ * Sanitize SVG content by removing potentially dangerous elements and attributes.
+ * Strips script tags, event handlers, foreignObject, and javascript: URIs.
+ */
+function sanitizeSvg(svgBuffer: Buffer): Buffer {
+  let svg = svgBuffer.toString('utf8');
+
+  // Remove <script> tags and their contents
+  svg = svg.replace(/<script[\s\S]*?<\/script\s*>/gi, '');
+  svg = svg.replace(/<script[^>]*\/>/gi, '');
+
+  // Remove <foreignObject> tags and their contents
+  svg = svg.replace(/<foreignObject[\s\S]*?<\/foreignObject\s*>/gi, '');
+
+  // Remove event handler attributes (on*)
+  svg = svg.replace(/\s+on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*)/gi, '');
+
+  // Remove javascript: URIs in href and xlink:href attributes
+  svg = svg.replace(/href\s*=\s*["']javascript:[^"']*["']/gi, 'href="#"');
+  svg = svg.replace(
+    /xlink:href\s*=\s*["']javascript:[^"']*["']/gi,
+    'xlink:href="#"'
+  );
+
+  return Buffer.from(svg, 'utf8');
+}
+
 export interface IconMetadata {
   id: string;
   name: string;
@@ -214,7 +241,9 @@ export async function uploadIcon(
     let processedBuffer = fileBuffer;
     let thumbnailFilename: string | undefined;
 
-    if (mimeType !== 'image/svg+xml') {
+    if (mimeType === 'image/svg+xml') {
+      processedBuffer = sanitizeSvg(fileBuffer);
+    } else {
       // For raster images, ensure reasonable size and create thumbnail
       processedBuffer = await sharp(fileBuffer)
         .resize(750, 750, { fit: 'inside', withoutEnlargement: true })


### PR DESCRIPTION
SVG files uploaded as icons are saved without sanitisation. Embedded
script tags, event handlers, foreignObject elements, and javascript:
URIs in SVG content enable stored XSS.

Adds sanitizeSvg() that strips dangerous elements and attributes
before saving. Applied via uploadIcon() so template imports are
also covered.