### PR TITLE
Retroactive placeholder filter evaluation during cleanup

### DIFF
--- a/server/lib/collections/services/MissingItemFilterService.ts
+++ b/server/lib/collections/services/MissingItemFilterService.ts
@@ -90,12 +90,14 @@ export class MissingItemFilterService {
    * @param missingItems - Items to filter
    * @param config - Collection configuration with filter settings
    * @param serviceLabel - Label for logging (e.g., 'Auto Request Service', 'Direct Download Service')
+   * @param options - Optional flags to control filtering behavior
    * @returns Filtered items with tracking arrays for logging
    */
   public async filterMissingItems(
     missingItems: MissingItem[],
     config: CollectionConfig,
-    serviceLabel: string
+    serviceLabel: string,
+    options?: { skipMediaTypeCheck?: boolean; skipRatingFilters?: boolean }
   ): Promise<FilteredMissingItemsResult> {
     // Track filtered items for summary logging
     const yearFilteredItems: string[] = [];
@@ -113,10 +115,12 @@ export class MissingItemFilterService {
 
     // Step 1: Filter by media type and minimum year
     const yearFilteredMissingItems = missingItems.filter((item) => {
-      // Check media type
-      if (item.mediaType === 'movie' && !config.searchMissingMovies)
-        return false;
-      if (item.mediaType === 'tv' && !config.searchMissingTV) return false;
+      // Check media type (skipped for placeholder filtering where these toggles don't apply)
+      if (!options?.skipMediaTypeCheck) {
+        if (item.mediaType === 'movie' && !config.searchMissingMovies)
+          return false;
+        if (item.mediaType === 'tv' && !config.searchMissingTV) return false;
+      }
       if (item.mediaType !== 'movie' && item.mediaType !== 'tv') return false;
 
       // Check minimum year filter
@@ -160,7 +164,11 @@ export class MissingItemFilterService {
 
     // Step 2: Bulk fetch IMDb ratings if filter is enabled
     const imdbRatingsMap = new Map<number, number | null>(); // tmdbId -> rating
-    if (config.minimumImdbRating && config.minimumImdbRating > 0) {
+    if (
+      config.minimumImdbRating &&
+      config.minimumImdbRating > 0 &&
+      !options?.skipRatingFilters
+    ) {
       await this.bulkFetchImdbRatings(
         yearFilteredMissingItems,
         imdbRatingsMap,
@@ -173,10 +181,11 @@ export class MissingItemFilterService {
     const rtRatingsMap = new Map<number, number | null>(); // tmdbId -> critics score
     const rtAudienceRatingsMap = new Map<number, number | null>(); // tmdbId -> audience score
     if (
-      (config.minimumRottenTomatoesRating &&
+      !options?.skipRatingFilters &&
+      ((config.minimumRottenTomatoesRating &&
         config.minimumRottenTomatoesRating > 0) ||
-      (config.minimumRottenTomatoesAudienceRating &&
-        config.minimumRottenTomatoesAudienceRating > 0)
+        (config.minimumRottenTomatoesAudienceRating &&
+          config.minimumRottenTomatoesAudienceRating > 0))
     ) {
       await this.fetchRTRatings(
         yearFilteredMissingItems,
@@ -192,7 +201,11 @@ export class MissingItemFilterService {
 
     for (const item of yearFilteredMissingItems) {
       // Check IMDb rating filter using cached ratings
-      if (config.minimumImdbRating && config.minimumImdbRating > 0) {
+      if (
+        config.minimumImdbRating &&
+        config.minimumImdbRating > 0 &&
+        !options?.skipRatingFilters
+      ) {
         if (imdbRatingsMap.has(item.tmdbId)) {
           const rating = imdbRatingsMap.get(item.tmdbId);
 
@@ -239,7 +252,8 @@ export class MissingItemFilterService {
       // Check Rotten Tomatoes critics rating filter using cached ratings
       if (
         config.minimumRottenTomatoesRating &&
-        config.minimumRottenTomatoesRating > 0
+        config.minimumRottenTomatoesRating > 0 &&
+        !options?.skipRatingFilters
       ) {
         if (rtRatingsMap.has(item.tmdbId)) {
           const score = rtRatingsMap.get(item.tmdbId);
@@ -290,7 +304,8 @@ export class MissingItemFilterService {
       // Check Rotten Tomatoes audience rating filter using cached ratings
       if (
         config.minimumRottenTomatoesAudienceRating &&
-        config.minimumRottenTomatoesAudienceRating > 0
+        config.minimumRottenTomatoesAudienceRating > 0 &&
+        !options?.skipRatingFilters
       ) {
         if (rtAudienceRatingsMap.has(item.tmdbId)) {
           const score = rtAudienceRatingsMap.get(item.tmdbId);

--- a/server/lib/placeholders/services/PlaceholderCleanup.ts
+++ b/server/lib/placeholders/services/PlaceholderCleanup.ts
@@ -2,6 +2,7 @@ import type PlexAPI from '@server/api/plexapi';
 import { getRepository } from '@server/datasource';
 import { ComingSoonItem } from '@server/entity/ComingSoonItem';
 import type { LibraryItemsCache } from '@server/lib/collections/core/CollectionUtilities';
+import type { MissingItem } from '@server/lib/collections/core/types';
 import type { CollectionConfig } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
@@ -455,10 +456,29 @@ export async function cleanupOrphanedPlaceholderFiles(): Promise<number> {
 }
 
 /**
+ * Check if any retroactively-applicable placeholder filters are configured.
+ * Rating filters are excluded because retroactive evaluation uses
+ * skipRatingFilters (unreleased content has no ratings).
+ */
+function hasPlaceholderFilters(config: CollectionConfig): boolean {
+  if (config.placeholderMinimumYear && config.placeholderMinimumYear > 0)
+    return true;
+
+  const pfs = config.placeholderFilterSettings;
+  if (pfs?.genres?.values?.length) return true;
+  if (pfs?.countries?.values?.length) return true;
+  if (pfs?.languages?.values?.length) return true;
+  if (pfs?.keywords?.values?.length) return true;
+
+  return false;
+}
+
+/**
  * Clean up placeholders for a collection:
  * 1. Items with real content detected in Plex (via discovery system)
  * 2. Items no longer in source data (orphaned items)
  * 3. Items that have been placeholders for 7+ days (stale items)
+ * 4. Items that no longer match placeholder filters (retroactive evaluation)
  *
  * Released items are tracked for configured window (placeholderReleasedDays, default: 7 days),
  * then database records are removed and overlay system automatically updates posters.
@@ -516,6 +536,80 @@ export async function cleanupPlaceholdersForConfig(
   // are removed after this many days. Not user-configurable to keep UX simple.
   const ORPHANED_GRACE_PERIOD_DAYS = 7;
 
+  // Retroactive filter evaluation: check existing placeholders against current filters.
+  // Placeholders that no longer pass filters are removed so filter changes take effect
+  // on already-created placeholders, not just new ones.
+  let filterPassedTmdbIds: Set<number> | undefined;
+
+  if (
+    config.createPlaceholdersForMissing &&
+    hasPlaceholderFilters(config) &&
+    sourceTmdbIds &&
+    sourceTmdbIds.size > 0
+  ) {
+    // Collect non-orphaned placeholders for filter evaluation
+    const nonOrphanedPlaceholders = placeholders.filter((p) =>
+      sourceTmdbIds.has(p.tmdbId)
+    );
+
+    if (nonOrphanedPlaceholders.length > 0) {
+      // Convert PlaceholderItem[] to MissingItem[] for the filter service
+      const syntheticMissingItems: MissingItem[] = nonOrphanedPlaceholders.map(
+        (p) => ({
+          tmdbId: p.tmdbId,
+          tvdbId: p.tvdbId,
+          mediaType: p.mediaType,
+          title: p.title,
+          year: p.year,
+          originalPosition: 0,
+          source: p.source,
+        })
+      );
+
+      try {
+        const { missingItemFilterService, buildPlaceholderFilterConfig } =
+          await import(
+            '@server/lib/collections/services/MissingItemFilterService'
+          );
+        const placeholderFilterConfig = buildPlaceholderFilterConfig(config);
+        const { filteredItems } =
+          await missingItemFilterService.filterMissingItems(
+            syntheticMissingItems,
+            placeholderFilterConfig,
+            'Placeholder Retroactive Filter',
+            { skipMediaTypeCheck: true, skipRatingFilters: true }
+          );
+
+        filterPassedTmdbIds = new Set(filteredItems.map((item) => item.tmdbId));
+
+        const filteredOutCount =
+          nonOrphanedPlaceholders.length - filterPassedTmdbIds.size;
+        if (filteredOutCount > 0) {
+          logger.info(
+            `${filteredOutCount} existing placeholders no longer match filters`,
+            {
+              label: 'PlaceholderService',
+              configName: config.name,
+              evaluated: nonOrphanedPlaceholders.length,
+              passed: filterPassedTmdbIds.size,
+              filteredOut: filteredOutCount,
+            }
+          );
+        }
+      } catch (filterError) {
+        // Filter evaluation failure should not block other cleanup
+        logger.warn('Failed to evaluate retroactive placeholder filters', {
+          label: 'PlaceholderService',
+          configName: config.name,
+          error:
+            filterError instanceof Error
+              ? filterError.message
+              : String(filterError),
+        });
+      }
+    }
+  }
+
   // Check for orphaned items (not in source) and stale items (too old)
   if (sourceTmdbIds && sourceTmdbIds.size > 0) {
     const STALE_THRESHOLD_DAYS = 7; // 7 days
@@ -531,6 +625,107 @@ export async function cleanupPlaceholdersForConfig(
           placeholder.createdAt &&
           Date.now() - placeholder.createdAt.getTime() >
             STALE_THRESHOLD_DAYS * 24 * 60 * 60 * 1000;
+
+        // Retroactive filter check: remove non-orphaned placeholders that
+        // no longer pass the current placeholder filter configuration.
+        if (
+          !isOrphaned &&
+          filterPassedTmdbIds &&
+          !filterPassedTmdbIds.has(placeholder.tmdbId)
+        ) {
+          logger.info('Removing placeholder that fails current filters', {
+            label: 'PlaceholderService',
+            title: placeholder.title,
+            tmdbId: placeholder.tmdbId,
+          });
+
+          let fileRemovalSucceeded = false;
+          if (placeholder.placeholderPath) {
+            const { removePlaceholder } = await import(
+              '@server/lib/placeholders/placeholderManager'
+            );
+            const { getPlaceholderRootFolder } = await import(
+              '@server/lib/placeholders/helpers/placeholderPathHelpers'
+            );
+            const libraryPath = getPlaceholderRootFolder(
+              config.libraryId,
+              placeholder.mediaType
+            );
+
+            if (!libraryPath) {
+              logger.error(
+                'Library path not configured - cannot remove filtered placeholder',
+                {
+                  label: 'PlaceholderService',
+                  title: placeholder.title,
+                  mediaType: placeholder.mediaType,
+                  libraryId: config.libraryId,
+                }
+              );
+              continue;
+            }
+
+            const fullPath = path.join(
+              libraryPath,
+              placeholder.placeholderPath
+            );
+
+            // Check if any OTHER collection still needs this file
+            const otherCollectionRecords = await repository.find({
+              where: {
+                placeholderPath: placeholder.placeholderPath,
+                configId: Not(config.id),
+              },
+            });
+
+            if (otherCollectionRecords.length > 0) {
+              fileRemovalSucceeded = true;
+              logger.info(
+                'Filtered placeholder file shared with other collections - keeping file',
+                {
+                  label: 'PlaceholderService',
+                  title: placeholder.title,
+                  otherCollections: otherCollectionRecords.length,
+                }
+              );
+            } else {
+              try {
+                await removePlaceholder(fullPath, placeholder.mediaType);
+                fileRemovalSucceeded = true;
+              } catch (error) {
+                const isFileNotFound =
+                  error instanceof Error &&
+                  'code' in error &&
+                  error.code === 'ENOENT';
+
+                if (isFileNotFound) {
+                  fileRemovalSucceeded = true;
+                } else {
+                  logger.error(
+                    'Failed to remove filtered placeholder file - keeping database record',
+                    {
+                      label: 'PlaceholderService',
+                      title: placeholder.title,
+                      path: fullPath,
+                      error:
+                        error instanceof Error ? error.message : String(error),
+                    }
+                  );
+                  continue;
+                }
+              }
+            }
+          } else {
+            fileRemovalSucceeded = true;
+          }
+
+          if (fileRemovalSucceeded) {
+            await repository.remove(placeholder);
+            removedCount++;
+          }
+
+          continue; // Skip orphan/stale checks - already handled
+        }
 
         // For orphaned items, check if past configured window
         if (isOrphaned && !isStale) {


### PR DESCRIPTION
Placeholder filters only applied to new placeholders during creation. Changing filters after placeholders already existed had no effect on them, so old placeholders that no longer matched would persist indefinitely.

`cleanupPlaceholdersForConfig()` now batch-evaluates existing placeholders against the current filter config each sync. Placeholders that no longer pass get their file and DB record removed. Rating filters are skipped since unreleased content won't have ratings data.

- Added `skipRatingFilters` option to `filterMissingItems()` (also adds `skipMediaTypeCheck` since placeholder filtering doesn't use movie/TV toggles)
- `hasPlaceholderFilters()` short-circuits when no filters are configured (zero overhead for the common case)
- Shared file removal already handles cross-collection files, ENOENT, and missing library paths

Fixes #522