### PR TITLE
fix: back off on IMDb Top 250 cache refresh failure

### DIFF
--- a/server/api/imdb.ts
+++ b/server/api/imdb.ts
@@ -62,6 +62,7 @@ class ImdbAPI {
   private top250TvCache: Map<string, number> = new Map();
   private top250LastRefresh: { movies?: number; tv?: number } = {};
   private readonly TOP250_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
+  private readonly TOP250_FAILURE_BACKOFF = 5 * 60 * 1000; // 5 minutes
 
   /**
    * Get a predefined IMDb top list
@@ -280,7 +281,9 @@ class ImdbAPI {
         label: 'IMDb API',
         error: error instanceof Error ? error.message : String(error),
       });
-      // Don't throw - fall back to empty cache
+      // Back off on failure to avoid retrying per item (~30s WAF timeout each)
+      this.top250LastRefresh[type === 'movie' ? 'movies' : 'tv'] =
+        Date.now() - this.TOP250_CACHE_TTL + this.TOP250_FAILURE_BACKOFF;
     }
   }
 


### PR DESCRIPTION
`refreshTop250Cache()` never sets `lastRefresh` on failure, so `needsRefresh()` returns `true` on every subsequent `checkTop250()` call. Each retry hits the AWS WAF challenge solver (~30s timeout), making overlay syncs across large libraries non-functional when WAF is blocking.

Sets `lastRefresh` on failure with a 5-minute backoff so it retries once per window instead of per item.

Fixes #546