### PR TITLE
feat: Re-enable Home & Recommended visibility for Overseerr user collections (Plex bug fixed)

### DIFF
--- a/src/components/Collections/FormSections/VisibilitySection.tsx
+++ b/src/components/Collections/FormSections/VisibilitySection.tsx
@@ -14,7 +14,7 @@ const messages = defineMessages({
   serverOwnerHome: 'Server Owner Home',
   libraryRecommended: 'Library Recommended',
   userRequestCollectionsRestricted:
-    "Individual user request collections are restricted to Library Tab Only visibility due a Plex bug that doesn't respect label restrictions on the Home/Recommended screens. TMDB Franchise Collections and Plex Library Auto Director Collections are hidden so that you don't clog up your home/recommended screens.",
+    'TMDB Franchise Collections and Plex Library Auto Director/Actor Collections are restricted to Library Tab Only visibility to avoid cluttering your Home and Recommended screens.',
   serverOwnerOnlyRestricted:
     "Server owner request collections can only appear on the server owner's home screen.",
   noVisibilityHubWarning:

--- a/src/components/Collections/Forms/CollectionConfigForm.tsx
+++ b/src/components/Collections/Forms/CollectionConfigForm.tsx
@@ -3255,8 +3255,6 @@ const CollectionFormConfigForm = ({
                                   isEnhancedForm={false}
                                   isDefaultPlexHub={isHub}
                                   restrictToLibraryOnly={
-                                    (values.type === 'overseerr' &&
-                                      values.subtype === 'users') ||
                                     (values.type === 'tmdb' &&
                                       values.subtype === 'auto_franchise') ||
                                     (values.type === 'plex' &&

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -372,7 +372,7 @@
   "components.Collections.FormSections.useSeparatorHelp": "Create a simple separator collection to group your auto {type} collections.",
   "components.Collections.FormSections.useTmdbFranchisePoster": "Use TMDB Franchise Poster",
   "components.Collections.FormSections.useTmdbFranchisePosterHelp": "Use the official TMDB franchise poster instead of auto-generating. This setting overrules the above auto-poster option if a collection poster is available from TMDB.",
-  "components.Collections.FormSections.userRequestCollectionsRestricted": "Individual user request collections are restricted to Library Tab Only visibility due a Plex bug that doesn't respect label restrictions on the Home/Recommended screens. TMDB Franchise Collections and Plex Library Auto Director Collections are hidden so that you don't clog up your home/recommended screens.",
+  "components.Collections.FormSections.userRequestCollectionsRestricted": "TMDB Franchise Collections and Plex Library Auto Director/Actor Collections are restricted to Library Tab Only visibility to avoid cluttering your Home and Recommended screens.",
   "components.Collections.FormSections.usersHome": "Users Home",
   "components.Collections.FormSections.validateUrl": "Validate URL",
   "components.Collections.FormSections.validatingUrl": "Validating...",

--- a/src/utils/collections/formStateManager.ts
+++ b/src/utils/collections/formStateManager.ts
@@ -337,10 +337,9 @@ export const FormStateHelpers = {
 
     // For User Requests (overseerr + users), check if Users Home is unlocked
     if (values.type === 'overseerr' && values.subtype === 'users') {
-      const isUsersHomeUnlocked = data?.hasUsersHomeUnlock || false;
       return {
-        usersHome: { enabled: isUsersHomeUnlocked, label: 'Users Home' },
-        serverOwnerHome: { enabled: false, label: 'Server Owner Home' }, // Users collections shouldn't be on server owner home
+        usersHome: { enabled: true, label: 'Users Home' },
+        serverOwnerHome: { enabled: true, label: 'Server Owner Home' },
         libraryRecommended: { enabled: true, label: 'Library Recommended' },
       };
     }


### PR DESCRIPTION
## Summary

Plex has fixed the long-standing bug where collections with label restrictions would still appear on Home and Recommended screens for users who shouldn't see them. This was confirmed in the Plex forums:

- [Excluded collections should not stay pinned to homescreen/library recommend](https://forums.plex.tv/t/excluded-collections-should-not-stay-pinned-to-homescreen-library-recommend/854353/42)
- [Privacy issue: label restrictions not respected for collections on the Home/Recommended pages](https://forums.plex.tv/t/privacy-issue-label-restrictions-not-respected-for-collections-on-the-home-recommended-pages/933544)

With this fix shipped in recent Plex Media Server versions (1.43.1+), we can now safely re-enable the ability to set Home and Recommended visibility on Overseerr/Seerr-based individual user collections. The `AgregarrOverseerrUser*` label filtering that Agregarr applies per-user will now be correctly respected by Plex on all screens.

## Changes

### 1. `CollectionConfigForm.tsx`
- Removed `(values.type === 'overseerr' && values.subtype === 'users')` from the `restrictToLibraryOnly` prop — Overseerr user collections are no longer forced to Library Tab Only visibility.

### 2. `formStateManager.ts`
- Enabled all visibility checkbox states (`usersHome`, `serverOwnerHome`, `libraryRecommended`) for Overseerr user collections, removing the `hasUsersHomeUnlock` gate.

### 3. `VisibilitySection.tsx`
- Updated the warning message to remove the Plex bug reference — the restriction notice now only applies to TMDB Franchise and Plex Auto Director/Actor collections.

### 4. `en.json`
- Updated the matching localization string accordingly.

## What stays the same
- `restrictToLibraryOnly` for TMDB `auto_franchise` and Plex `directors`/`actors` — those remain restricted to avoid flooding home screens
- `restrictToServerOwnerOnly` for `overseerr` + `server_owner` — different restriction, unrelated
- Label-based user filtering via `PlexUserManager.ts` (`AgregarrOverseerrUser*` labels) — this is what actually ensures privacy between users' collections