### PR TITLE
feat: check *arr download status for placeholder lifecycle

### DIFF
--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -19,6 +19,7 @@ export interface SonarrSeason {
   seasonNumber: number;
   monitored: boolean;
   statistics?: {
+    nextAiring?: string;
     previousAiring?: string;
     episodeFileCount: number;
     episodeCount: number;
@@ -86,6 +87,8 @@ export interface SonarrSeries {
   tvMazeId: number;
   firstAired: string;
   lastInfoSync?: string;
+  nextAiring?: string;
+  previousAiring?: string;
   seriesType: 'standard' | 'daily' | 'anime';
   cleanTitle: string;
   imdbId: string;

--- a/server/lib/collections/services/CollectionSyncService.ts
+++ b/server/lib/collections/services/CollectionSyncService.ts
@@ -172,10 +172,8 @@ export class CollectionSyncService {
           let titleFixFailures = 0;
 
           for (const { plexItem, needsTitleFix, marker } of discovered) {
-            if (!plexItem) {
-              continue; // Not found in Plex
-            }
-
+            // Cleanup triggers when needsTitleFix is false (real content detected via Plex OR *arr)
+            // This works even without a plexItem (content downloaded to different library)
             if (!needsTitleFix && marker.tmdbId) {
               // Real content detected - clean up placeholder
               await cleanupPlaceholderForRealContent(
@@ -184,7 +182,7 @@ export class CollectionSyncService {
                 'tv'
               );
               cleanedUp++;
-            } else if (needsTitleFix) {
+            } else if (needsTitleFix && plexItem) {
               // Still a placeholder - fix episode title
               const fixed = await ensurePlaceholderEpisodeTitle(
                 plexClient,
@@ -316,8 +314,10 @@ export class CollectionSyncService {
           let moviesCleanedUp = 0;
           let labelsFixed = 0;
 
-          for (const { plexItem, needsCleanup, movie } of discovered) {
-            if (plexItem && needsCleanup) {
+          for (const { needsCleanup, movie, plexItem } of discovered) {
+            // Cleanup triggers when needsCleanup is true (real content detected via Plex OR *arr)
+            // This works even without a plexItem (content downloaded to different library)
+            if (needsCleanup) {
               // Real content detected - clean up placeholder
               await cleanupPlaceholderForRealContent(
                 movie.tmdbId,

--- a/server/lib/placeholders/placeholderManager.ts
+++ b/server/lib/placeholders/placeholderManager.ts
@@ -89,12 +89,25 @@ async function createMoviePlaceholder(
 async function createTVPlaceholder(
   options: PlaceholderOptions
 ): Promise<PlaceholderResult> {
-  const { title, year, libraryPath, trailerPath } = options;
+  const { title, year, libraryPath, trailerPath, sonarrFolderName } = options;
 
   // Directory format: ShowName (Year)/Season 00/S00E00.Trailer.mp4
-  const sanitizedTitle = sanitizeFilename(title);
-  const yearStr = year ? ` (${year})` : '';
-  const showDir = path.join(libraryPath, `${sanitizedTitle}${yearStr}`);
+  // If Sonarr folder name is provided, use it to match Sonarr's naming convention
+  // This prevents Plex from merging placeholder folders with real content folders
+  let folderName: string;
+  if (sonarrFolderName) {
+    folderName = sonarrFolderName;
+    logger.debug('Using Sonarr folder name for TV placeholder', {
+      label: 'PlaceholderService',
+      title,
+      sonarrFolderName,
+    });
+  } else {
+    const sanitizedTitle = sanitizeFilename(title);
+    const yearStr = year ? ` (${year})` : '';
+    folderName = `${sanitizedTitle}${yearStr}`;
+  }
+  const showDir = path.join(libraryPath, folderName);
   const seasonDir = path.join(showDir, 'Season 00');
 
   logger.debug('Creating TV show placeholder', {

--- a/server/lib/placeholders/services/PlaceholderContextService.ts
+++ b/server/lib/placeholders/services/PlaceholderContextService.ts
@@ -508,6 +508,129 @@ export class PlaceholderContextService {
   }
 
   /**
+   * Batch fetch download status from Radarr/Sonarr for multiple items
+   * Fetches libraries once and builds lookup maps for efficient querying
+   * Returns maps keyed by tmdbId (movies) and tvdbId (TV)
+   */
+  async batchCheckDownloadStatus(
+    items: {
+      tmdbId: number;
+      tvdbId?: number;
+      mediaType: 'movie' | 'tv';
+    }[]
+  ): Promise<{
+    moviesByTmdbId: Map<number, { downloaded: boolean; inRadarr: boolean }>;
+    showsByTvdbId: Map<
+      number,
+      { downloaded: boolean; inSonarr: boolean; folderName?: string }
+    >;
+  }> {
+    const settings = getSettings();
+    const moviesByTmdbId = new Map<
+      number,
+      { downloaded: boolean; inRadarr: boolean }
+    >();
+    const showsByTvdbId = new Map<
+      number,
+      { downloaded: boolean; inSonarr: boolean; folderName?: string }
+    >();
+
+    // Check if we have any movies or TV items to look up
+    const hasMovies = items.some((i) => i.mediaType === 'movie');
+    const hasTV = items.some((i) => i.mediaType === 'tv');
+
+    // Fetch Radarr libraries once
+    if (hasMovies && settings.radarr) {
+      for (const radarrInstance of settings.radarr) {
+        try {
+          const radarrClient = new RadarrAPI({
+            url: `${radarrInstance.useSsl ? 'https' : 'http'}://${
+              radarrInstance.hostname
+            }:${radarrInstance.port}${radarrInstance.baseUrl || ''}/api/v3`,
+            apiKey: radarrInstance.apiKey,
+          });
+
+          const movies = await radarrClient.getMovies();
+
+          for (const movie of movies) {
+            if (movie.tmdbId) {
+              const existing = moviesByTmdbId.get(movie.tmdbId);
+              // OR downloaded status across instances - if ANY instance has it, it's downloaded
+              moviesByTmdbId.set(movie.tmdbId, {
+                downloaded: existing?.downloaded || movie.hasFile || false,
+                inRadarr: true,
+              });
+            }
+          }
+
+          logger.debug('Fetched Radarr library for batch download check', {
+            label: 'PlaceholderContextService',
+            instance: radarrInstance.hostname,
+            movieCount: movies.length,
+          });
+        } catch (error) {
+          logger.warn('Failed to fetch Radarr library for batch check', {
+            label: 'PlaceholderContextService',
+            instance: radarrInstance.hostname,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+
+    // Fetch Sonarr libraries once
+    if (hasTV && settings.sonarr) {
+      for (const sonarrInstance of settings.sonarr) {
+        try {
+          const sonarrClient = new SonarrAPI({
+            url: `${sonarrInstance.useSsl ? 'https' : 'http'}://${
+              sonarrInstance.hostname
+            }:${sonarrInstance.port}${sonarrInstance.baseUrl || ''}/api/v3`,
+            apiKey: sonarrInstance.apiKey,
+          });
+
+          const shows = await sonarrClient.getSeries();
+
+          for (const show of shows) {
+            if (show.tvdbId) {
+              const existing = showsByTvdbId.get(show.tvdbId);
+              // Extract folder name from Sonarr path
+              const folderName = show.path
+                ? show.path
+                    .replace(/[\\/]+$/, '')
+                    .split(/[\\/]/)
+                    .pop() || undefined
+                : undefined;
+              // OR downloaded status across instances - if ANY instance has it, it's downloaded
+              showsByTvdbId.set(show.tvdbId, {
+                downloaded:
+                  existing?.downloaded ||
+                  (show.statistics?.episodeFileCount || 0) > 0,
+                inSonarr: true,
+                folderName: existing?.folderName || folderName,
+              });
+            }
+          }
+
+          logger.debug('Fetched Sonarr library for batch download check', {
+            label: 'PlaceholderContextService',
+            instance: sonarrInstance.hostname,
+            showCount: shows.length,
+          });
+        } catch (error) {
+          logger.warn('Failed to fetch Sonarr library for batch check', {
+            label: 'PlaceholderContextService',
+            instance: sonarrInstance.hostname,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+
+    return { moviesByTmdbId, showsByTvdbId };
+  }
+
+  /**
    * Check monitoring status in Radarr/Sonarr
    * Returns whether item is in *arr, monitored, and has files
    */

--- a/server/lib/placeholders/services/PlaceholderCreation.ts
+++ b/server/lib/placeholders/services/PlaceholderCreation.ts
@@ -187,12 +187,98 @@ export async function processPlaceholdersForMissingItems(
     tmdbIdsWithSourceData.has(item.tmdbId)
   );
 
+  // Check *arr download status before creating placeholders
+  // This prevents re-creating placeholders when content has been downloaded
+  // but Plex hasn't scanned it yet (race condition fix for issue #390)
+  const { placeholderContextService } = await import(
+    '@server/lib/placeholders/services/PlaceholderContextService'
+  );
+
+  const { moviesByTmdbId, showsByTvdbId } =
+    await placeholderContextService.batchCheckDownloadStatus(
+      filteredMissingItems.map((item) => ({
+        tmdbId: item.tmdbId,
+        tvdbId: item.tvdbId,
+        mediaType: item.mediaType,
+      }))
+    );
+
+  const itemsNotDownloaded: MissingItem[] = [];
+  let skippedAlreadyDownloaded = 0;
+
+  for (const item of filteredMissingItems) {
+    let isDownloaded = false;
+
+    if (item.mediaType === 'movie') {
+      const radarrStatus = moviesByTmdbId.get(item.tmdbId);
+      isDownloaded = radarrStatus?.downloaded ?? false;
+    } else if (item.mediaType === 'tv' && item.tvdbId) {
+      const sonarrStatus = showsByTvdbId.get(item.tvdbId);
+      isDownloaded = sonarrStatus?.downloaded ?? false;
+    }
+
+    if (isDownloaded) {
+      skippedAlreadyDownloaded++;
+      logger.debug(
+        'Skipping placeholder creation - content already downloaded in *arr',
+        {
+          label: 'PlaceholderService',
+          title: item.title,
+          tmdbId: item.tmdbId,
+          mediaType: item.mediaType,
+        }
+      );
+    } else {
+      itemsNotDownloaded.push(item);
+    }
+  }
+
+  if (skippedAlreadyDownloaded > 0) {
+    logger.info(
+      'Skipped placeholder creation for items already downloaded in *arr',
+      {
+        label: 'PlaceholderService',
+        configName: config.name,
+        skippedCount: skippedAlreadyDownloaded,
+        remainingCount: itemsNotDownloaded.length,
+      }
+    );
+  }
+
+  if (itemsNotDownloaded.length === 0) {
+    logger.info('No items need placeholders after *arr download check', {
+      label: 'PlaceholderService',
+      configName: config.name,
+      originalCount: missingItems.length,
+      skippedAlreadyDownloaded,
+    });
+    return [];
+  }
+
+  // Filter sourceData to match remaining items
+  const remainingTmdbIds = new Set(itemsNotDownloaded.map((i) => i.tmdbId));
+  const remainingSourceData = filteredSourceData.filter((s) =>
+    remainingTmdbIds.has(s.tmdbId)
+  );
+
+  // Build a map of TVDB ID -> Sonarr folder name for TV shows
+  const sonarrFolderNames = new Map<number, string>();
+  for (const item of itemsNotDownloaded) {
+    if (item.mediaType === 'tv' && item.tvdbId) {
+      const sonarrStatus = showsByTvdbId.get(item.tvdbId);
+      if (sonarrStatus?.folderName) {
+        sonarrFolderNames.set(item.tvdbId, sonarrStatus.folderName);
+      }
+    }
+  }
+
   // Call the internal placeholder creation logic
   return createPlaceholders(
-    filteredMissingItems,
-    filteredSourceData,
+    itemsNotDownloaded,
+    remainingSourceData,
     config,
-    plexClient
+    plexClient,
+    sonarrFolderNames
   );
 }
 
@@ -273,7 +359,8 @@ function missingItemsToPlaceholderSourceData(
  */
 async function createPlaceholderFile(
   sourceItem: ComingSoonSourceData,
-  libraryKey: string
+  libraryKey: string,
+  sonarrFolderName?: string
 ): Promise<string> {
   const { downloadTrailer } = await import(
     '@server/lib/placeholders/trailerDownload'
@@ -331,6 +418,7 @@ async function createPlaceholderFile(
     mediaType: sourceItem.mediaType,
     libraryPath,
     trailerPath,
+    sonarrFolderName,
   });
 
   return result.placeholderPath;
@@ -917,7 +1005,8 @@ async function createPlaceholders(
   missingItems: MissingItem[],
   sourceData: ComingSoonSourceData[],
   config: CollectionConfig,
-  plexClient: PlexAPI
+  plexClient: PlexAPI,
+  sonarrFolderNames?: Map<number, string>
 ): Promise<CollectionItem[]> {
   if (missingItems.length === 0) {
     return [];
@@ -1495,9 +1584,15 @@ async function createPlaceholders(
     }
 
     try {
+      // Pass Sonarr folder name for TV shows to prevent Plex merge conflicts
+      const folderName =
+        sourceItem.mediaType === 'tv' && sourceItem.tvdbId
+          ? sonarrFolderNames?.get(sourceItem.tvdbId)
+          : undefined;
       const placeholderPath = await createPlaceholderFile(
         sourceItem,
-        config.libraryId
+        config.libraryId,
+        folderName
       );
 
       createdPlaceholders.push({ sourceItem, placeholderPath });

--- a/server/lib/placeholders/services/PlaceholderDiscovery.ts
+++ b/server/lib/placeholders/services/PlaceholderDiscovery.ts
@@ -135,6 +135,18 @@ export async function discoverPlaceholdersFromMarkers(
       libraryId
     );
 
+    // Batch check *arr download status for all tier 1 markers
+    const arrLookups = tier1Markers
+      .filter((m) => m.tmdbId !== undefined)
+      .map((m) => ({
+        tmdbId: m.tmdbId as number,
+        tvdbId: m.tvdbId,
+        mediaType: 'tv' as const,
+      }));
+
+    const { showsByTvdbId } =
+      await placeholderContextService.batchCheckDownloadStatus(arrLookups);
+
     for (const marker of tier1Markers) {
       if (!marker.tmdbId) {
         continue;
@@ -142,11 +154,39 @@ export async function discoverPlaceholdersFromMarkers(
 
       const plexItem = plexMatches.get(`${marker.tmdbId}-tv`);
 
+      // Check if *arr reports content as downloaded
+      const arrStatus = marker.tvdbId
+        ? showsByTvdbId.get(marker.tvdbId)
+        : undefined;
+      const isDownloadedInArr = arrStatus?.downloaded === true;
+
       // Marker file on disk proves this is an Agregarr-created placeholder.
       // Don't re-verify via isPlaceholderItem — returns false for TV shows
       // when Children metadata is missing from the Plex API response.
+      // Use *arr download status as additional cleanup signal.
       let needsTitleFix = false;
       if (plexItem) {
+        needsTitleFix = !isDownloadedInArr;
+        if (isDownloadedInArr) {
+          logger.info(
+            'Placeholder has content downloaded in Sonarr - triggering cleanup',
+            {
+              label: 'PlaceholderService',
+              title: marker.title,
+              tvdbId: marker.tvdbId,
+            }
+          );
+        }
+      } else if (isDownloadedInArr) {
+        logger.info(
+          'No Plex item but content downloaded in Sonarr - triggering cleanup',
+          {
+            label: 'PlaceholderService',
+            title: marker.title,
+            tvdbId: marker.tvdbId,
+          }
+        );
+      } else {
         needsTitleFix = true;
       }
 
@@ -161,51 +201,116 @@ export async function discoverPlaceholdersFromMarkers(
     }
   }
 
-  // TIER 2 & 3: Process old markers without tmdbId
+  // Batch check *arr download status for all tier 2/3 markers that have DB records
+  // This avoids per-marker full library pulls
+  const tier2DbRecords = new Map<string, { tmdbId: number; tvdbId?: number }>();
   for (const marker of tier2And3Markers) {
-    // TIER 2: Check database for existing record
     const dbRecord = await repository.findOne({
       where: { placeholderPath: marker.placeholderPath },
     });
-
     if (dbRecord) {
+      tier2DbRecords.set(marker.placeholderPath, {
+        tmdbId: dbRecord.tmdbId,
+        tvdbId: dbRecord.tvdbId,
+      });
+    }
+  }
+
+  // Batch *arr check for all tier 2 markers with tvdbIds
+  let tier2ArrShows = new Map<
+    number,
+    { downloaded: boolean; inSonarr: boolean; folderName?: string }
+  >();
+  const tier2ArrLookups = [...tier2DbRecords.values()]
+    .filter((r) => r.tvdbId)
+    .map((r) => ({
+      tmdbId: r.tmdbId,
+      tvdbId: r.tvdbId,
+      mediaType: 'tv' as const,
+    }));
+  if (tier2ArrLookups.length > 0) {
+    const result = await placeholderContextService.batchCheckDownloadStatus(
+      tier2ArrLookups
+    );
+    tier2ArrShows = result.showsByTvdbId;
+  }
+
+  // TIER 2 & 3: Process old markers without tmdbId
+  for (const marker of tier2And3Markers) {
+    // TIER 2: Check database for existing record
+    const dbRecordInfo = tier2DbRecords.get(marker.placeholderPath);
+
+    if (dbRecordInfo) {
       logger.info('Tier 2: Found database record for old marker', {
         label: 'PlaceholderService',
         title: marker.title,
-        tmdbId: dbRecord.tmdbId,
+        tmdbId: dbRecordInfo.tmdbId,
       });
 
       // Upgrade marker file with tmdbId from database
       try {
         await upgradeMarkerFile(
           marker.filePath,
-          dbRecord.tmdbId,
-          dbRecord.tvdbId
+          dbRecordInfo.tmdbId,
+          dbRecordInfo.tvdbId
         );
 
         // Query Plex using tmdbId from database
         const plexMatches = await findPlexItemsByTmdbIds(
           plexClient,
-          [{ tmdbId: dbRecord.tmdbId, mediaType: 'tv', title: marker.title }],
+          [
+            {
+              tmdbId: dbRecordInfo.tmdbId,
+              mediaType: 'tv',
+              title: marker.title,
+            },
+          ],
           libraryId
         );
 
-        const plexItem = plexMatches.get(`${dbRecord.tmdbId}-tv`);
+        const plexItem = plexMatches.get(`${dbRecordInfo.tmdbId}-tv`);
+
+        // Check *arr download status from batched results
+        const arrStatus = dbRecordInfo.tvdbId
+          ? tier2ArrShows.get(dbRecordInfo.tvdbId)
+          : undefined;
+        const isDownloadedInArr = arrStatus?.downloaded === true;
 
         // Marker file on disk proves this is an Agregarr-created placeholder.
         // Don't re-verify via isPlaceholderItem — returns false for TV shows
         // when Children metadata is missing from the Plex API response.
-        // Only *arr download status determines cleanup vs title-fix.
+        // Use *arr download status as additional cleanup signal.
         let needsTitleFix = false;
         if (plexItem) {
+          needsTitleFix = !isDownloadedInArr;
+          if (isDownloadedInArr) {
+            logger.info(
+              'Tier 2: Content downloaded in Sonarr - triggering cleanup',
+              {
+                label: 'PlaceholderService',
+                title: marker.title,
+                tvdbId: dbRecordInfo.tvdbId,
+              }
+            );
+          }
+        } else if (isDownloadedInArr) {
+          logger.info(
+            'Tier 2: No Plex item but content downloaded - triggering cleanup',
+            {
+              label: 'PlaceholderService',
+              title: marker.title,
+              tvdbId: dbRecordInfo.tvdbId,
+            }
+          );
+        } else {
           needsTitleFix = true;
         }
 
         discovered.push({
           marker: {
             ...marker,
-            tmdbId: dbRecord.tmdbId,
-            tvdbId: dbRecord.tvdbId,
+            tmdbId: dbRecordInfo.tmdbId,
+            tvdbId: dbRecordInfo.tvdbId,
           },
           plexItem: plexItem
             ? { ratingKey: plexItem.ratingKey, title: plexItem.title }
@@ -392,9 +497,22 @@ export async function discoverMoviePlaceholdersFromFilenames(
     libraryId
   );
 
+  // Batch check *arr download status for all movies
+  const arrLookups = movies.map((m) => ({
+    tmdbId: m.tmdbId,
+    mediaType: 'movie' as const,
+  }));
+
+  const { moviesByTmdbId } =
+    await placeholderContextService.batchCheckDownloadStatus(arrLookups);
+
   // Step 3: Match filesystem placeholders to Plex items and verify they're still placeholders
   for (const movie of movies) {
     const plexItem = plexMatches.get(`${movie.tmdbId}-movie`);
+
+    // Check if *arr reports content as downloaded
+    const arrStatus = moviesByTmdbId.get(movie.tmdbId);
+    const isDownloadedInArr = arrStatus?.downloaded === true;
 
     // Verify it's still a placeholder (check if real movie was added)
     let needsCleanup = false;
@@ -412,8 +530,29 @@ export async function discoverMoviePlaceholdersFromFilenames(
           title: movie.title,
           ratingKey: plexItem.ratingKey,
         });
-        needsCleanup = true; // Mark for cleanup - real movie exists
+        needsCleanup = true;
+      } else if (isDownloadedInArr) {
+        logger.info(
+          'Movie placeholder has content downloaded in Radarr - triggering cleanup',
+          {
+            label: 'PlaceholderService',
+            title: movie.title,
+            tmdbId: movie.tmdbId,
+          }
+        );
+        needsCleanup = true;
       }
+    } else if (isDownloadedInArr) {
+      // No Plex item but *arr says downloaded - still trigger cleanup
+      logger.info(
+        'No Plex item but content downloaded in Radarr - triggering cleanup',
+        {
+          label: 'PlaceholderService',
+          title: movie.title,
+          tmdbId: movie.tmdbId,
+        }
+      );
+      needsCleanup = true;
     }
 
     discovered.push({

--- a/server/lib/placeholders/types.ts
+++ b/server/lib/placeholders/types.ts
@@ -20,6 +20,8 @@ export interface PlaceholderOptions {
   libraryPath: string;
   /** Path to downloaded trailer file */
   trailerPath: string;
+  /** Folder name from Sonarr (for TV shows to match Sonarr's naming convention) */
+  sonarrFolderName?: string;
 }
 
 /**


### PR DESCRIPTION
`processPlaceholdersForMissingItems()` creates placeholders without checking
whether Radarr/Sonarr already has the content downloaded. This causes
placeholders to be re-created during every sync for items that are downloaded
but not yet scanned by Plex.

Added `batchCheckDownloadStatus()` to `PlaceholderContextService` that fetches
all Radarr movies and Sonarr shows once per sync and builds lookup maps.

- Creation flow skips items where *arr reports content as downloaded
- Discovery uses *arr status as additional cleanup signal alongside Plex checks
- Cleanup triggers even without a Plex item match (content in different library)
- TV placeholders use Sonarr's folder name to prevent Plex merge conflicts
- Multi-instance support: content is downloaded if present in any *arr instance
- Fail-open: if *arr is unreachable, placeholders are created normally

Supersedes #404 (rebased from scratch due to upstream refactors).

Fixes #390