### PR TITLE
Feat: Refresh Overlay of a Single Item via API

### DIFF
--- a/agregarr-api.yml
+++ b/agregarr-api.yml
@@ -1,7 +1,7 @@
-openapi: '3.0.2'
+openapi: "3.0.2"
 info:
-  title: 'Agregarr API'
-  version: '1.0.0'
+  title: "Agregarr API"
+  version: "1.0.0"
   description: |
     This is the documentation for the Agregarr API backend.
 
@@ -77,7 +77,7 @@ tags:
   - name: uploads
     description: Authenticated file upload and import/export endpoints for posters, wallpapers, theme music, icons, and template ZIP files.
 servers:
-  - url: '{server}/api/v1'
+  - url: "{server}/api/v1"
     variables:
       server:
         default: http://localhost:7171
@@ -93,7 +93,7 @@ components:
           readOnly: true
         email:
           type: string
-          example: 'hey@itsme.com'
+          example: "hey@itsme.com"
           readOnly: true
         username:
           type: string
@@ -115,11 +115,11 @@ components:
           readOnly: true
         createdAt:
           type: string
-          example: '2020-09-02T05:02:23.000Z'
+          example: "2020-09-02T05:02:23.000Z"
           readOnly: true
         updatedAt:
           type: string
-          example: '2020-09-02T05:02:23.000Z'
+          example: "2020-09-02T05:02:23.000Z"
           readOnly: true
         requestCount:
           type: number
@@ -178,16 +178,16 @@ components:
             type: string
           description: Per-library movie placeholder root folders (libraryKey -> path)
           example:
-            '1': /data/media/movies
-            '3': /data/media/movies-4k
+            "1": /data/media/movies
+            "3": /data/media/movies-4k
         placeholderTVRootFolders:
           type: object
           additionalProperties:
             type: string
           description: Per-library TV placeholder root folders (libraryKey -> path)
           example:
-            '2': /data/media/tv
-            '4': /data/media/anime
+            "2": /data/media/tv
+            "4": /data/media/anime
         skipYoutubeTrailerDownloads:
           type: boolean
           description: If true, skip YouTube trailer downloads and use hardcoded placeholder video only (speeds up sync)
@@ -212,15 +212,15 @@ components:
       properties:
         name:
           type: string
-          example: 'Main Server'
+          example: "Main Server"
           readOnly: true
         machineId:
           type: string
-          example: '1234123412341234'
+          example: "1234123412341234"
           readOnly: true
         ip:
           type: string
-          example: '127.0.0.1'
+          example: "127.0.0.1"
         port:
           type: number
           example: 32400
@@ -231,11 +231,11 @@ components:
           type: array
           readOnly: true
           items:
-            $ref: '#/components/schemas/PlexLibrary'
+            $ref: "#/components/schemas/PlexLibrary"
         webAppUrl:
           type: string
           nullable: true
-          example: 'https://app.plex.tv/desktop'
+          example: "https://app.plex.tv/desktop"
       required:
         - name
         - machineId
@@ -246,37 +246,37 @@ components:
       properties:
         id:
           type: string
-          description: 'Unique collection identifier (sequential number starting from 10000)'
-          example: '10000'
+          description: "Unique collection identifier (sequential number starting from 10000)"
+          example: "10000"
         name:
           type: string
-          example: 'User Requests'
+          example: "User Requests"
         type:
           type: string
           enum:
             [
-              'overseerr',
-              'tautulli',
-              'trakt',
-              'tmdb',
-              'imdb',
-              'mdblist',
-              'letterboxd',
-              'networks',
-              'originals',
-              'plex',
-              'multi-source',
-              'anilist',
-              'myanimelist',
-              'radarrtag',
-              'sonarrtag',
-              'comingsoon',
-              'filtered_hub',
+              "overseerr",
+              "tautulli",
+              "trakt",
+              "tmdb",
+              "imdb",
+              "mdblist",
+              "letterboxd",
+              "networks",
+              "originals",
+              "plex",
+              "multi-source",
+              "anilist",
+              "myanimelist",
+              "radarrtag",
+              "sonarrtag",
+              "comingsoon",
+              "filtered_hub",
             ]
-          example: 'overseerr'
+          example: "overseerr"
         subtype:
           type: string
-          example: 'users'
+          example: "users"
         template:
           type: string
           example: "{nickname}'s Requests"
@@ -293,85 +293,85 @@ components:
         customPoster:
           oneOf:
             - type: string
-              description: 'Filename of custom poster image (legacy format)'
-              example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
+              description: "Filename of custom poster image (legacy format)"
+              example: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
             - type: object
-              description: 'Per-library poster mapping (libraryId -> filename)'
+              description: "Per-library poster mapping (libraryId -> filename)"
               additionalProperties:
                 type: string
               example:
-                lib1: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
-                lib2: 'a12bc34d-58cc-4372-a567-0e02b2c3d480.jpg'
+                lib1: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
+                lib2: "a12bc34d-58cc-4372-a567-0e02b2c3d480.jpg"
           nullable: true
         autoPoster:
           type: boolean
-          description: 'Auto-generate poster during sync'
+          description: "Auto-generate poster during sync"
           example: true
           nullable: true
         autoPosterTemplate:
           type: integer
-          description: 'Template ID for auto-generated posters (null for default template)'
+          description: "Template ID for auto-generated posters (null for default template)"
           example: 1
           nullable: true
         useTmdbFranchisePoster:
           type: boolean
-          description: 'Use TMDB franchise poster instead of auto-generated poster (only for TMDB auto_franchise collections)'
+          description: "Use TMDB franchise poster instead of auto-generated poster (only for TMDB auto_franchise collections)"
           example: false
           nullable: true
         hideIndividualItems:
           type: boolean
-          description: 'Hide individual items, show collection (collectionMode = 1, only for TMDB auto_franchise collections)'
+          description: "Hide individual items, show collection (collectionMode = 1, only for TMDB auto_franchise collections)"
           example: false
           nullable: true
         applyOverlaysDuringSync:
           type: boolean
-          description: 'Apply item overlays during sync (for Coming Soon collections)'
+          description: "Apply item overlays during sync (for Coming Soon collections)"
           example: true
           nullable: true
         customWallpaper:
           oneOf:
             - type: string
-              description: 'Filename of custom wallpaper image (art)'
-              example: 'wallpaper-12345.jpg'
+              description: "Filename of custom wallpaper image (art)"
+              example: "wallpaper-12345.jpg"
             - type: object
-              description: 'Per-library wallpaper mapping (libraryId -> filename)'
+              description: "Per-library wallpaper mapping (libraryId -> filename)"
               additionalProperties:
                 type: string
               example:
-                lib1: 'wallpaper-12345.jpg'
-                lib2: 'wallpaper-67890.jpg'
+                lib1: "wallpaper-12345.jpg"
+                lib2: "wallpaper-67890.jpg"
           nullable: true
         customSummary:
           type: string
-          description: 'Custom summary/description text for the collection'
-          example: 'A curated collection of the best movies'
+          description: "Custom summary/description text for the collection"
+          example: "A curated collection of the best movies"
           nullable: true
         customTheme:
           oneOf:
             - type: string
-              description: 'Filename of custom theme music file'
-              example: 'theme-12345.mp3'
+              description: "Filename of custom theme music file"
+              example: "theme-12345.mp3"
             - type: object
-              description: 'Per-library theme mapping (libraryId -> filename)'
+              description: "Per-library theme mapping (libraryId -> filename)"
               additionalProperties:
                 type: string
               example:
-                lib1: 'theme-12345.mp3'
-                lib2: 'theme-67890.mp3'
+                lib1: "theme-12345.mp3"
+                lib2: "theme-67890.mp3"
           nullable: true
         enableCustomWallpaper:
           type: boolean
-          description: 'Enable custom wallpaper sync to Plex'
+          description: "Enable custom wallpaper sync to Plex"
           example: false
           nullable: true
         enableCustomSummary:
           type: boolean
-          description: 'Enable custom summary sync to Plex'
+          description: "Enable custom summary sync to Plex"
           example: false
           nullable: true
         enableCustomTheme:
           type: boolean
-          description: 'Enable custom theme sync to Plex'
+          description: "Enable custom theme sync to Plex"
           example: false
           nullable: true
         visibilityConfig:
@@ -387,7 +387,7 @@ components:
               example: false
             libraryRecommended:
               type: boolean
-              description: 'Show in library recommended section'
+              description: "Show in library recommended section"
               example: false
           required:
             - usersHome
@@ -398,37 +398,37 @@ components:
           example: 20
         mediaType:
           type: string
-          enum: ['movie', 'tv', 'both']
-          example: 'both'
+          enum: ["movie", "tv", "both"]
+          example: "both"
         libraryIds:
           type: array
           items:
             type: string
           description: "Array of selected library IDs (['all'] for all libraries)"
-          example: ['1', '2']
+          example: ["1", "2"]
           nullable: true
         libraryName:
           type: string
-          description: 'Selected library name for display'
-          example: 'Movies'
+          description: "Selected library name for display"
+          example: "Movies"
           nullable: true
         sortOrderHome:
           type: integer
-          description: 'Order for Plex home screen (creation time based)'
+          description: "Order for Plex home screen (creation time based)"
           example: 0
           nullable: true
         sortOrderLibrary:
           type: integer
-          description: 'Position in library (0 for A-Z section, 1+ for promoted section)'
+          description: "Position in library (0 for A-Z section, 1+ for promoted section)"
           example: 0
           nullable: true
         isLibraryPromoted:
           type: boolean
-          description: 'true = promoted section (uses exclamation marks), false = A-Z section'
+          description: "true = promoted section (uses exclamation marks), false = A-Z section"
           example: true
         randomizeHomeOrder:
           type: boolean
-          description: 'If true, randomize position amongst other randomized items on home screen'
+          description: "If true, randomize position amongst other randomized items on home screen"
           example: false
           nullable: true
         parentConfigId:
@@ -443,33 +443,33 @@ components:
           nullable: true
         customDays:
           type: integer
-          description: 'Number of days for Tautulli collections (required for Tautulli type)'
+          description: "Number of days for Tautulli collections (required for Tautulli type)"
           example: 30
           nullable: true
         createPlaceholdersForMissing:
           type: boolean
-          description: 'Create placeholder files for missing items (enabled by default for Coming Soon collections)'
+          description: "Create placeholder files for missing items (enabled by default for Coming Soon collections)"
           example: false
           nullable: true
         placeholderDaysAhead:
           type: integer
-          description: 'Days to look ahead for release dates when creating placeholders (default: 360)'
+          description: "Days to look ahead for release dates when creating placeholders (default: 360)"
           example: 360
           nullable: true
         placeholderReleasedDays:
           type: integer
-          description: 'Days to keep released items with overlay before cleanup (default: 7)'
+          description: "Days to keep released items with overlay before cleanup (default: 7)"
           example: 7
           nullable: true
         placeholderMinimumYear:
           type: integer
-          description: 'Only include placeholder items released on or after this year (0 = no limit)'
+          description: "Only include placeholder items released on or after this year (0 = no limit)"
           example: 2010
           nullable: true
         placeholderMinimumImdbRating:
           type: number
           format: float
-          description: 'Only include placeholder items with IMDb rating >= this value (0 = no limit)'
+          description: "Only include placeholder items with IMDb rating >= this value (0 = no limit)"
           example: 6.8
           minimum: 0
           maximum: 10
@@ -477,7 +477,7 @@ components:
         placeholderMinimumRottenTomatoesRating:
           type: number
           format: float
-          description: 'Only include placeholder items with Rotten Tomatoes critics score >= this value (0 = no limit)'
+          description: "Only include placeholder items with Rotten Tomatoes critics score >= this value (0 = no limit)"
           example: 70
           minimum: 0
           maximum: 100
@@ -485,157 +485,157 @@ components:
         placeholderMinimumRottenTomatoesAudienceRating:
           type: number
           format: float
-          description: 'Only include placeholder items with Rotten Tomatoes audience score >= this value (0 = no limit)'
+          description: "Only include placeholder items with Rotten Tomatoes audience score >= this value (0 = no limit)"
           example: 75
           minimum: 0
           maximum: 100
           nullable: true
         placeholderFilterSettings:
           type: object
-          description: 'Unified filter settings for placeholders with include/exclude modes'
+          description: "Unified filter settings for placeholders with include/exclude modes"
           properties:
             genres:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these genres, or include only items with these genres'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these genres, or include only items with these genres"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: integer
-                  description: 'TMDB genre IDs'
+                  description: "TMDB genre IDs"
                   example: [28, 53]
             countries:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items from these countries, or include only items from these countries'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items from these countries, or include only items from these countries"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: string
-                  description: 'ISO 3166-1 country codes'
-                  example: ['JP', 'KR']
+                  description: "ISO 3166-1 country codes"
+                  example: ["JP", "KR"]
             languages:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these languages, or include only items with these languages'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these languages, or include only items with these languages"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: string
-                  description: 'ISO 639-1 language codes'
-                  example: ['ja', 'ko']
+                  description: "ISO 639-1 language codes"
+                  example: ["ja", "ko"]
             keywords:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these keywords, or include only items with these keywords'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these keywords, or include only items with these keywords"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: integer
-                  description: 'TMDB keyword IDs'
+                  description: "TMDB keyword IDs"
                   example: [210024, 818]
           nullable: true
         includeAllReleasedItems:
           type: boolean
-          description: 'If true, include all released items regardless of release date (default: true for new configs)'
+          description: "If true, include all released items regardless of release date (default: true for new configs)"
           example: true
           nullable: true
         comingSoonDays:
           type: integer
-          description: 'DEPRECATED: Use placeholderDaysAhead instead'
+          description: "DEPRECATED: Use placeholderDaysAhead instead"
           deprecated: true
           example: 360
           nullable: true
         comingSoonReleasedDays:
           type: integer
-          description: 'DEPRECATED: Use placeholderReleasedDays instead'
+          description: "DEPRECATED: Use placeholderReleasedDays instead"
           deprecated: true
           example: 7
           nullable: true
         comingSoonRadarrServerId:
           type: integer
-          description: 'Selected Radarr server ID for coming soon monitored subtype'
+          description: "Selected Radarr server ID for coming soon monitored subtype"
           nullable: true
         comingSoonSonarrServerId:
           type: integer
-          description: 'Selected Sonarr server ID for coming soon monitored subtype'
+          description: "Selected Sonarr server ID for coming soon monitored subtype"
           nullable: true
         comingSoonFilterByTags:
           type: boolean
-          description: 'Enable tag filtering for coming soon monitored subtype'
+          description: "Enable tag filtering for coming soon monitored subtype"
           nullable: true
         comingSoonTagMode:
           type: string
-          enum: ['include', 'exclude']
-          description: 'Tag filter mode for coming soon monitored subtype'
+          enum: ["include", "exclude"]
+          description: "Tag filter mode for coming soon monitored subtype"
           nullable: true
         comingSoonRadarrTagIds:
           type: array
           items:
             type: integer
-          description: 'Radarr tag IDs to filter by for coming soon monitored subtype'
+          description: "Radarr tag IDs to filter by for coming soon monitored subtype"
           nullable: true
         comingSoonSonarrTagIds:
           type: array
           items:
             type: integer
-          description: 'Sonarr tag IDs to filter by for coming soon monitored subtype'
+          description: "Sonarr tag IDs to filter by for coming soon monitored subtype"
           nullable: true
         minimumPlays:
           type: integer
-          description: 'Minimum play count for Tautulli collections (defaults to 3 if not set, 1-100)'
+          description: "Minimum play count for Tautulli collections (defaults to 3 if not set, 1-100)"
           example: 3
           nullable: true
         tautulliStatType:
           type: string
-          enum: ['plays', 'duration']
-          description: 'Tautulli statistic type: plays (play count) or duration (watch time)'
-          example: 'plays'
+          enum: ["plays", "duration"]
+          description: "Tautulli statistic type: plays (play count) or duration (watch time)"
+          example: "plays"
           nullable: true
         searchMissingMovies:
           type: boolean
-          description: 'Auto-request missing movies'
+          description: "Auto-request missing movies"
           example: false
           nullable: true
         searchMissingTV:
           type: boolean
-          description: 'Auto-request missing TV shows'
+          description: "Auto-request missing TV shows"
           example: false
           nullable: true
         autoApproveMovies:
           type: boolean
-          description: 'Auto-approve movie requests'
+          description: "Auto-approve movie requests"
           example: false
           nullable: true
         autoApproveTV:
           type: boolean
-          description: 'Auto-approve TV show requests'
+          description: "Auto-approve TV show requests"
           example: false
           nullable: true
         maxSeasonsToRequest:
           type: integer
-          description: 'Max seasons for auto-approval (TV shows with more seasons require manual approval)'
+          description: "Max seasons for auto-approval (TV shows with more seasons require manual approval)"
           example: 5
           nullable: true
         seasonsPerShowLimit:
           type: integer
-          description: 'Limit each TV show to only the first X seasons (0 = all seasons)'
+          description: "Limit each TV show to only the first X seasons (0 = all seasons)"
           example: 2
           nullable: true
         seasonGrabOrder:
@@ -644,18 +644,18 @@ components:
             - first
             - latest
             - airing
-          description: 'Order to grab seasons: first N seasons (default), N latest seasons (including unreleased), or N most recently aired seasons'
-          example: 'first'
+          description: "Order to grab seasons: first N seasons (default), N latest seasons (including unreleased), or N most recently aired seasons"
+          example: "first"
           nullable: true
         minimumYear:
           type: integer
-          description: 'Only process movies/TV shows released on or after this year (0 = no limit)'
+          description: "Only process movies/TV shows released on or after this year (0 = no limit)"
           example: 2010
           nullable: true
         minimumImdbRating:
           type: number
           format: float
-          description: 'Only process movies/TV shows with IMDb rating >= this value (0 = no limit)'
+          description: "Only process movies/TV shows with IMDb rating >= this value (0 = no limit)"
           example: 6.8
           minimum: 0
           maximum: 10
@@ -663,7 +663,7 @@ components:
         minimumRottenTomatoesRating:
           type: number
           format: float
-          description: 'Only process movies/TV shows with Rotten Tomatoes critics score >= this value (0 = no limit)'
+          description: "Only process movies/TV shows with Rotten Tomatoes critics score >= this value (0 = no limit)"
           example: 70
           minimum: 0
           maximum: 100
@@ -671,85 +671,85 @@ components:
         minimumRottenTomatoesAudienceRating:
           type: number
           format: float
-          description: 'Only process movies/TV shows with Rotten Tomatoes audience score >= this value (0 = no limit)'
+          description: "Only process movies/TV shows with Rotten Tomatoes audience score >= this value (0 = no limit)"
           example: 75
           minimum: 0
           maximum: 100
           nullable: true
         filterSettings:
           type: object
-          description: 'Unified filter settings with include/exclude modes'
+          description: "Unified filter settings with include/exclude modes"
           properties:
             genres:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these genres, or include only items with these genres'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these genres, or include only items with these genres"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: integer
-                  description: 'TMDB genre IDs'
+                  description: "TMDB genre IDs"
                   example: [28, 53]
             countries:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items from these countries, or include only items from these countries'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items from these countries, or include only items from these countries"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: string
-                  description: 'ISO 3166-1 country codes'
-                  example: ['JP', 'KR']
+                  description: "ISO 3166-1 country codes"
+                  example: ["JP", "KR"]
             languages:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these languages, or include only items with these languages'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these languages, or include only items with these languages"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: string
-                  description: 'ISO 639-1 language codes'
-                  example: ['ja', 'ko']
+                  description: "ISO 639-1 language codes"
+                  example: ["ja", "ko"]
             keywords:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these keywords, or include only items with these keywords'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these keywords, or include only items with these keywords"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: integer
-                  description: 'TMDB keyword IDs'
+                  description: "TMDB keyword IDs"
                   example: [210024, 818]
           nullable: true
         traktCustomListUrl:
           type: string
-          description: 'Custom Trakt list URL (e.g., https://trakt.tv/users/username/lists/list-name or https://app.trakt.tv/users/username/lists/list-name)'
-          example: 'https://trakt.tv/users/username/lists/my-list'
+          description: "Custom Trakt list URL (e.g., https://trakt.tv/users/username/lists/list-name or https://app.trakt.tv/users/username/lists/list-name)"
+          example: "https://trakt.tv/users/username/lists/my-list"
           nullable: true
         tmdbCustomCollectionUrl:
           type: string
-          description: 'Custom TMDB collection or list URL (e.g., https://www.themoviedb.org/collection/123456 or https://www.themoviedb.org/list/310)'
-          example: 'https://www.themoviedb.org/list/310-my-movie-list'
+          description: "Custom TMDB collection or list URL (e.g., https://www.themoviedb.org/collection/123456 or https://www.themoviedb.org/list/310)"
+          example: "https://www.themoviedb.org/list/310-my-movie-list"
           nullable: true
         tmdbMovieSortBy:
           type: string
-          description: 'TMDB /discover/movie sort_by (only for TMDB Custom Advanced Filters)'
+          description: "TMDB /discover/movie sort_by (only for TMDB Custom Advanced Filters)"
           enum:
             - original_title.asc
             - original_title.desc
@@ -769,7 +769,7 @@ components:
           nullable: true
         tmdbTvSortBy:
           type: string
-          description: 'TMDB /discover/tv sort_by (only for TMDB Custom Advanced Filters)'
+          description: "TMDB /discover/tv sort_by (only for TMDB Custom Advanced Filters)"
           enum:
             - first_air_date.asc
             - first_air_date.desc
@@ -792,13 +792,13 @@ components:
           nullable: true
         imdbCustomListUrl:
           type: string
-          description: 'Custom IMDb list or watchlist URL (e.g., https://www.imdb.com/list/ls123456789/ or https://www.imdb.com/user/ur12345678/watchlist)'
-          example: 'https://www.imdb.com/list/ls123456789/'
+          description: "Custom IMDb list or watchlist URL (e.g., https://www.imdb.com/list/ls123456789/ or https://www.imdb.com/user/ur12345678/watchlist)"
+          example: "https://www.imdb.com/list/ls123456789/"
           nullable: true
         mdblistCustomListUrl:
           type: string
-          description: 'Custom MDBList list URL (e.g., https://mdblist.com/lists/username/listname)'
-          example: 'https://mdblist.com/lists/garycrawfordgc/netflix-shows'
+          description: "Custom MDBList list URL (e.g., https://mdblist.com/lists/username/listname)"
+          example: "https://mdblist.com/lists/garycrawfordgc/netflix-shows"
           nullable: true
         sortOrder:
           type: string
@@ -814,48 +814,48 @@ components:
             - date_added_asc
             - alphabetical_asc
             - alphabetical_desc
-          description: 'Sort order for collection items'
-          example: 'default'
-          default: 'default'
+          description: "Sort order for collection items"
+          example: "default"
+          default: "default"
           nullable: true
         personMinimumItems:
           type: number
-          description: 'Unified minimum items required to create actor/director collections'
+          description: "Unified minimum items required to create actor/director collections"
           example: 3
           nullable: true
         useSeparator:
           type: boolean
-          description: 'Create a separator collection for auto actor/director collections'
+          description: "Create a separator collection for auto actor/director collections"
           example: false
           nullable: true
         separatorTitle:
           type: string
-          description: 'Title for the separator collection'
-          example: 'Actors Collections'
+          description: "Title for the separator collection"
+          example: "Actors Collections"
           nullable: true
         excludeFromCollections:
           type: array
           items:
             type: string
-          description: 'Array of collection IDs to exclude items from (mutual exclusion)'
-          example: ['10001', '10002']
+          description: "Array of collection IDs to exclude items from (mutual exclusion)"
+          example: ["10001", "10002"]
           nullable: true
         timeRestriction:
           type: object
-          description: 'Time restriction settings for the collection'
+          description: "Time restriction settings for the collection"
           properties:
             alwaysActive:
               type: boolean
-              description: 'If true, collection is always active (default)'
+              description: "If true, collection is always active (default)"
               example: true
             removeFromPlexWhenInactive:
               type: boolean
-              description: 'If true, completely remove from Plex when inactive (old behavior)'
+              description: "If true, completely remove from Plex when inactive (old behavior)"
               example: false
               nullable: true
             inactiveVisibilityConfig:
               type: object
-              description: 'Visibility settings to use when collection is inactive (only used if removeFromPlexWhenInactive is false)'
+              description: "Visibility settings to use when collection is inactive (only used if removeFromPlexWhenInactive is false)"
               properties:
                 usersHome:
                   type: boolean
@@ -867,7 +867,7 @@ components:
                   example: false
                 libraryRecommended:
                   type: boolean
-                  description: 'Show in library recommended section when inactive'
+                  description: "Show in library recommended section when inactive"
                   example: true
               required:
                 - usersHome
@@ -876,25 +876,25 @@ components:
               nullable: true
             dateRanges:
               type: array
-              description: 'Date ranges when collection should be active (repeated annually)'
+              description: "Date ranges when collection should be active (repeated annually)"
               items:
                 type: object
                 properties:
                   startDate:
                     type: string
                     description: "DD-MM format (e.g., '05-12' for 5th December)"
-                    example: '05-12'
+                    example: "05-12"
                   endDate:
                     type: string
                     description: "DD-MM format (e.g., '26-12' for 26th December)"
-                    example: '26-12'
+                    example: "26-12"
                 required:
                   - startDate
                   - endDate
               nullable: true
             weeklySchedule:
               type: object
-              description: 'Days of the week when collection should be active'
+              description: "Days of the week when collection should be active"
               properties:
                 monday:
                   type: boolean
@@ -921,63 +921,63 @@ components:
           nullable: true
         isActive:
           type: boolean
-          description: 'Whether collection is currently active (time restrictions met)'
+          description: "Whether collection is currently active (time restrictions met)"
           example: true
           readOnly: true
         collectionType:
           type: string
-          enum: ['default_plex_hub', 'agregarr_created', 'pre_existing']
-          description: 'Backend categorization system for different collection types'
-          example: 'agregarr_created'
+          enum: ["default_plex_hub", "agregarr_created", "pre_existing"]
+          description: "Backend categorization system for different collection types"
+          example: "agregarr_created"
           nullable: true
         isLinked:
           type: boolean
-          description: 'Whether collection is actively linked to other collections'
+          description: "Whether collection is actively linked to other collections"
           example: true
           nullable: true
         isUnlinked:
           type: boolean
-          description: 'True if this collection was deliberately unlinked and should not be grouped with siblings'
+          description: "True if this collection was deliberately unlinked and should not be grouped with siblings"
           example: false
           nullable: true
         missing:
           type: boolean
-          description: 'True if collection no longer exists in Plex'
+          description: "True if collection no longer exists in Plex"
           example: false
         lastSyncedAt:
           type: string
           format: date-time
-          description: 'ISO timestamp of last successful sync to Plex'
-          example: '2024-01-15T10:30:00.000Z'
+          description: "ISO timestamp of last successful sync to Plex"
+          example: "2024-01-15T10:30:00.000Z"
           nullable: true
         lastModifiedAt:
           type: string
           format: date-time
-          description: 'ISO timestamp when config was last modified'
-          example: '2024-01-15T09:15:00.000Z'
+          description: "ISO timestamp when config was last modified"
+          example: "2024-01-15T09:15:00.000Z"
           nullable: true
         needsSync:
           type: boolean
-          description: 'True if collection has been modified and needs to be synced to Plex'
+          description: "True if collection has been modified and needs to be synced to Plex"
           example: false
           nullable: true
         showUnwatchedOnly:
           type: boolean
-          description: 'Create a smart collection that shows only unwatched items from this collection'
+          description: "Create a smart collection that shows only unwatched items from this collection"
           example: false
           nullable: true
         smartCollectionSort:
           type: object
-          description: 'Sort option for smart collections'
+          description: "Sort option for smart collections"
           properties:
             value:
               type: string
               description: "The sort parameter value (e.g., 'year:desc', 'titleSort', 'rating:desc')"
-              example: 'year:desc'
+              example: "year:desc"
             label:
               type: string
-              description: 'Human-readable label for the dropdown'
-              example: 'Year (Newest First)'
+              description: "Human-readable label for the dropdown"
+              example: "Year (Newest First)"
           nullable: true
       required:
         - id
@@ -989,41 +989,41 @@ components:
         - maxItems
     CollectionConfigCreate:
       type: object
-      description: 'Schema for creating a new collection configuration'
+      description: "Schema for creating a new collection configuration"
       properties:
         id:
           type: string
-          description: 'Empty string for new collections (will be assigned sequential number by backend)'
-          example: ''
+          description: "Empty string for new collections (will be assigned sequential number by backend)"
+          example: ""
         name:
           type: string
-          example: 'User Requests'
+          example: "User Requests"
         type:
           type: string
           enum:
             [
-              'overseerr',
-              'tautulli',
-              'trakt',
-              'tmdb',
-              'imdb',
-              'mdblist',
-              'letterboxd',
-              'networks',
-              'originals',
-              'plex',
-              'multi-source',
-              'anilist',
-              'myanimelist',
-              'radarrtag',
-              'sonarrtag',
-              'comingsoon',
-              'filtered_hub',
+              "overseerr",
+              "tautulli",
+              "trakt",
+              "tmdb",
+              "imdb",
+              "mdblist",
+              "letterboxd",
+              "networks",
+              "originals",
+              "plex",
+              "multi-source",
+              "anilist",
+              "myanimelist",
+              "radarrtag",
+              "sonarrtag",
+              "comingsoon",
+              "filtered_hub",
             ]
-          example: 'overseerr'
+          example: "overseerr"
         subtype:
           type: string
-          example: 'users'
+          example: "users"
         template:
           type: string
           example: "{nickname}'s Requests"
@@ -1040,85 +1040,85 @@ components:
         customPoster:
           oneOf:
             - type: string
-              description: 'Filename of custom poster image (legacy format)'
-              example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
+              description: "Filename of custom poster image (legacy format)"
+              example: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
             - type: object
-              description: 'Per-library poster mapping (libraryId -> filename)'
+              description: "Per-library poster mapping (libraryId -> filename)"
               additionalProperties:
                 type: string
               example:
-                lib1: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
-                lib2: 'a12bc34d-58cc-4372-a567-0e02b2c3d480.jpg'
+                lib1: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
+                lib2: "a12bc34d-58cc-4372-a567-0e02b2c3d480.jpg"
           nullable: true
         autoPoster:
           type: boolean
-          description: 'Auto-generate poster during sync'
+          description: "Auto-generate poster during sync"
           example: true
           nullable: true
         autoPosterTemplate:
           type: integer
-          description: 'Template ID for auto-generated posters (null for default template)'
+          description: "Template ID for auto-generated posters (null for default template)"
           example: 1
           nullable: true
         useTmdbFranchisePoster:
           type: boolean
-          description: 'Use TMDB franchise poster instead of auto-generated poster (only for TMDB auto_franchise collections)'
+          description: "Use TMDB franchise poster instead of auto-generated poster (only for TMDB auto_franchise collections)"
           example: false
           nullable: true
         hideIndividualItems:
           type: boolean
-          description: 'Hide individual items, show collection (collectionMode = 1, only for TMDB auto_franchise collections)'
+          description: "Hide individual items, show collection (collectionMode = 1, only for TMDB auto_franchise collections)"
           example: false
           nullable: true
         applyOverlaysDuringSync:
           type: boolean
-          description: 'Apply item overlays during sync (for Coming Soon collections)'
+          description: "Apply item overlays during sync (for Coming Soon collections)"
           example: true
           nullable: true
         customWallpaper:
           oneOf:
             - type: string
-              description: 'Filename of custom wallpaper image (art)'
-              example: 'wallpaper-12345.jpg'
+              description: "Filename of custom wallpaper image (art)"
+              example: "wallpaper-12345.jpg"
             - type: object
-              description: 'Per-library wallpaper mapping (libraryId -> filename)'
+              description: "Per-library wallpaper mapping (libraryId -> filename)"
               additionalProperties:
                 type: string
               example:
-                lib1: 'wallpaper-12345.jpg'
-                lib2: 'wallpaper-67890.jpg'
+                lib1: "wallpaper-12345.jpg"
+                lib2: "wallpaper-67890.jpg"
           nullable: true
         customSummary:
           type: string
-          description: 'Custom summary/description text for the collection'
-          example: 'A curated collection of the best movies'
+          description: "Custom summary/description text for the collection"
+          example: "A curated collection of the best movies"
           nullable: true
         customTheme:
           oneOf:
             - type: string
-              description: 'Filename of custom theme music file'
-              example: 'theme-12345.mp3'
+              description: "Filename of custom theme music file"
+              example: "theme-12345.mp3"
             - type: object
-              description: 'Per-library theme mapping (libraryId -> filename)'
+              description: "Per-library theme mapping (libraryId -> filename)"
               additionalProperties:
                 type: string
               example:
-                lib1: 'theme-12345.mp3'
-                lib2: 'theme-67890.mp3'
+                lib1: "theme-12345.mp3"
+                lib2: "theme-67890.mp3"
           nullable: true
         enableCustomWallpaper:
           type: boolean
-          description: 'Enable custom wallpaper sync to Plex'
+          description: "Enable custom wallpaper sync to Plex"
           example: false
           nullable: true
         enableCustomSummary:
           type: boolean
-          description: 'Enable custom summary sync to Plex'
+          description: "Enable custom summary sync to Plex"
           example: false
           nullable: true
         enableCustomTheme:
           type: boolean
-          description: 'Enable custom theme sync to Plex'
+          description: "Enable custom theme sync to Plex"
           example: false
           nullable: true
         visibilityConfig:
@@ -1134,7 +1134,7 @@ components:
               example: false
             libraryRecommended:
               type: boolean
-              description: 'Show in library recommended section'
+              description: "Show in library recommended section"
               example: false
           required:
             - usersHome
@@ -1145,72 +1145,72 @@ components:
           example: 20
         mediaType:
           type: string
-          enum: ['movie', 'tv', 'both']
-          example: 'both'
+          enum: ["movie", "tv", "both"]
+          example: "both"
         libraryId:
           type: string
           description: "Selected library ID - each config is for exactly one library (optional when mediaType is 'both')"
-          example: '1'
+          example: "1"
         libraryName:
           type: string
           description: "Selected library name for display (optional when mediaType is 'both')"
-          example: 'Movies'
+          example: "Movies"
         libraryIds:
           type: array
           items:
             type: string
           description: "Array of library IDs when mediaType is 'both' (backend expands into individual configs)"
-          example: ['1', '2']
+          example: ["1", "2"]
         libraryNames:
           type: array
           items:
             type: string
           description: "Array of library names when mediaType is 'both' (backend expands into individual configs)"
-          example: ['Movies', 'TV Shows']
+          example: ["Movies", "TV Shows"]
         sortOrderHome:
           type: integer
-          description: 'Order for Plex home screen (creation time based)'
+          description: "Order for Plex home screen (creation time based)"
           example: 0
           nullable: true
         sortOrderLibrary:
           type: integer
-          description: 'Order for Plex library tab (sortTitle based)'
+          description: "Order for Plex library tab (sortTitle based)"
           example: 0
           nullable: true
         randomizeHomeOrder:
           type: boolean
-          description: 'If true, randomize position amongst other randomized items on home screen'
+          description: "If true, randomize position amongst other randomized items on home screen"
           example: false
           nullable: true
         customDays:
           type: integer
-          description: 'Number of days for Tautulli collections (required for Tautulli type)'
+          description: "Number of days for Tautulli collections (required for Tautulli type)"
           example: 30
           nullable: true
         createPlaceholdersForMissing:
           type: boolean
-          description: 'Create placeholder files for missing items (enabled by default for Coming Soon collections)'
+          description: "Create placeholder files for missing items (enabled by default for Coming Soon collections)"
           example: false
           nullable: true
         placeholderDaysAhead:
           type: integer
-          description: 'Days to look ahead for release dates when creating placeholders (default: 360)'
+          description: "Days to look ahead for release dates when creating placeholders (default: 360)"
           example: 360
           nullable: true
         placeholderReleasedDays:
           type: integer
-          description: 'Days to keep released items with overlay before cleanup (default: 7)'
+          description: "Days to keep released items with overlay before cleanup (default: 7)"
           example: 7
           nullable: true
         placeholderMinimumYear:
           type: integer
-          description: 'Only include placeholder items released on or after this year (0 = no limit)'
+          description: "Only include placeholder items released on or after this year (0 = no limit)"
           example: 2010
           nullable: true
         placeholderMinimumImdbRating:
           type: number
           format: float
-          description: 'Only include placeholder items with IMDb rating >= this value (0 = no limit)'
+          description: "Only include placeholder items with IMDb rating >= this value (0 = no limit)"
           example: 6.8
           minimum: 0
           maximum: 10
@@ -1218,7 +1218,7 @@ components:
         placeholderMinimumRottenTomatoesRating:
           type: number
           format: float
-          description: 'Only include placeholder items with Rotten Tomatoes critics score >= this value (0 = no limit)'
+          description: "Only include placeholder items with Rotten Tomatoes critics score >= this value (0 = no limit)"
           example: 70
           minimum: 0
           maximum: 100
@@ -1226,145 +1226,145 @@ components:
         placeholderMinimumRottenTomatoesAudienceRating:
           type: number
           format: float
-          description: 'Only include placeholder items with Rotten Tomatoes audience score >= this value (0 = no limit)'
+          description: "Only include placeholder items with Rotten Tomatoes audience score >= this value (0 = no limit)"
           example: 75
           minimum: 0
           maximum: 100
           nullable: true
         placeholderFilterSettings:
           type: object
-          description: 'Unified filter settings for placeholders with include/exclude modes'
+          description: "Unified filter settings for placeholders with include/exclude modes"
           properties:
             genres:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these genres, or include only items with these genres'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these genres, or include only items with these genres"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: integer
-                  description: 'TMDB genre IDs'
+                  description: "TMDB genre IDs"
                   example: [28, 53]
             countries:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items from these countries, or include only items from these countries'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items from these countries, or include only items from these countries"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: string
-                  description: 'ISO 3166-1 country codes'
-                  example: ['JP', 'KR']
+                  description: "ISO 3166-1 country codes"
+                  example: ["JP", "KR"]
             languages:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these languages, or include only items with these languages'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these languages, or include only items with these languages"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: string
-                  description: 'ISO 639-1 language codes'
-                  example: ['ja', 'ko']
+                  description: "ISO 639-1 language codes"
+                  example: ["ja", "ko"]
             keywords:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these keywords, or include only items with these keywords'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these keywords, or include only items with these keywords"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: integer
-                  description: 'TMDB keyword IDs'
+                  description: "TMDB keyword IDs"
                   example: [210024, 818]
           nullable: true
         includeAllReleasedItems:
           type: boolean
-          description: 'If true, include all released items regardless of release date (default: true for new configs)'
+          description: "If true, include all released items regardless of release date (default: true for new configs)"
           example: true
           nullable: true
         comingSoonRadarrServerId:
           type: integer
-          description: 'Selected Radarr server ID for coming soon monitored subtype'
+          description: "Selected Radarr server ID for coming soon monitored subtype"
           nullable: true
         comingSoonSonarrServerId:
           type: integer
-          description: 'Selected Sonarr server ID for coming soon monitored subtype'
+          description: "Selected Sonarr server ID for coming soon monitored subtype"
           nullable: true
         comingSoonFilterByTags:
           type: boolean
-          description: 'Enable tag filtering for coming soon monitored subtype'
+          description: "Enable tag filtering for coming soon monitored subtype"
           nullable: true
         comingSoonTagMode:
           type: string
-          enum: ['include', 'exclude']
-          description: 'Tag filter mode for coming soon monitored subtype'
+          enum: ["include", "exclude"]
+          description: "Tag filter mode for coming soon monitored subtype"
           nullable: true
         comingSoonRadarrTagIds:
           type: array
           items:
             type: integer
-          description: 'Radarr tag IDs to filter by for coming soon monitored subtype'
+          description: "Radarr tag IDs to filter by for coming soon monitored subtype"
           nullable: true
         comingSoonSonarrTagIds:
           type: array
           items:
             type: integer
-          description: 'Sonarr tag IDs to filter by for coming soon monitored subtype'
+          description: "Sonarr tag IDs to filter by for coming soon monitored subtype"
           nullable: true
         minimumPlays:
           type: integer
-          description: 'Minimum play count for Tautulli collections (defaults to 3 if not set, 1-100)'
+          description: "Minimum play count for Tautulli collections (defaults to 3 if not set, 1-100)"
           example: 3
           nullable: true
         tautulliStatType:
           type: string
-          enum: ['plays', 'duration']
-          description: 'Tautulli statistic type: plays (play count) or duration (watch time)'
-          example: 'plays'
+          enum: ["plays", "duration"]
+          description: "Tautulli statistic type: plays (play count) or duration (watch time)"
+          example: "plays"
           nullable: true
         searchMissingMovies:
           type: boolean
-          description: 'Auto-request missing movies'
+          description: "Auto-request missing movies"
           example: false
           nullable: true
         searchMissingTV:
           type: boolean
-          description: 'Auto-request missing TV shows'
+          description: "Auto-request missing TV shows"
           example: false
           nullable: true
         autoApproveMovies:
           type: boolean
-          description: 'Auto-approve movie requests'
+          description: "Auto-approve movie requests"
           example: false
           nullable: true
         autoApproveTV:
           type: boolean
-          description: 'Auto-approve TV show requests'
+          description: "Auto-approve TV show requests"
           example: false
           nullable: true
         maxSeasonsToRequest:
           type: integer
-          description: 'Max seasons for auto-approval (TV shows with more seasons require manual approval)'
+          description: "Max seasons for auto-approval (TV shows with more seasons require manual approval)"
           example: 5
           nullable: true
         seasonsPerShowLimit:
           type: integer
-          description: 'Limit each TV show to only the first X seasons (0 = all seasons)'
+          description: "Limit each TV show to only the first X seasons (0 = all seasons)"
           example: 2
           nullable: true
         seasonGrabOrder:
@@ -1373,18 +1373,18 @@ components:
             - first
             - latest
             - airing
-          description: 'Order to grab seasons: first N seasons (default), N latest seasons (including unreleased), or N most recently aired seasons'
-          example: 'first'
+          description: "Order to grab seasons: first N seasons (default), N latest seasons (including unreleased), or N most recently aired seasons"
+          example: "first"
           nullable: true
         minimumYear:
           type: integer
-          description: 'Only process movies/TV shows released on or after this year (0 = no limit)'
+          description: "Only process movies/TV shows released on or after this year (0 = no limit)"
           example: 2010
           nullable: true
         minimumImdbRating:
           type: number
           format: float
-          description: 'Only process movies/TV shows with IMDb rating >= this value (0 = no limit)'
+          description: "Only process movies/TV shows with IMDb rating >= this value (0 = no limit)"
           example: 6.8
           minimum: 0
           maximum: 10
@@ -1392,7 +1392,7 @@ components:
         minimumRottenTomatoesRating:
           type: number
           format: float
-          description: 'Only process movies/TV shows with Rotten Tomatoes critics score >= this value (0 = no limit)'
+          description: "Only process movies/TV shows with Rotten Tomatoes critics score >= this value (0 = no limit)"
           example: 70
           minimum: 0
           maximum: 100
@@ -1400,85 +1400,85 @@ components:
         minimumRottenTomatoesAudienceRating:
           type: number
           format: float
-          description: 'Only process movies/TV shows with Rotten Tomatoes audience score >= this value (0 = no limit)'
+          description: "Only process movies/TV shows with Rotten Tomatoes audience score >= this value (0 = no limit)"
           example: 75
           minimum: 0
           maximum: 100
           nullable: true
         filterSettings:
           type: object
-          description: 'Unified filter settings with include/exclude modes'
+          description: "Unified filter settings with include/exclude modes"
           properties:
             genres:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these genres, or include only items with these genres'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these genres, or include only items with these genres"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: integer
-                  description: 'TMDB genre IDs'
+                  description: "TMDB genre IDs"
                   example: [28, 53]
             countries:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items from these countries, or include only items from these countries'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items from these countries, or include only items from these countries"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: string
-                  description: 'ISO 3166-1 country codes'
-                  example: ['JP', 'KR']
+                  description: "ISO 3166-1 country codes"
+                  example: ["JP", "KR"]
             languages:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these languages, or include only items with these languages'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these languages, or include only items with these languages"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: string
-                  description: 'ISO 639-1 language codes'
-                  example: ['ja', 'ko']
+                  description: "ISO 639-1 language codes"
+                  example: ["ja", "ko"]
             keywords:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these keywords, or include only items with these keywords'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these keywords, or include only items with these keywords"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: integer
-                  description: 'TMDB keyword IDs'
+                  description: "TMDB keyword IDs"
                   example: [210024, 818]
           nullable: true
         traktCustomListUrl:
           type: string
-          description: 'Custom Trakt list URL (e.g., https://trakt.tv/users/username/lists/list-name or https://app.trakt.tv/users/username/lists/list-name)'
-          example: 'https://trakt.tv/users/username/lists/my-list'
+          description: "Custom Trakt list URL (e.g., https://trakt.tv/users/username/lists/list-name or https://app.trakt.tv/users/username/lists/list-name)"
+          example: "https://trakt.tv/users/username/lists/my-list"
           nullable: true
         tmdbCustomCollectionUrl:
           type: string
-          description: 'Custom TMDB collection or list URL (e.g., https://www.themoviedb.org/collection/123456 or https://www.themoviedb.org/list/310)'
-          example: 'https://www.themoviedb.org/list/310-my-movie-list'
+          description: "Custom TMDB collection or list URL (e.g., https://www.themoviedb.org/collection/123456 or https://www.themoviedb.org/list/310)"
+          example: "https://www.themoviedb.org/list/310-my-movie-list"
           nullable: true
         tmdbMovieSortBy:
           type: string
-          description: 'TMDB /discover/movie sort_by (only for TMDB Custom Advanced Filters)'
+          description: "TMDB /discover/movie sort_by (only for TMDB Custom Advanced Filters)"
           enum:
             - original_title.asc
             - original_title.desc
@@ -1498,7 +1498,7 @@ components:
           nullable: true
         tmdbTvSortBy:
           type: string
-          description: 'TMDB /discover/tv sort_by (only for TMDB Custom Advanced Filters)'
+          description: "TMDB /discover/tv sort_by (only for TMDB Custom Advanced Filters)"
           enum:
             - first_air_date.asc
             - first_air_date.desc
@@ -1521,13 +1521,13 @@ components:
           nullable: true
         imdbCustomListUrl:
           type: string
-          description: 'Custom IMDb list or watchlist URL (e.g., https://www.imdb.com/list/ls123456789/ or https://www.imdb.com/user/ur12345678/watchlist)'
-          example: 'https://www.imdb.com/list/ls123456789/'
+          description: "Custom IMDb list or watchlist URL (e.g., https://www.imdb.com/list/ls123456789/ or https://www.imdb.com/user/ur12345678/watchlist)"
+          example: "https://www.imdb.com/list/ls123456789/"
           nullable: true
         mdblistCustomListUrl:
           type: string
-          description: 'Custom MDBList list URL (e.g., https://mdblist.com/lists/username/listname)'
-          example: 'https://mdblist.com/lists/garycrawfordgc/netflix-shows'
+          description: "Custom MDBList list URL (e.g., https://mdblist.com/lists/username/listname)"
+          example: "https://mdblist.com/lists/garycrawfordgc/netflix-shows"
           nullable: true
         sortOrder:
           type: string
@@ -1543,48 +1543,48 @@ components:
             - date_added_asc
             - alphabetical_asc
             - alphabetical_desc
-          description: 'Sort order for collection items'
-          example: 'default'
-          default: 'default'
+          description: "Sort order for collection items"
+          example: "default"
+          default: "default"
           nullable: true
         personMinimumItems:
           type: number
-          description: 'Unified minimum items required to create actor/director collections'
+          description: "Unified minimum items required to create actor/director collections"
           example: 3
           nullable: true
         useSeparator:
           type: boolean
-          description: 'Create a separator collection for auto actor/director collections'
+          description: "Create a separator collection for auto actor/director collections"
           example: false
           nullable: true
         separatorTitle:
           type: string
-          description: 'Title for the separator collection'
-          example: 'Actors Collections'
+          description: "Title for the separator collection"
+          example: "Actors Collections"
           nullable: true
         excludeFromCollections:
           type: array
           items:
             type: string
-          description: 'Array of collection IDs to exclude items from (mutual exclusion)'
-          example: ['10001', '10002']
+          description: "Array of collection IDs to exclude items from (mutual exclusion)"
+          example: ["10001", "10002"]
           nullable: true
         timeRestriction:
           type: object
-          description: 'Time restriction settings for the collection'
+          description: "Time restriction settings for the collection"
           properties:
             alwaysActive:
               type: boolean
-              description: 'If true, collection is always active (default)'
+              description: "If true, collection is always active (default)"
               example: true
             removeFromPlexWhenInactive:
               type: boolean
-              description: 'If true, completely remove from Plex when inactive (old behavior)'
+              description: "If true, completely remove from Plex when inactive (old behavior)"
               example: false
               nullable: true
             inactiveVisibilityConfig:
               type: object
-              description: 'Visibility settings to use when collection is inactive (only used if removeFromPlexWhenInactive is false)'
+              description: "Visibility settings to use when collection is inactive (only used if removeFromPlexWhenInactive is false)"
               properties:
                 usersHome:
                   type: boolean
@@ -1596,7 +1596,7 @@ components:
                   example: false
                 libraryRecommended:
                   type: boolean
-                  description: 'Show in library recommended section when inactive'
+                  description: "Show in library recommended section when inactive"
                   example: true
               required:
                 - usersHome
@@ -1605,25 +1605,25 @@ components:
               nullable: true
             dateRanges:
               type: array
-              description: 'Date ranges when collection should be active (repeated annually)'
+              description: "Date ranges when collection should be active (repeated annually)"
               items:
                 type: object
                 properties:
                   startDate:
                     type: string
                     description: "DD-MM format (e.g., '05-12' for 5th December)"
-                    example: '05-12'
+                    example: "05-12"
                   endDate:
                     type: string
                     description: "DD-MM format (e.g., '26-12' for 26th December)"
-                    example: '26-12'
+                    example: "26-12"
                 required:
                   - startDate
                   - endDate
               nullable: true
             weeklySchedule:
               type: object
-              description: 'Days of the week when collection should be active'
+              description: "Days of the week when collection should be active"
               properties:
                 monday:
                   type: boolean
@@ -1651,34 +1651,34 @@ components:
         # Multi-source collection properties
         isMultiSource:
           type: boolean
-          description: 'Enable multi-source mode for combining multiple collection sources'
+          description: "Enable multi-source mode for combining multiple collection sources"
           example: false
           nullable: true
         sources:
           type: array
-          description: 'Array of source configurations for multi-source collections'
+          description: "Array of source configurations for multi-source collections"
           items:
-            $ref: '#/components/schemas/CollectionSourceConfig'
+            $ref: "#/components/schemas/CollectionSourceConfig"
           nullable: true
         combineMode:
           type: string
-          enum: ['interleaved', 'list_order', 'randomised', 'cycle_lists']
-          description: 'How to combine multiple sources: interleaved (alternate items), list_order (all from first, then second), randomised (shuffle all), cycle_lists (rotate active source)'
-          example: 'list_order'
+          enum: ["interleaved", "list_order", "randomised", "cycle_lists"]
+          description: "How to combine multiple sources: interleaved (alternate items), list_order (all from first, then second), randomised (shuffle all), cycle_lists (rotate active source)"
+          example: "list_order"
           nullable: true
         customSyncSchedule:
           type: object
-          description: 'Custom sync schedule configuration'
+          description: "Custom sync schedule configuration"
           properties:
             enabled:
               type: boolean
-              description: 'Enable custom sync schedule'
+              description: "Enable custom sync schedule"
               example: false
             scheduleType:
               type: string
-              enum: ['preset', 'custom']
-              description: 'Type of schedule: preset dropdown or custom cron'
-              example: 'preset'
+              enum: ["preset", "custom"]
+              description: "Type of schedule: preset dropdown or custom cron"
+              example: "preset"
             intervalHours:
               type: number
               description: "Legacy field for backward compatibility (when scheduleType === 'preset')"
@@ -1689,41 +1689,41 @@ components:
             preset:
               type: string
               description: "Preset option key (e.g., '10m', '30m', '1h', '6h', '1d', '1w')"
-              example: '1d'
+              example: "1d"
               nullable: true
             customCron:
               type: string
               description: "Custom cron expression (when scheduleType === 'custom')"
-              example: '0 9 * * MON'
+              example: "0 9 * * MON"
               nullable: true
             startNow:
               type: boolean
-              description: 'If true, start immediately; if false, use startDate/startTime'
+              description: "If true, start immediately; if false, use startDate/startTime"
               example: true
             startDate:
               type: string
               description: "Start date in DD-MM format (e.g., '01-01' for January 1st)"
-              example: '01-01'
-              pattern: '^(0[1-9]|[12][0-9]|3[01])-(0[1-9]|1[0-2])$'
+              example: "01-01"
+              pattern: "^(0[1-9]|[12][0-9]|3[01])-(0[1-9]|1[0-2])$"
               nullable: true
             startTime:
               type: string
               description: "Start time in HH:MM format (e.g., '09:00')"
-              example: '09:00'
-              pattern: '^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$'
+              example: "09:00"
+              pattern: "^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$"
               nullable: true
             firstSyncAt:
               type: string
               format: date-time
-              description: 'ISO timestamp of when this schedule was first created (for persistence across restarts)'
-              example: '2024-01-01T09:00:00.000Z'
+              description: "ISO timestamp of when this schedule was first created (for persistence across restarts)"
+              example: "2024-01-01T09:00:00.000Z"
               nullable: true
           nullable: true
         downloadMode:
           type: string
-          enum: ['overseerr', 'direct']
-          description: 'Download method: overseerr (requests) or direct (*arr)'
-          example: 'overseerr'
+          enum: ["overseerr", "direct"]
+          description: "Download method: overseerr (requests) or direct (*arr)"
+          example: "overseerr"
           nullable: true
         directDownloadRadarrServerId:
           type: integer
@@ -1738,7 +1738,7 @@ components:
         directDownloadRadarrRootFolder:
           type: string
           description: "Selected Radarr root folder path for movies (when downloadMode is 'direct')"
-          example: '/movies'
+          example: "/movies"
           nullable: true
         directDownloadRadarrTags:
           type: array
@@ -1770,7 +1770,7 @@ components:
         directDownloadSonarrRootFolder:
           type: string
           description: "Selected Sonarr root folder path for TV shows (when downloadMode is 'direct')"
-          example: '/tv'
+          example: "/tv"
           nullable: true
         directDownloadSonarrTags:
           type: array
@@ -1789,17 +1789,17 @@ components:
           description: "Override Sonarr monitor type for TV shows (when downloadMode is 'direct')"
           enum:
             [
-              'all',
-              'future',
-              'missing',
-              'existing',
-              'recent',
-              'pilot',
-              'firstSeason',
-              'lastSeason',
-              'none',
+              "all",
+              "future",
+              "missing",
+              "existing",
+              "recent",
+              "pilot",
+              "firstSeason",
+              "lastSeason",
+              "none",
             ]
-          example: 'all'
+          example: "all"
           nullable: true
         directDownloadSonarrSearchOnAdd:
           type: boolean
@@ -1819,7 +1819,7 @@ components:
         overseerrRadarrRootFolder:
           type: string
           description: "Override Radarr root folder path for Overseerr movie requests (when downloadMode is 'overseerr')"
-          example: '/movies'
+          example: "/movies"
           nullable: true
         overseerrRadarrTags:
           type: array
@@ -1841,7 +1841,7 @@ components:
         overseerrSonarrRootFolder:
           type: string
           description: "Override Sonarr root folder path for Overseerr TV requests (when downloadMode is 'overseerr')"
-          example: '/tv'
+          example: "/tv"
           nullable: true
         overseerrSonarrTags:
           type: array
@@ -1852,21 +1852,21 @@ components:
           nullable: true
         showUnwatchedOnly:
           type: boolean
-          description: 'Create a smart collection that shows only unwatched items from this collection'
+          description: "Create a smart collection that shows only unwatched items from this collection"
           example: false
           nullable: true
         smartCollectionSort:
           type: object
-          description: 'Sort option for smart collections'
+          description: "Sort option for smart collections"
           properties:
             value:
               type: string
               description: "The sort parameter value (e.g., 'year:desc', 'titleSort', 'rating:desc')"
-              example: 'year:desc'
+              example: "year:desc"
             label:
               type: string
-              description: 'Human-readable label for the dropdown'
-              example: 'Year (Newest First)'
+              description: "Human-readable label for the dropdown"
+              example: "Year (Newest First)"
           nullable: true
       required:
         - id
@@ -1876,41 +1876,41 @@ components:
 
     CollectionConfigUpdate:
       type: object
-      description: 'Schema for updating collection configuration settings (excludes computed fields)'
+      description: "Schema for updating collection configuration settings (excludes computed fields)"
       properties:
         id:
           type: string
-          description: 'Unique collection identifier (sequential number starting from 10000)'
-          example: '10000'
+          description: "Unique collection identifier (sequential number starting from 10000)"
+          example: "10000"
         name:
           type: string
-          example: 'User Requests'
+          example: "User Requests"
         type:
           type: string
           enum:
             [
-              'overseerr',
-              'tautulli',
-              'trakt',
-              'tmdb',
-              'imdb',
-              'mdblist',
-              'letterboxd',
-              'networks',
-              'originals',
-              'plex',
-              'multi-source',
-              'anilist',
-              'myanimelist',
-              'radarrtag',
-              'sonarrtag',
-              'comingsoon',
-              'filtered_hub',
+              "overseerr",
+              "tautulli",
+              "trakt",
+              "tmdb",
+              "imdb",
+              "mdblist",
+              "letterboxd",
+              "networks",
+              "originals",
+              "plex",
+              "multi-source",
+              "anilist",
+              "myanimelist",
+              "radarrtag",
+              "sonarrtag",
+              "comingsoon",
+              "filtered_hub",
             ]
-          example: 'overseerr'
+          example: "overseerr"
         subtype:
           type: string
-          example: 'users'
+          example: "users"
         template:
           type: string
           example: "{nickname}'s Requests"
@@ -1927,85 +1927,85 @@ components:
         customPoster:
           oneOf:
             - type: string
-              description: 'Filename of custom poster image (legacy format)'
-              example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
+              description: "Filename of custom poster image (legacy format)"
+              example: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
             - type: object
-              description: 'Per-library poster mapping (libraryId -> filename)'
+              description: "Per-library poster mapping (libraryId -> filename)"
               additionalProperties:
                 type: string
               example:
-                lib1: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
-                lib2: 'a12bc34d-58cc-4372-a567-0e02b2c3d480.jpg'
+                lib1: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
+                lib2: "a12bc34d-58cc-4372-a567-0e02b2c3d480.jpg"
           nullable: true
         autoPoster:
           type: boolean
-          description: 'Auto-generate poster during sync'
+          description: "Auto-generate poster during sync"
           example: true
           nullable: true
         autoPosterTemplate:
           type: integer
-          description: 'Template ID for auto-generated posters (null for default template)'
+          description: "Template ID for auto-generated posters (null for default template)"
           example: 1
           nullable: true
         useTmdbFranchisePoster:
           type: boolean
-          description: 'Use TMDB franchise poster instead of auto-generated poster (only for TMDB auto_franchise collections)'
+          description: "Use TMDB franchise poster instead of auto-generated poster (only for TMDB auto_franchise collections)"
           example: false
           nullable: true
         hideIndividualItems:
           type: boolean
-          description: 'Hide individual items, show collection (collectionMode = 1, only for TMDB auto_franchise collections)'
+          description: "Hide individual items, show collection (collectionMode = 1, only for TMDB auto_franchise collections)"
           example: false
           nullable: true
         applyOverlaysDuringSync:
           type: boolean
-          description: 'Apply item overlays during sync (for Coming Soon collections)'
+          description: "Apply item overlays during sync (for Coming Soon collections)"
           example: true
           nullable: true
         customWallpaper:
           oneOf:
             - type: string
-              description: 'Filename of custom wallpaper image (art)'
-              example: 'wallpaper-12345.jpg'
+              description: "Filename of custom wallpaper image (art)"
+              example: "wallpaper-12345.jpg"
             - type: object
-              description: 'Per-library wallpaper mapping (libraryId -> filename)'
+              description: "Per-library wallpaper mapping (libraryId -> filename)"
               additionalProperties:
                 type: string
               example:
-                lib1: 'wallpaper-12345.jpg'
-                lib2: 'wallpaper-67890.jpg'
+                lib1: "wallpaper-12345.jpg"
+                lib2: "wallpaper-67890.jpg"
           nullable: true
         customSummary:
           type: string
-          description: 'Custom summary/description text for the collection'
-          example: 'A curated collection of the best movies'
+          description: "Custom summary/description text for the collection"
+          example: "A curated collection of the best movies"
           nullable: true
         customTheme:
           oneOf:
             - type: string
-              description: 'Filename of custom theme music file'
-              example: 'theme-12345.mp3'
+              description: "Filename of custom theme music file"
+              example: "theme-12345.mp3"
             - type: object
-              description: 'Per-library theme mapping (libraryId -> filename)'
+              description: "Per-library theme mapping (libraryId -> filename)"
               additionalProperties:
                 type: string
               example:
-                lib1: 'theme-12345.mp3'
-                lib2: 'theme-67890.mp3'
+                lib1: "theme-12345.mp3"
+                lib2: "theme-67890.mp3"
           nullable: true
         enableCustomWallpaper:
           type: boolean
-          description: 'Enable custom wallpaper sync to Plex'
+          description: "Enable custom wallpaper sync to Plex"
           example: false
           nullable: true
         enableCustomSummary:
           type: boolean
-          description: 'Enable custom summary sync to Plex'
+          description: "Enable custom summary sync to Plex"
           example: false
           nullable: true
         enableCustomTheme:
           type: boolean
-          description: 'Enable custom theme sync to Plex'
+          description: "Enable custom theme sync to Plex"
           example: false
           nullable: true
         visibilityConfig:
@@ -2021,7 +2021,7 @@ components:
               example: false
             libraryRecommended:
               type: boolean
-              description: 'Show in library recommended section'
+              description: "Show in library recommended section"
               example: false
           required:
             - usersHome
@@ -2032,37 +2032,37 @@ components:
           example: 20
         mediaType:
           type: string
-          enum: ['movie', 'tv', 'both']
-          example: 'both'
+          enum: ["movie", "tv", "both"]
+          example: "both"
         libraryIds:
           type: array
           items:
             type: string
           description: "Array of selected library IDs (['all'] for all libraries)"
-          example: ['1', '2']
+          example: ["1", "2"]
           nullable: true
         libraryName:
           type: string
-          description: 'Selected library name for display'
-          example: 'Movies'
+          description: "Selected library name for display"
+          example: "Movies"
           nullable: true
         sortOrderHome:
           type: integer
-          description: 'Order for Plex home screen (creation time based)'
+          description: "Order for Plex home screen (creation time based)"
           example: 0
           nullable: true
         sortOrderLibrary:
           type: integer
-          description: 'Position in library (0 for A-Z section, 1+ for promoted section)'
+          description: "Position in library (0 for A-Z section, 1+ for promoted section)"
           example: 0
           nullable: true
         isLibraryPromoted:
           type: boolean
-          description: 'true = promoted section (uses exclamation marks), false = A-Z section'
+          description: "true = promoted section (uses exclamation marks), false = A-Z section"
           example: true
         randomizeHomeOrder:
           type: boolean
-          description: 'If true, randomize position amongst other randomized items on home screen'
+          description: "If true, randomize position amongst other randomized items on home screen"
           example: false
           nullable: true
         parentConfigId:
@@ -2077,33 +2077,33 @@ components:
           nullable: true
         customDays:
           type: integer
-          description: 'Number of days for Tautulli collections (required for Tautulli type)'
+          description: "Number of days for Tautulli collections (required for Tautulli type)"
           example: 30
           nullable: true
         createPlaceholdersForMissing:
           type: boolean
-          description: 'Create placeholder files for missing items (enabled by default for Coming Soon collections)'
+          description: "Create placeholder files for missing items (enabled by default for Coming Soon collections)"
           example: false
           nullable: true
         placeholderDaysAhead:
           type: integer
-          description: 'Days to look ahead for release dates when creating placeholders (default: 360)'
+          description: "Days to look ahead for release dates when creating placeholders (default: 360)"
           example: 360
           nullable: true
         placeholderReleasedDays:
           type: integer
-          description: 'Days to keep released items with overlay before cleanup (default: 7)'
+          description: "Days to keep released items with overlay before cleanup (default: 7)"
           example: 7
           nullable: true
         placeholderMinimumYear:
           type: integer
-          description: 'Only include placeholder items released on or after this year (0 = no limit)'
+          description: "Only include placeholder items released on or after this year (0 = no limit)"
           example: 2010
           nullable: true
         placeholderMinimumImdbRating:
           type: number
           format: float
-          description: 'Only include placeholder items with IMDb rating >= this value (0 = no limit)'
+          description: "Only include placeholder items with IMDb rating >= this value (0 = no limit)"
           example: 6.8
           minimum: 0
           maximum: 10
@@ -2111,7 +2111,7 @@ components:
         placeholderMinimumRottenTomatoesRating:
           type: number
           format: float
-          description: 'Only include placeholder items with Rotten Tomatoes critics score >= this value (0 = no limit)'
+          description: "Only include placeholder items with Rotten Tomatoes critics score >= this value (0 = no limit)"
           example: 70
           minimum: 0
           maximum: 100
@@ -2119,151 +2119,151 @@ components:
         placeholderMinimumRottenTomatoesAudienceRating:
           type: number
           format: float
-          description: 'Only include placeholder items with Rotten Tomatoes audience score >= this value (0 = no limit)'
+          description: "Only include placeholder items with Rotten Tomatoes audience score >= this value (0 = no limit)"
           example: 75
           minimum: 0
           maximum: 100
           nullable: true
         placeholderFilterSettings:
           type: object
-          description: 'Unified filter settings for placeholders with include/exclude modes'
+          description: "Unified filter settings for placeholders with include/exclude modes"
           properties:
             genres:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these genres, or include only items with these genres'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these genres, or include only items with these genres"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: integer
-                  description: 'TMDB genre IDs'
+                  description: "TMDB genre IDs"
                   example: [28, 53]
             countries:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items from these countries, or include only items from these countries'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items from these countries, or include only items from these countries"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: string
-                  description: 'ISO 3166-1 country codes'
-                  example: ['JP', 'KR']
+                  description: "ISO 3166-1 country codes"
+                  example: ["JP", "KR"]
             languages:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these languages, or include only items with these languages'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these languages, or include only items with these languages"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: string
-                  description: 'ISO 639-1 language codes'
-                  example: ['ja', 'ko']
+                  description: "ISO 639-1 language codes"
+                  example: ["ja", "ko"]
             keywords:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these keywords, or include only items with these keywords'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these keywords, or include only items with these keywords"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: integer
-                  description: 'TMDB keyword IDs'
+                  description: "TMDB keyword IDs"
                   example: [210024, 818]
           nullable: true
         includeAllReleasedItems:
           type: boolean
-          description: 'If true, include all released items regardless of release date (default: true for new configs)'
+          description: "If true, include all released items regardless of release date (default: true for new configs)"
           example: true
           nullable: true
         comingSoonRadarrServerId:
           type: integer
-          description: 'Selected Radarr server ID for coming soon monitored subtype'
+          description: "Selected Radarr server ID for coming soon monitored subtype"
           nullable: true
         comingSoonSonarrServerId:
           type: integer
-          description: 'Selected Sonarr server ID for coming soon monitored subtype'
+          description: "Selected Sonarr server ID for coming soon monitored subtype"
           nullable: true
         comingSoonFilterByTags:
           type: boolean
-          description: 'Enable tag filtering for coming soon monitored subtype'
+          description: "Enable tag filtering for coming soon monitored subtype"
           nullable: true
         comingSoonTagMode:
           type: string
-          enum: ['include', 'exclude']
-          description: 'Tag filter mode for coming soon monitored subtype'
+          enum: ["include", "exclude"]
+          description: "Tag filter mode for coming soon monitored subtype"
           nullable: true
         comingSoonRadarrTagIds:
           type: array
           items:
             type: integer
-          description: 'Radarr tag IDs to filter by for coming soon monitored subtype'
+          description: "Radarr tag IDs to filter by for coming soon monitored subtype"
           nullable: true
         comingSoonSonarrTagIds:
           type: array
           items:
             type: integer
-          description: 'Sonarr tag IDs to filter by for coming soon monitored subtype'
+          description: "Sonarr tag IDs to filter by for coming soon monitored subtype"
           nullable: true
         minimumPlays:
           type: integer
-          description: 'Minimum play count for Tautulli collections (defaults to 3 if not set, 1-100)'
+          description: "Minimum play count for Tautulli collections (defaults to 3 if not set, 1-100)"
           example: 3
           nullable: true
         tautulliStatType:
           type: string
-          enum: ['plays', 'duration']
-          example: 'plays'
+          enum: ["plays", "duration"]
+          example: "plays"
           nullable: true
         libraryNames:
           type: array
           items:
             type: string
-          description: 'Array of selected library names for display'
-          example: ['Movies', 'TV Shows']
+          description: "Array of selected library names for display"
+          example: ["Movies", "TV Shows"]
           nullable: true
         searchMissingMovies:
           type: boolean
-          description: 'Automatically search for missing movies'
+          description: "Automatically search for missing movies"
           example: false
           nullable: true
         searchMissingTV:
           type: boolean
-          description: 'Automatically search for missing TV shows'
+          description: "Automatically search for missing TV shows"
           example: false
           nullable: true
         autoApproveMovies:
           type: boolean
-          description: 'Auto-approve movie requests'
+          description: "Auto-approve movie requests"
           example: false
           nullable: true
         autoApproveTV:
           type: boolean
-          description: 'Auto-approve TV show requests'
+          description: "Auto-approve TV show requests"
           example: false
           nullable: true
         maxSeasonsToRequest:
           type: integer
-          description: 'Max seasons for auto-approval (TV shows with more seasons require manual approval)'
+          description: "Max seasons for auto-approval (TV shows with more seasons require manual approval)"
           example: 5
           nullable: true
         seasonsPerShowLimit:
           type: integer
-          description: 'Limit each TV show to only the first X seasons (0 = all seasons)'
+          description: "Limit each TV show to only the first X seasons (0 = all seasons)"
           example: 2
           nullable: true
         seasonGrabOrder:
@@ -2272,18 +2272,18 @@ components:
             - first
             - latest
             - airing
-          description: 'Order to grab seasons: first N seasons (default), N latest seasons (including unreleased), or N most recently aired seasons'
-          example: 'first'
+          description: "Order to grab seasons: first N seasons (default), N latest seasons (including unreleased), or N most recently aired seasons"
+          example: "first"
           nullable: true
         minimumYear:
           type: integer
-          description: 'Only process movies/TV shows released on or after this year (0 = no limit)'
+          description: "Only process movies/TV shows released on or after this year (0 = no limit)"
           example: 2010
           nullable: true
         minimumImdbRating:
           type: number
           format: float
-          description: 'Only process movies/TV shows with IMDb rating >= this value (0 = no limit)'
+          description: "Only process movies/TV shows with IMDb rating >= this value (0 = no limit)"
           example: 6.8
           minimum: 0
           maximum: 10
@@ -2291,7 +2291,7 @@ components:
         minimumRottenTomatoesRating:
           type: number
           format: float
-          description: 'Only process movies/TV shows with Rotten Tomatoes critics score >= this value (0 = no limit)'
+          description: "Only process movies/TV shows with Rotten Tomatoes critics score >= this value (0 = no limit)"
           example: 70
           minimum: 0
           maximum: 100
@@ -2299,101 +2299,101 @@ components:
         minimumRottenTomatoesAudienceRating:
           type: number
           format: float
-          description: 'Only process movies/TV shows with Rotten Tomatoes audience score >= this value (0 = no limit)'
+          description: "Only process movies/TV shows with Rotten Tomatoes audience score >= this value (0 = no limit)"
           example: 75
           minimum: 0
           maximum: 100
           nullable: true
         filterSettings:
           type: object
-          description: 'Unified filter settings with include/exclude modes'
+          description: "Unified filter settings with include/exclude modes"
           properties:
             genres:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these genres, or include only items with these genres'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these genres, or include only items with these genres"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: integer
-                  description: 'TMDB genre IDs'
+                  description: "TMDB genre IDs"
                   example: [28, 53]
             countries:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items from these countries, or include only items from these countries'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items from these countries, or include only items from these countries"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: string
-                  description: 'ISO 3166-1 country codes'
-                  example: ['JP', 'KR']
+                  description: "ISO 3166-1 country codes"
+                  example: ["JP", "KR"]
             languages:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these languages, or include only items with these languages'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these languages, or include only items with these languages"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: string
-                  description: 'ISO 639-1 language codes'
-                  example: ['ja', 'ko']
+                  description: "ISO 639-1 language codes"
+                  example: ["ja", "ko"]
             keywords:
               type: object
               properties:
                 mode:
                   type: string
-                  enum: ['exclude', 'include']
-                  description: 'Filter mode: exclude items with these keywords, or include only items with these keywords'
-                  example: 'exclude'
+                  enum: ["exclude", "include"]
+                  description: "Filter mode: exclude items with these keywords, or include only items with these keywords"
+                  example: "exclude"
                 values:
                   type: array
                   items:
                     type: integer
-                  description: 'TMDB keyword IDs'
+                  description: "TMDB keyword IDs"
                   example: [210024, 818]
           nullable: true
         traktCustomListUrl:
           type: string
-          description: 'Custom Trakt list URL (e.g., https://trakt.tv/users/username/lists/list-name or https://app.trakt.tv/users/username/lists/list-name)'
-          example: 'https://trakt.tv/users/username/lists/my-list'
+          description: "Custom Trakt list URL (e.g., https://trakt.tv/users/username/lists/list-name or https://app.trakt.tv/users/username/lists/list-name)"
+          example: "https://trakt.tv/users/username/lists/my-list"
           nullable: true
         tmdbCustomCollectionUrl:
           type: string
-          description: 'Custom TMDB collection or list URL (e.g., https://www.themoviedb.org/collection/123456 or https://www.themoviedb.org/list/310)'
-          example: 'https://www.themoviedb.org/list/310-my-movie-list'
+          description: "Custom TMDB collection or list URL (e.g., https://www.themoviedb.org/collection/123456 or https://www.themoviedb.org/list/310)"
+          example: "https://www.themoviedb.org/list/310-my-movie-list"
           nullable: true
         imdbCustomListUrl:
           type: string
-          description: 'Custom IMDb list or watchlist URL (e.g., https://www.imdb.com/list/ls123456789/ or https://www.imdb.com/user/ur12345678/watchlist)'
-          example: 'https://www.imdb.com/list/ls123456789/'
+          description: "Custom IMDb list or watchlist URL (e.g., https://www.imdb.com/list/ls123456789/ or https://www.imdb.com/user/ur12345678/watchlist)"
+          example: "https://www.imdb.com/list/ls123456789/"
           nullable: true
         mdblistCustomListUrl:
           type: string
-          description: 'Custom MDBList list URL (e.g., https://mdblist.com/lists/username/listname)'
-          example: 'https://mdblist.com/lists/garycrawfordgc/netflix-shows'
+          description: "Custom MDBList list URL (e.g., https://mdblist.com/lists/username/listname)"
+          example: "https://mdblist.com/lists/garycrawfordgc/netflix-shows"
           nullable: true
         letterboxdCustomListUrl:
           type: string
-          description: 'Custom Letterboxd list URL (e.g., https://letterboxd.com/user/list/list-name/)'
-          example: 'https://letterboxd.com/user/list/my-list/'
+          description: "Custom Letterboxd list URL (e.g., https://letterboxd.com/user/list/list-name/)"
+          example: "https://letterboxd.com/user/list/my-list/"
           nullable: true
         networksCountry:
           type: string
           description: "Selected country for Networks collections (e.g., 'united-states', 'world')"
-          example: 'united-states'
+          example: "united-states"
           nullable: true
         sortOrder:
           type: string
@@ -2409,77 +2409,77 @@ components:
             - date_added_asc
             - alphabetical_asc
             - alphabetical_desc
-          description: 'Sort order for collection items'
-          example: 'default'
-          default: 'default'
+          description: "Sort order for collection items"
+          example: "default"
+          default: "default"
           nullable: true
         personMinimumItems:
           type: number
-          description: 'Unified minimum items required to create actor/director collections'
+          description: "Unified minimum items required to create actor/director collections"
           example: 3
           nullable: true
         useSeparator:
           type: boolean
-          description: 'Create a separator collection for auto actor/director collections'
+          description: "Create a separator collection for auto actor/director collections"
           example: false
           nullable: true
         separatorTitle:
           type: string
-          description: 'Title for the separator collection'
-          example: 'Actors Collections'
+          description: "Title for the separator collection"
+          example: "Actors Collections"
           nullable: true
         excludeFromCollections:
           type: array
           items:
             type: string
-          description: 'Array of collection IDs to exclude items from (mutual exclusion)'
-          example: ['10001', '10002']
+          description: "Array of collection IDs to exclude items from (mutual exclusion)"
+          example: ["10001", "10002"]
           nullable: true
         timeRestriction:
           type: object
-          description: 'Time restriction settings for the collection'
+          description: "Time restriction settings for the collection"
           properties:
             alwaysActive:
               type: boolean
-              description: 'If true, collection is always active (default)'
+              description: "If true, collection is always active (default)"
               example: true
             removeFromPlexWhenInactive:
               type: boolean
-              description: 'If true, remove collection from Plex when inactive'
+              description: "If true, remove collection from Plex when inactive"
               example: false
             timeSlots:
               type: array
-              description: 'Array of time slot objects'
+              description: "Array of time slot objects"
               items:
                 type: object
                 properties:
                   startTime:
                     type: string
-                    description: 'HH:MM format'
-                    example: '09:00'
+                    description: "HH:MM format"
+                    example: "09:00"
                   endTime:
                     type: string
-                    description: 'HH:MM format'
-                    example: '17:00'
+                    description: "HH:MM format"
+                    example: "17:00"
               nullable: true
             dateRanges:
               type: array
-              description: 'Array of date range objects'
+              description: "Array of date range objects"
               items:
                 type: object
                 properties:
                   startDate:
                     type: string
-                    description: 'DD-MM format'
-                    example: '05-12'
+                    description: "DD-MM format"
+                    example: "05-12"
                   endDate:
                     type: string
-                    description: 'DD-MM format'
-                    example: '26-12'
+                    description: "DD-MM format"
+                    example: "26-12"
               nullable: true
             weeklySchedule:
               type: object
-              description: 'Days of the week when collection should be active'
+              description: "Days of the week when collection should be active"
               properties:
                 monday:
                   type: boolean
@@ -2506,55 +2506,55 @@ components:
           nullable: true
         collectionType:
           type: string
-          enum: ['default_plex_hub', 'agregarr_created', 'pre_existing']
-          description: 'Backend categorization system for different collection types'
-          example: 'agregarr_created'
+          enum: ["default_plex_hub", "agregarr_created", "pre_existing"]
+          description: "Backend categorization system for different collection types"
+          example: "agregarr_created"
           nullable: true
         isLinked:
           type: boolean
-          description: 'Whether collection is actively linked to other collections'
+          description: "Whether collection is actively linked to other collections"
           example: true
           nullable: true
         isUnlinked:
           type: boolean
-          description: 'True if this collection was deliberately unlinked and should not be grouped with siblings'
+          description: "True if this collection was deliberately unlinked and should not be grouped with siblings"
           example: false
           nullable: true
         missing:
           type: boolean
-          description: 'True if collection no longer exists in Plex'
+          description: "True if collection no longer exists in Plex"
           example: false
         # Multi-source collection properties
         isMultiSource:
           type: boolean
-          description: 'Enable multi-source mode for combining multiple collection sources'
+          description: "Enable multi-source mode for combining multiple collection sources"
           example: false
           nullable: true
         sources:
           type: array
-          description: 'Array of source configurations for multi-source collections'
+          description: "Array of source configurations for multi-source collections"
           items:
-            $ref: '#/components/schemas/CollectionSourceConfig'
+            $ref: "#/components/schemas/CollectionSourceConfig"
           nullable: true
         combineMode:
           type: string
-          enum: ['interleaved', 'list_order', 'randomised', 'cycle_lists']
-          description: 'How to combine multiple sources: interleaved (alternate items), list_order (all from first, then second), randomised (shuffle all), cycle_lists (rotate active source)'
-          example: 'list_order'
+          enum: ["interleaved", "list_order", "randomised", "cycle_lists"]
+          description: "How to combine multiple sources: interleaved (alternate items), list_order (all from first, then second), randomised (shuffle all), cycle_lists (rotate active source)"
+          example: "list_order"
           nullable: true
         customSyncSchedule:
           type: object
-          description: 'Custom sync schedule configuration'
+          description: "Custom sync schedule configuration"
           properties:
             enabled:
               type: boolean
-              description: 'Enable custom sync schedule'
+              description: "Enable custom sync schedule"
               example: false
             scheduleType:
               type: string
-              enum: ['preset', 'custom']
-              description: 'Type of schedule: preset dropdown or custom cron'
-              example: 'preset'
+              enum: ["preset", "custom"]
+              description: "Type of schedule: preset dropdown or custom cron"
+              example: "preset"
             intervalHours:
               type: number
               description: "Legacy field for backward compatibility (when scheduleType === 'preset')"
@@ -2565,41 +2565,41 @@ components:
             preset:
               type: string
               description: "Preset option key (e.g., '10m', '30m', '1h', '6h', '1d', '1w')"
-              example: '1d'
+              example: "1d"
               nullable: true
             customCron:
               type: string
               description: "Custom cron expression (when scheduleType === 'custom')"
-              example: '0 9 * * MON'
+              example: "0 9 * * MON"
               nullable: true
             startNow:
               type: boolean
-              description: 'If true, start immediately; if false, use startDate/startTime'
+              description: "If true, start immediately; if false, use startDate/startTime"
               example: true
             startDate:
               type: string
               description: "Start date in DD-MM format (e.g., '01-01' for January 1st)"
-              example: '01-01'
-              pattern: '^(0[1-9]|[12][0-9]|3[01])-(0[1-9]|1[0-2])$'
+              example: "01-01"
+              pattern: "^(0[1-9]|[12][0-9]|3[01])-(0[1-9]|1[0-2])$"
               nullable: true
             startTime:
               type: string
               description: "Start time in HH:MM format (e.g., '09:00')"
-              example: '09:00'
-              pattern: '^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$'
+              example: "09:00"
+              pattern: "^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$"
               nullable: true
             firstSyncAt:
               type: string
               format: date-time
-              description: 'ISO timestamp of when this schedule was first created (for persistence across restarts)'
-              example: '2024-01-01T09:00:00.000Z'
+              description: "ISO timestamp of when this schedule was first created (for persistence across restarts)"
+              example: "2024-01-01T09:00:00.000Z"
               nullable: true
           nullable: true
         downloadMode:
           type: string
-          enum: ['overseerr', 'direct']
-          description: 'Download method: overseerr (requests) or direct (*arr)'
-          example: 'overseerr'
+          enum: ["overseerr", "direct"]
+          description: "Download method: overseerr (requests) or direct (*arr)"
+          example: "overseerr"
           nullable: true
         directDownloadRadarrServerId:
           type: integer
@@ -2614,7 +2614,7 @@ components:
         directDownloadRadarrRootFolder:
           type: string
           description: "Selected Radarr root folder path for movies (when downloadMode is 'direct')"
-          example: '/movies'
+          example: "/movies"
           nullable: true
         directDownloadRadarrTags:
           type: array
@@ -2646,7 +2646,7 @@ components:
         directDownloadSonarrRootFolder:
           type: string
           description: "Selected Sonarr root folder path for TV shows (when downloadMode is 'direct')"
-          example: '/tv'
+          example: "/tv"
           nullable: true
         directDownloadSonarrTags:
           type: array
@@ -2665,17 +2665,17 @@ components:
           description: "Override Sonarr monitor type for TV shows (when downloadMode is 'direct')"
           enum:
             [
-              'all',
-              'future',
-              'missing',
-              'existing',
-              'recent',
-              'pilot',
-              'firstSeason',
-              'lastSeason',
-              'none',
+              "all",
+              "future",
+              "missing",
+              "existing",
+              "recent",
+              "pilot",
+              "firstSeason",
+              "lastSeason",
+              "none",
             ]
-          example: 'all'
+          example: "all"
           nullable: true
         directDownloadSonarrSearchOnAdd:
           type: boolean
@@ -2695,7 +2695,7 @@ components:
         overseerrRadarrRootFolder:
           type: string
           description: "Override Radarr root folder path for Overseerr movie requests (when downloadMode is 'overseerr')"
-          example: '/movies'
+          example: "/movies"
           nullable: true
         overseerrRadarrTags:
           type: array
@@ -2717,7 +2717,7 @@ components:
         overseerrSonarrRootFolder:
           type: string
           description: "Override Sonarr root folder path for Overseerr TV requests (when downloadMode is 'overseerr')"
-          example: '/tv'
+          example: "/tv"
           nullable: true
         overseerrSonarrTags:
           type: array
@@ -2728,21 +2728,21 @@ components:
           nullable: true
         showUnwatchedOnly:
           type: boolean
-          description: 'Create a smart collection that shows only unwatched items from this collection'
+          description: "Create a smart collection that shows only unwatched items from this collection"
           example: false
           nullable: true
         smartCollectionSort:
           type: object
-          description: 'Sort option for smart collections'
+          description: "Sort option for smart collections"
           properties:
             value:
               type: string
               description: "The sort parameter value (e.g., 'year:desc', 'titleSort', 'rating:desc')"
-              example: 'year:desc'
+              example: "year:desc"
             label:
               type: string
-              description: 'Human-readable label for the dropdown'
-              example: 'Year (Newest First)'
+              description: "Human-readable label for the dropdown"
+              example: "Year (Newest First)"
           nullable: true
       required:
         - id
@@ -2755,79 +2755,79 @@ components:
 
     CollectionSourceConfig:
       type: object
-      description: 'Individual source configuration for multi-source collections'
+      description: "Individual source configuration for multi-source collections"
       properties:
         id:
           type: string
-          description: 'Unique identifier for this source within the collection'
-          example: 'source-1234567890'
+          description: "Unique identifier for this source within the collection"
+          example: "source-1234567890"
         type:
           type: string
           enum:
             [
-              'trakt',
-              'tmdb',
-              'imdb',
-              'mdblist',
-              'letterboxd',
-              'tautulli',
-              'overseerr',
-              'networks',
-              'originals',
-              'plex',
-              'anilist',
-              'myanimelist',
-              'radarrtag',
-              'sonarrtag',
-              'comingsoon',
-              'filtered_hub',
+              "trakt",
+              "tmdb",
+              "imdb",
+              "mdblist",
+              "letterboxd",
+              "tautulli",
+              "overseerr",
+              "networks",
+              "originals",
+              "plex",
+              "anilist",
+              "myanimelist",
+              "radarrtag",
+              "sonarrtag",
+              "comingsoon",
+              "filtered_hub",
             ]
-          description: 'Type of collection source'
-          example: 'trakt'
+          description: "Type of collection source"
+          example: "trakt"
         subtype:
           type: string
-          description: 'Sub-type of the collection source'
-          example: 'trending'
+          description: "Sub-type of the collection source"
+          example: "trending"
           nullable: true
         customUrl:
           type: string
-          description: 'Custom URL for list-based sources (Trakt, TMDB, IMDb, Letterboxd)'
-          example: 'https://trakt.tv/users/username/lists/my-list'
+          description: "Custom URL for list-based sources (Trakt, TMDB, IMDb, Letterboxd)"
+          example: "https://trakt.tv/users/username/lists/my-list"
           nullable: true
         timePeriod:
           type: string
-          enum: ['daily', 'weekly', 'monthly', 'all']
-          description: 'Time period for time-based sources'
-          example: 'weekly'
+          enum: ["daily", "weekly", "monthly", "all"]
+          description: "Time period for time-based sources"
+          example: "weekly"
           nullable: true
         priority:
           type: integer
-          description: 'Order priority when combining (0 = highest priority)'
+          description: "Order priority when combining (0 = highest priority)"
           example: 0
           minimum: 0
         isExpanded:
           type: boolean
-          description: 'UI state for expandable sections'
+          description: "UI state for expandable sections"
           example: true
           nullable: true
         customDays:
           type: integer
-          description: 'Number of days to look back for Tautulli statistics'
+          description: "Number of days to look back for Tautulli statistics"
           example: 30
           minimum: 1
           maximum: 365
           nullable: true
         minimumPlays:
           type: integer
-          description: 'Minimum play count required for Tautulli sources'
+          description: "Minimum play count required for Tautulli sources"
           example: 3
           minimum: 1
           maximum: 100
           nullable: true
         networksCountry:
           type: string
-          description: 'Selected country for Networks collections'
-          example: 'united-states'
+          description: "Selected country for Networks collections"
+          example: "united-states"
           nullable: true
       required:
         - id
@@ -2839,32 +2839,32 @@ components:
       properties:
         id:
           type: string
-          description: 'Unique hub identifier (libraryId-hubIdentifier)'
-          example: '1-movie.recentlyadded'
+          description: "Unique hub identifier (libraryId-hubIdentifier)"
+          example: "1-movie.recentlyadded"
         hubIdentifier:
           type: string
-          description: 'Plex built-in hub identifier'
-          example: 'movie.recentlyadded'
+          description: "Plex built-in hub identifier"
+          example: "movie.recentlyadded"
         name:
           type: string
-          description: 'Display name for the hub'
-          example: 'Recently Added Movies'
+          description: "Display name for the hub"
+          example: "Recently Added Movies"
         libraryId:
           type: string
-          description: 'Plex library ID'
-          example: '1'
+          description: "Plex library ID"
+          example: "1"
         libraryName:
           type: string
-          description: 'Plex library display name'
-          example: 'Films'
+          description: "Plex library display name"
+          example: "Films"
         mediaType:
           type: string
-          enum: ['movie', 'tv', 'both']
-          description: 'Media type of the hub'
-          example: 'movie'
+          enum: ["movie", "tv", "both"]
+          description: "Media type of the hub"
+          example: "movie"
         sortOrderLibrary:
           type: integer
-          description: 'Position/order within the library'
+          description: "Position/order within the library"
           example: 0
         visibilityConfig:
           type: object
@@ -2879,7 +2879,7 @@ components:
               example: false
             libraryRecommended:
               type: boolean
-              description: 'Show in library recommended section'
+              description: "Show in library recommended section"
               example: false
           required:
             - usersHome
@@ -2887,55 +2887,55 @@ components:
             - libraryRecommended
         isActive:
           type: boolean
-          description: 'Whether hub is currently active (always true for built-in hubs, time restrictions for collections)'
+          description: "Whether hub is currently active (always true for built-in hubs, time restrictions for collections)"
           example: true
           readOnly: true
         isLinked:
           type: boolean
-          description: 'True if hub is actively linked to other hubs'
+          description: "True if hub is actively linked to other hubs"
           example: false
         linkId:
           type: integer
-          description: 'Group ID for linked hubs (preserved even when isLinked=false)'
+          description: "Group ID for linked hubs (preserved even when isLinked=false)"
           example: 1
         isUnlinked:
           type: boolean
-          description: 'True if this hub was deliberately unlinked and should not be grouped with siblings'
+          description: "True if this hub was deliberately unlinked and should not be grouped with siblings"
           example: false
         sortOrderHome:
           type: integer
-          description: 'Position on Plex home screen'
+          description: "Position on Plex home screen"
           example: 0
         isLibraryPromoted:
           type: boolean
-          description: 'true = promoted section (uses exclamation marks), false = A-Z section'
+          description: "true = promoted section (uses exclamation marks), false = A-Z section"
           example: false
         randomizeHomeOrder:
           type: boolean
-          description: 'If true, randomize position amongst other randomized items on home screen'
+          description: "If true, randomize position amongst other randomized items on home screen"
           example: false
           nullable: true
         everLibraryPromoted:
           type: boolean
-          description: 'True if this hub has ever been promoted to the promoted section (once true, stays true until sortTitle reset)'
+          description: "True if this hub has ever been promoted to the promoted section (once true, stays true until sortTitle reset)"
           example: false
           nullable: true
         isPromotedToHub:
           type: boolean
-          description: 'True if hub exists as a promotable item in Plex (appears in hub management list)'
+          description: "True if hub exists as a promotable item in Plex (appears in hub management list)"
           example: false
           nullable: true
         timeRestriction:
           type: object
-          description: 'Time restriction settings for the hub'
+          description: "Time restriction settings for the hub"
           properties:
             alwaysActive:
               type: boolean
-              description: 'If true, hub is always active (default)'
+              description: "If true, hub is always active (default)"
               example: true
             removeFromPlexWhenInactive:
               type: boolean
-              description: 'If true, remove hub from Plex when inactive'
+              description: "If true, remove hub from Plex when inactive"
               example: false
             inactiveVisibilityConfig:
               type: object
@@ -2955,11 +2955,11 @@ components:
                   startDate:
                     type: string
                     description: "DD-MM format (e.g., '05-12' for 5th December)"
-                    example: '05-12'
+                    example: "05-12"
                   endDate:
                     type: string
                     description: "DD-MM format (e.g., '26-12' for 26th December)"
-                    example: '26-12'
+                    example: "26-12"
                 required:
                   - startDate
                   - endDate
@@ -2987,23 +2987,23 @@ components:
           nullable: true
         missing:
           type: boolean
-          description: 'True if hub no longer exists in Plex'
+          description: "True if hub no longer exists in Plex"
           example: false
         lastSyncedAt:
           type: string
           format: date-time
-          description: 'ISO timestamp of last successful sync to Plex'
-          example: '2024-01-15T10:30:00.000Z'
+          description: "ISO timestamp of last successful sync to Plex"
+          example: "2024-01-15T10:30:00.000Z"
           nullable: true
         lastModifiedAt:
           type: string
           format: date-time
-          description: 'ISO timestamp when config was last modified'
-          example: '2024-01-15T09:15:00.000Z'
+          description: "ISO timestamp when config was last modified"
+          example: "2024-01-15T09:15:00.000Z"
           nullable: true
         needsSync:
           type: boolean
-          description: 'True if hub has been modified and needs to be synced to Plex'
+          description: "True if hub has been modified and needs to be synced to Plex"
           example: false
           nullable: true
       required:
@@ -3019,44 +3019,44 @@ components:
 
     PlexHubConfigUpdate:
       type: object
-      description: 'Schema for updating PlexHubConfig settings (excludes computed fields)'
+      description: "Schema for updating PlexHubConfig settings (excludes computed fields)"
       properties:
         id:
           type: string
-          description: 'Unique hub identifier (libraryId-hubIdentifier)'
-          example: '1-movie.recentlyadded'
+          description: "Unique hub identifier (libraryId-hubIdentifier)"
+          example: "1-movie.recentlyadded"
         hubIdentifier:
           type: string
-          description: 'Plex built-in hub identifier'
-          example: 'movie.recentlyadded'
+          description: "Plex built-in hub identifier"
+          example: "movie.recentlyadded"
         name:
           type: string
-          description: 'Display name for the hub'
-          example: 'Recently Added Movies'
+          description: "Display name for the hub"
+          example: "Recently Added Movies"
         libraryId:
           type: string
-          description: 'Plex library ID'
-          example: '1'
+          description: "Plex library ID"
+          example: "1"
         libraryName:
           type: string
-          description: 'Plex library display name'
-          example: 'Films'
+          description: "Plex library display name"
+          example: "Films"
         mediaType:
           type: string
-          enum: ['movie', 'tv', 'both']
-          description: 'Media type of the hub'
-          example: 'movie'
+          enum: ["movie", "tv", "both"]
+          description: "Media type of the hub"
+          example: "movie"
         sortOrderHome:
           type: integer
-          description: 'Position/order on Plex home screen'
+          description: "Position/order on Plex home screen"
           example: 0
         sortOrderLibrary:
           type: integer
-          description: 'Position/order within the library'
+          description: "Position/order within the library"
           example: 0
         isLibraryPromoted:
           type: boolean
-          description: 'true = promoted section (uses exclamation marks), false = A-Z section'
+          description: "true = promoted section (uses exclamation marks), false = A-Z section"
           example: false
         visibilityConfig:
           type: object
@@ -3071,7 +3071,7 @@ components:
               example: false
             libraryRecommended:
               type: boolean
-              description: 'Show in library recommended section'
+              description: "Show in library recommended section"
               example: false
           required:
             - usersHome
@@ -3079,76 +3079,76 @@ components:
             - libraryRecommended
         isLinked:
           type: boolean
-          description: 'True if hub is actively linked to other hubs'
+          description: "True if hub is actively linked to other hubs"
           example: false
         linkId:
           type: integer
-          description: 'Group ID for linked hubs (preserved even when isLinked=false)'
+          description: "Group ID for linked hubs (preserved even when isLinked=false)"
           example: 1
         isUnlinked:
           type: boolean
-          description: 'True if this hub was deliberately unlinked and should not be grouped with siblings'
+          description: "True if this hub was deliberately unlinked and should not be grouped with siblings"
           example: false
         randomizeHomeOrder:
           type: boolean
-          description: 'If true, randomize position amongst other randomized items on home screen'
+          description: "If true, randomize position amongst other randomized items on home screen"
           example: false
           nullable: true
         everLibraryPromoted:
           type: boolean
-          description: 'True if this hub has ever been promoted to the promoted section (once true, stays true until sortTitle reset)'
+          description: "True if this hub has ever been promoted to the promoted section (once true, stays true until sortTitle reset)"
           example: false
           nullable: true
         isPromotedToHub:
           type: boolean
-          description: 'True if hub exists as a promotable item in Plex (appears in hub management list)'
+          description: "True if hub exists as a promotable item in Plex (appears in hub management list)"
           example: false
           nullable: true
         missing:
           type: boolean
-          description: 'True if hub no longer exists in Plex'
+          description: "True if hub no longer exists in Plex"
           example: false
         timeRestriction:
           type: object
-          description: 'Time restriction settings for the hub'
+          description: "Time restriction settings for the hub"
           properties:
             alwaysActive:
               type: boolean
-              description: 'If true, hub is always active (default)'
+              description: "If true, hub is always active (default)"
               example: true
             removeFromPlexWhenInactive:
               type: boolean
-              description: 'If true, remove hub from Plex when inactive'
+              description: "If true, remove hub from Plex when inactive"
               example: false
             timeSlots:
               type: array
-              description: 'Array of time slot objects'
+              description: "Array of time slot objects"
               items:
                 type: object
                 properties:
                   startTime:
                     type: string
-                    description: 'HH:MM format'
-                    example: '09:00'
+                    description: "HH:MM format"
+                    example: "09:00"
                   endTime:
                     type: string
-                    description: 'HH:MM format'
-                    example: '17:00'
+                    description: "HH:MM format"
+                    example: "17:00"
               nullable: true
             dateRanges:
               type: array
-              description: 'Array of date range objects'
+              description: "Array of date range objects"
               items:
                 type: object
                 properties:
                   startDate:
                     type: string
-                    description: 'DD-MM format'
-                    example: '05-12'
+                    description: "DD-MM format"
+                    example: "05-12"
                   endDate:
                     type: string
-                    description: 'DD-MM format'
-                    example: '26-12'
+                    description: "DD-MM format"
+                    example: "26-12"
               nullable: true
             weeklySchedule:
               type: object
@@ -3184,40 +3184,40 @@ components:
       properties:
         id:
           type: string
-          description: 'Unique collection identifier (libraryId-collectionRatingKey)'
-          example: '1-35954'
+          description: "Unique collection identifier (libraryId-collectionRatingKey)"
+          example: "1-35954"
         collectionRatingKey:
           type: string
-          description: 'Plex collection rating key'
-          example: '35954'
+          description: "Plex collection rating key"
+          example: "35954"
         name:
           type: string
-          description: 'Display name from Plex'
-          example: 'Action Movies'
+          description: "Display name from Plex"
+          example: "Action Movies"
         libraryId:
           type: string
-          description: 'Plex library ID'
-          example: '1'
+          description: "Plex library ID"
+          example: "1"
         libraryName:
           type: string
-          description: 'Plex library display name'
-          example: 'Films'
+          description: "Plex library display name"
+          example: "Films"
         mediaType:
           type: string
-          enum: ['movie', 'tv', 'both']
-          description: 'Media type based on collection contents'
-          example: 'movie'
+          enum: ["movie", "tv", "both"]
+          description: "Media type based on collection contents"
+          example: "movie"
         sortOrderHome:
           type: integer
-          description: 'Position on Plex home screen'
+          description: "Position on Plex home screen"
           example: 0
         sortOrderLibrary:
           type: integer
-          description: 'Position in library (0 for A-Z section, 1+ for promoted section)'
+          description: "Position in library (0 for A-Z section, 1+ for promoted section)"
           example: 0
         isLibraryPromoted:
           type: boolean
-          description: 'true = promoted section (uses exclamation marks), false = A-Z section'
+          description: "true = promoted section (uses exclamation marks), false = A-Z section"
           example: false
         visibilityConfig:
           type: object
@@ -3232,7 +3232,7 @@ components:
               example: false
             libraryRecommended:
               type: boolean
-              description: 'Show in library recommended section'
+              description: "Show in library recommended section"
               example: false
           required:
             - usersHome
@@ -3240,26 +3240,26 @@ components:
             - libraryRecommended
         isActive:
           type: boolean
-          description: 'Whether collection is currently active (computed from time restrictions)'
+          description: "Whether collection is currently active (computed from time restrictions)"
           example: true
           readOnly: true
         collectionType:
           type: string
-          enum: ['default_plex_hub', 'agregarr_created', 'pre_existing']
-          description: 'Type of collection (determined during discovery)'
-          example: 'pre_existing'
+          enum: ["default_plex_hub", "agregarr_created", "pre_existing"]
+          description: "Type of collection (determined during discovery)"
+          example: "pre_existing"
           readOnly: true
         isLinked:
           type: boolean
-          description: 'True if collection is actively linked to other collections'
+          description: "True if collection is actively linked to other collections"
           example: false
         linkId:
           type: integer
-          description: 'Group ID for linked collections (preserved even when isLinked=false)'
+          description: "Group ID for linked collections (preserved even when isLinked=false)"
           example: 1
         isUnlinked:
           type: boolean
-          description: 'True if this collection was deliberately unlinked and should not be grouped with siblings'
+          description: "True if this collection was deliberately unlinked and should not be grouped with siblings"
           example: false
           nullable: true
         timeRestriction:
@@ -3267,11 +3267,11 @@ components:
           properties:
             alwaysActive:
               type: boolean
-              description: 'If true, collection is always active (default)'
+              description: "If true, collection is always active (default)"
               example: true
             removeFromPlexWhenInactive:
               type: boolean
-              description: 'If true, completely remove from Plex when inactive'
+              description: "If true, completely remove from Plex when inactive"
               example: false
               nullable: true
             inactiveVisibilityConfig:
@@ -3292,11 +3292,11 @@ components:
                   startDate:
                     type: string
                     description: "DD-MM format (e.g., '05-12' for 5th December)"
-                    example: '05-12'
+                    example: "05-12"
                   endDate:
                     type: string
                     description: "DD-MM format (e.g., '26-12' for 26th December)"
-                    example: '26-12'
+                    example: "26-12"
                 required:
                   - startDate
                   - endDate
@@ -3324,104 +3324,104 @@ components:
           nullable: true
         customPoster:
           type: string
-          description: 'Path to custom poster image file'
-          example: '/app/config/poster-123.jpg'
+          description: "Path to custom poster image file"
+          example: "/app/config/poster-123.jpg"
           nullable: true
         autoPoster:
           type: boolean
-          description: 'Auto-generate poster during sync'
+          description: "Auto-generate poster during sync"
           example: true
           nullable: true
         autoPosterTemplate:
           type: integer
-          description: 'Template ID for auto-generated posters (null for default template)'
+          description: "Template ID for auto-generated posters (null for default template)"
           example: 1
           nullable: true
         titleSort:
           type: string
-          description: 'Plex sortTitle field for alphabetical ordering'
-          example: 'Action Movies'
+          description: "Plex sortTitle field for alphabetical ordering"
+          example: "Action Movies"
           nullable: true
         randomizeHomeOrder:
           type: boolean
-          description: 'If true, randomize position amongst other randomized items on home screen'
+          description: "If true, randomize position amongst other randomized items on home screen"
           example: false
           nullable: true
         everLibraryPromoted:
           type: boolean
-          description: 'True if this collection has ever been promoted to the promoted section (once true, stays true until sortTitle reset)'
+          description: "True if this collection has ever been promoted to the promoted section (once true, stays true until sortTitle reset)"
           example: false
           nullable: true
         isPromotedToHub:
           type: boolean
-          description: 'True if collection exists as a promotable hub in Plex (appears in hub management list)'
+          description: "True if collection exists as a promotable hub in Plex (appears in hub management list)"
           example: false
           nullable: true
         customWallpaper:
           oneOf:
             - type: string
-              description: 'Filename of custom wallpaper image (art)'
-              example: 'wallpaper-12345.jpg'
+              description: "Filename of custom wallpaper image (art)"
+              example: "wallpaper-12345.jpg"
             - type: object
-              description: 'Per-library wallpaper mapping (libraryId -> filename)'
+              description: "Per-library wallpaper mapping (libraryId -> filename)"
               additionalProperties:
                 type: string
               example:
-                lib1: 'wallpaper-12345.jpg'
-                lib2: 'wallpaper-67890.jpg'
+                lib1: "wallpaper-12345.jpg"
+                lib2: "wallpaper-67890.jpg"
           nullable: true
         customSummary:
           type: string
-          description: 'Custom summary/description text for the collection'
-          example: 'A curated collection of the best movies'
+          description: "Custom summary/description text for the collection"
+          example: "A curated collection of the best movies"
           nullable: true
         customTheme:
           oneOf:
             - type: string
-              description: 'Filename of custom theme music file'
-              example: 'theme-12345.mp3'
+              description: "Filename of custom theme music file"
+              example: "theme-12345.mp3"
             - type: object
-              description: 'Per-library theme mapping (libraryId -> filename)'
+              description: "Per-library theme mapping (libraryId -> filename)"
               additionalProperties:
                 type: string
               example:
-                lib1: 'theme-12345.mp3'
-                lib2: 'theme-67890.mp3'
+                lib1: "theme-12345.mp3"
+                lib2: "theme-67890.mp3"
           nullable: true
         enableCustomWallpaper:
           type: boolean
-          description: 'Enable custom wallpaper sync to Plex'
+          description: "Enable custom wallpaper sync to Plex"
           example: false
           nullable: true
         enableCustomSummary:
           type: boolean
-          description: 'Enable custom summary sync to Plex'
+          description: "Enable custom summary sync to Plex"
           example: false
           nullable: true
         enableCustomTheme:
           type: boolean
-          description: 'Enable custom theme sync to Plex'
+          description: "Enable custom theme sync to Plex"
           example: false
           nullable: true
         missing:
           type: boolean
-          description: 'True if collection no longer exists in Plex'
+          description: "True if collection no longer exists in Plex"
           example: false
         lastSyncedAt:
           type: string
           format: date-time
-          description: 'ISO timestamp of last successful sync to Plex'
-          example: '2024-01-15T10:30:00.000Z'
+          description: "ISO timestamp of last successful sync to Plex"
+          example: "2024-01-15T10:30:00.000Z"
           nullable: true
         lastModifiedAt:
           type: string
           format: date-time
-          description: 'ISO timestamp when config was last modified'
-          example: '2024-01-15T09:15:00.000Z'
+          description: "ISO timestamp when config was last modified"
+          example: "2024-01-15T09:15:00.000Z"
           nullable: true
         needsSync:
           type: boolean
-          description: 'True if collection has been modified and needs to be synced to Plex'
+          description: "True if collection has been modified and needs to be synced to Plex"
           example: false
           nullable: true
       required:
@@ -3438,44 +3438,44 @@ components:
 
     PreExistingCollectionConfigUpdate:
       type: object
-      description: 'Schema for updating PreExistingCollectionConfig settings (excludes computed fields)'
+      description: "Schema for updating PreExistingCollectionConfig settings (excludes computed fields)"
       properties:
         id:
           type: string
-          description: 'Unique collection identifier (libraryId-collectionRatingKey)'
-          example: '1-35954'
+          description: "Unique collection identifier (libraryId-collectionRatingKey)"
+          example: "1-35954"
         collectionRatingKey:
           type: string
-          description: 'Plex collection rating key'
-          example: '35954'
+          description: "Plex collection rating key"
+          example: "35954"
         name:
           type: string
-          description: 'Display name from Plex'
-          example: 'Action Movies'
+          description: "Display name from Plex"
+          example: "Action Movies"
         libraryId:
           type: string
-          description: 'Plex library ID'
-          example: '1'
+          description: "Plex library ID"
+          example: "1"
         libraryName:
           type: string
-          description: 'Plex library display name'
-          example: 'Films'
+          description: "Plex library display name"
+          example: "Films"
         mediaType:
           type: string
-          enum: ['movie', 'tv', 'both']
-          description: 'Media type based on collection contents'
-          example: 'movie'
+          enum: ["movie", "tv", "both"]
+          description: "Media type based on collection contents"
+          example: "movie"
         sortOrderHome:
           type: integer
-          description: 'Position on Plex home screen'
+          description: "Position on Plex home screen"
           example: 0
         sortOrderLibrary:
           type: integer
-          description: 'Position in library (0 for A-Z section, 1+ for promoted section)'
+          description: "Position in library (0 for A-Z section, 1+ for promoted section)"
           example: 0
         isLibraryPromoted:
           type: boolean
-          description: 'true = promoted section (uses exclamation marks), false = A-Z section'
+          description: "true = promoted section (uses exclamation marks), false = A-Z section"
           example: false
         visibilityConfig:
           type: object
@@ -3490,7 +3490,7 @@ components:
               example: false
             libraryRecommended:
               type: boolean
-              description: 'Show in library recommended section'
+              description: "Show in library recommended section"
               example: false
           required:
             - usersHome
@@ -3498,57 +3498,57 @@ components:
             - libraryRecommended
         isLinked:
           type: boolean
-          description: 'True if collection is actively linked to other collections'
+          description: "True if collection is actively linked to other collections"
           example: false
         linkId:
           type: integer
-          description: 'Group ID for linked collections (preserved even when isLinked=false)'
+          description: "Group ID for linked collections (preserved even when isLinked=false)"
           example: 1
         isUnlinked:
           type: boolean
-          description: 'True if this collection was deliberately unlinked and should not be grouped with siblings'
+          description: "True if this collection was deliberately unlinked and should not be grouped with siblings"
           example: false
         timeRestriction:
           type: object
-          description: 'Time restriction settings for the collection'
+          description: "Time restriction settings for the collection"
           properties:
             alwaysActive:
               type: boolean
-              description: 'If true, collection is always active (default)'
+              description: "If true, collection is always active (default)"
               example: true
             removeFromPlexWhenInactive:
               type: boolean
-              description: 'If true, remove collection from Plex when inactive'
+              description: "If true, remove collection from Plex when inactive"
               example: false
             timeSlots:
               type: array
-              description: 'Array of time slot objects'
+              description: "Array of time slot objects"
               items:
                 type: object
                 properties:
                   startTime:
                     type: string
-                    description: 'HH:MM format'
-                    example: '09:00'
+                    description: "HH:MM format"
+                    example: "09:00"
                   endTime:
                     type: string
-                    description: 'HH:MM format'
-                    example: '17:00'
+                    description: "HH:MM format"
+                    example: "17:00"
               nullable: true
             dateRanges:
               type: array
-              description: 'Array of date range objects'
+              description: "Array of date range objects"
               items:
                 type: object
                 properties:
                   startDate:
                     type: string
-                    description: 'DD-MM format'
-                    example: '05-12'
+                    description: "DD-MM format"
+                    example: "05-12"
                   endDate:
                     type: string
-                    description: 'DD-MM format'
-                    example: '26-12'
+                    description: "DD-MM format"
+                    example: "26-12"
               nullable: true
             weeklySchedule:
               type: object
@@ -3574,95 +3574,95 @@ components:
         customPoster:
           oneOf:
             - type: string
-              description: 'Filename of custom poster image (legacy format)'
-              example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
+              description: "Filename of custom poster image (legacy format)"
+              example: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
             - type: object
-              description: 'Per-library poster mapping (libraryId -> filename)'
+              description: "Per-library poster mapping (libraryId -> filename)"
               additionalProperties:
                 type: string
               example:
-                lib1: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
-                lib2: 'a12bc34d-58cc-4372-a567-0e02b2c3d480.jpg'
+                lib1: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
+                lib2: "a12bc34d-58cc-4372-a567-0e02b2c3d480.jpg"
           nullable: true
         autoPoster:
           type: boolean
-          description: 'Auto-generate poster during sync'
+          description: "Auto-generate poster during sync"
           example: true
           nullable: true
         autoPosterTemplate:
           type: integer
-          description: 'Template ID for auto-generated posters (null for default template)'
+          description: "Template ID for auto-generated posters (null for default template)"
           example: 1
           nullable: true
         titleSort:
           type: string
-          description: 'Plex sortTitle field for alphabetical ordering'
-          example: 'Action Movies'
+          description: "Plex sortTitle field for alphabetical ordering"
+          example: "Action Movies"
           nullable: true
         randomizeHomeOrder:
           type: boolean
-          description: 'If true, randomize position amongst other randomized items on home screen'
+          description: "If true, randomize position amongst other randomized items on home screen"
           example: false
           nullable: true
         everLibraryPromoted:
           type: boolean
-          description: 'True if this collection has ever been promoted to the promoted section (once true, stays true until sortTitle reset)'
+          description: "True if this collection has ever been promoted to the promoted section (once true, stays true until sortTitle reset)"
           example: false
           nullable: true
         isPromotedToHub:
           type: boolean
-          description: 'True if collection exists as a promotable hub in Plex (appears in hub management list)'
+          description: "True if collection exists as a promotable hub in Plex (appears in hub management list)"
           example: false
           nullable: true
         customWallpaper:
           oneOf:
             - type: string
-              description: 'Filename of custom wallpaper image (art)'
-              example: 'wallpaper-12345.jpg'
+              description: "Filename of custom wallpaper image (art)"
+              example: "wallpaper-12345.jpg"
             - type: object
-              description: 'Per-library wallpaper mapping (libraryId -> filename)'
+              description: "Per-library wallpaper mapping (libraryId -> filename)"
               additionalProperties:
                 type: string
               example:
-                lib1: 'wallpaper-12345.jpg'
-                lib2: 'wallpaper-67890.jpg'
+                lib1: "wallpaper-12345.jpg"
+                lib2: "wallpaper-67890.jpg"
           nullable: true
         customSummary:
           type: string
-          description: 'Custom summary/description text for the collection'
-          example: 'A curated collection of the best movies'
+          description: "Custom summary/description text for the collection"
+          example: "A curated collection of the best movies"
           nullable: true
         customTheme:
           oneOf:
             - type: string
-              description: 'Filename of custom theme music file'
-              example: 'theme-12345.mp3'
+              description: "Filename of custom theme music file"
+              example: "theme-12345.mp3"
             - type: object
-              description: 'Per-library theme mapping (libraryId -> filename)'
+              description: "Per-library theme mapping (libraryId -> filename)"
               additionalProperties:
                 type: string
               example:
-                lib1: 'theme-12345.mp3'
-                lib2: 'theme-67890.mp3'
+                lib1: "theme-12345.mp3"
+                lib2: "theme-67890.mp3"
           nullable: true
         enableCustomWallpaper:
           type: boolean
-          description: 'Enable custom wallpaper sync to Plex'
+          description: "Enable custom wallpaper sync to Plex"
           example: false
           nullable: true
         enableCustomSummary:
           type: boolean
-          description: 'Enable custom summary sync to Plex'
+          description: "Enable custom summary sync to Plex"
           example: false
           nullable: true
         enableCustomTheme:
           type: boolean
-          description: 'Enable custom theme sync to Plex'
+          description: "Enable custom theme sync to Plex"
           example: false
           nullable: true
         missing:
           type: boolean
-          description: 'True if collection no longer exists in Plex'
+          description: "True if collection no longer exists in Plex"
           example: false
       required:
         - id
@@ -3677,40 +3677,40 @@ components:
 
     DiscoveredCollectionConfig:
       type: object
-      description: 'Pre-existing collection config for discovery (collectionRatingKey is extracted server-side)'
+      description: "Pre-existing collection config for discovery (collectionRatingKey is extracted server-side)"
       properties:
         id:
           type: string
-          description: 'Unique collection identifier (libraryId-collectionRatingKey)'
-          example: '1:36466'
+          description: "Unique collection identifier (libraryId-collectionRatingKey)"
+          example: "1:36466"
         hubIdentifier:
           type: string
-          description: 'Plex hub identifier for the collection'
-          example: 'custom.collection.1.36466'
+          description: "Plex hub identifier for the collection"
+          example: "custom.collection.1.36466"
         name:
           type: string
-          description: 'Display name from Plex'
-          example: 'movies that i like'
+          description: "Display name from Plex"
+          example: "movies that i like"
         libraryId:
           type: string
-          description: 'Plex library ID'
-          example: '1'
+          description: "Plex library ID"
+          example: "1"
         libraryName:
           type: string
-          description: 'Plex library display name'
-          example: 'Films'
+          description: "Plex library display name"
+          example: "Films"
         mediaType:
           type: string
-          enum: ['movie', 'tv', 'both']
-          description: 'Media type based on collection contents'
-          example: 'movie'
+          enum: ["movie", "tv", "both"]
+          description: "Media type based on collection contents"
+          example: "movie"
         sortOrderHome:
           type: integer
-          description: 'Position on Plex home screen'
+          description: "Position on Plex home screen"
           example: 0
         sortOrderLibrary:
           type: integer
-          description: 'Position in library'
+          description: "Position in library"
           example: 0
         visibilityConfig:
           type: object
@@ -3730,8 +3730,8 @@ components:
             - libraryRecommended
         collectionType:
           type: string
-          description: 'Type of collection for discovery'
-          example: 'pre_existing'
+          description: "Type of collection for discovery"
+          example: "pre_existing"
       required:
         - id
         - name
@@ -3744,94 +3744,94 @@ components:
 
     OverlayTemplate:
       type: object
-      description: 'Overlay template for applying customizable badges and banners to library posters'
+      description: "Overlay template for applying customizable badges and banners to library posters"
       properties:
         id:
           type: integer
           readOnly: true
-          description: 'Unique identifier'
+          description: "Unique identifier"
           example: 1
         name:
           type: string
-          description: 'Template name'
-          example: 'IMDb Rating Badge'
+          description: "Template name"
+          example: "IMDb Rating Badge"
         description:
           type: string
           nullable: true
-          description: 'Optional template description'
-          example: 'Shows IMDb rating in top-right corner with gold background'
+          description: "Optional template description"
+          example: "Shows IMDb rating in top-right corner with gold background"
         type:
           type: string
-          enum: ['rating', 'metadata', 'technical', 'status', 'generic']
-          description: 'Template type for organization'
-          example: 'rating'
+          enum: ["rating", "metadata", "technical", "status", "generic"]
+          description: "Template type for organization"
+          example: "rating"
         templateData:
           type: object
-          description: 'Overlay template design data with layered elements'
+          description: "Overlay template design data with layered elements"
           properties:
             width:
               type: number
-              description: 'Canvas width for editing'
+              description: "Canvas width for editing"
               example: 1000
             height:
               type: number
-              description: 'Canvas height for editing'
+              description: "Canvas height for editing"
               example: 1500
             elements:
               type: array
-              description: 'Layered overlay elements (text, tile, variable, SVG, raster)'
+              description: "Layered overlay elements (text, tile, variable, SVG, raster)"
               items:
                 type: object
         applicationCondition:
           type: object
           nullable: true
-          description: 'Flat section-based condition structure for when this template should be applied'
+          description: "Flat section-based condition structure for when this template should be applied"
           properties:
             sections:
               type: array
-              description: 'Array of condition sections (combined with OR by default)'
+              description: "Array of condition sections (combined with OR by default)"
               items:
                 type: object
                 properties:
                   sectionOperator:
                     type: string
-                    enum: ['and', 'or']
-                    description: 'How this section combines with the previous section (omitted for first section)'
-                    example: 'or'
+                    enum: ["and", "or"]
+                    description: "How this section combines with the previous section (omitted for first section)"
+                    example: "or"
                   rules:
                     type: array
-                    description: 'Array of condition rules within this section'
+                    description: "Array of condition rules within this section"
                     items:
                       type: object
                       properties:
                         ruleOperator:
                           type: string
-                          enum: ['and', 'or']
-                          description: 'How this rule combines with the previous rule (omitted for first rule)'
-                          example: 'and'
+                          enum: ["and", "or"]
+                          description: "How this rule combines with the previous rule (omitted for first rule)"
+                          example: "and"
                         field:
                           type: string
-                          description: 'Context field to evaluate (e.g., imdbRating, resolution, daysUntilRelease, daysUntilAction)'
-                          example: 'imdbRating'
+                          description: "Context field to evaluate (e.g., imdbRating, resolution, daysUntilRelease, daysUntilAction)"
+                          example: "imdbRating"
                         operator:
                           type: string
                           enum:
                             [
-                              'eq',
-                              'neq',
-                              'gt',
-                              'gte',
-                              'lt',
-                              'lte',
-                              'in',
-                              'contains',
-                              'notContains',
-                              'regex',
-                              'begins',
-                              'ends',
+                              "eq",
+                              "neq",
+                              "gt",
+                              "gte",
+                              "lt",
+                              "lte",
+                              "in",
+                              "contains",
+                              "notContains",
+                              "regex",
+                              "begins",
+                              "ends",
                             ]
-                          description: 'Comparison operator'
-                          example: 'gte'
+                          description: "Comparison operator"
+                          example: "gte"
                         value:
                           oneOf:
                             - type: string
@@ -3842,7 +3842,7 @@ components:
                                 oneOf:
                                   - type: string
                                   - type: number
-                          description: 'Value to compare against'
+                          description: "Value to compare against"
                           example: 7.5
                       required:
                         - field
@@ -3853,33 +3853,33 @@ components:
           example:
             sections:
               - rules:
-                  - field: 'imdbRating'
-                    operator: 'gte'
+                  - field: "imdbRating"
+                    operator: "gte"
                     value: 8.0
-                  - ruleOperator: 'and'
-                    field: 'isMonitored'
-                    operator: 'eq'
+                  - ruleOperator: "and"
+                    field: "isMonitored"
+                    operator: "eq"
                     value: true
         isDefault:
           type: boolean
           readOnly: true
-          description: 'Whether this is a system preset template (cannot be edited/deleted)'
+          description: "Whether this is a system preset template (cannot be edited/deleted)"
           example: true
         isActive:
           type: boolean
-          description: 'Whether template is active'
+          description: "Whether template is active"
           example: true
           default: true
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          description: 'Creation timestamp'
+          description: "Creation timestamp"
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          description: 'Last update timestamp'
+          description: "Last update timestamp"
       required:
         - name
         - type
@@ -3887,117 +3887,117 @@ components:
 
     IconMapping:
       type: object
-      description: 'Maps a field value to an icon path for mapped-icon overlay elements'
+      description: "Maps a field value to an icon path for mapped-icon overlay elements"
       properties:
         value:
           type: string
-          description: 'The value to match (e.g., country code, language name)'
-          example: 'US'
+          description: "The value to match (e.g., country code, language name)"
+          example: "US"
         iconPath:
           type: string
-          description: 'Path to the icon file'
-          example: '/assets/mapped-icons/flags/US.svg'
+          description: "Path to the icon file"
+          example: "/assets/mapped-icons/flags/US.svg"
       required:
         - value
         - iconPath
 
     OverlayMappingsResponse:
       type: object
-      description: 'Response containing icon mappings for a field'
+      description: "Response containing icon mappings for a field"
       properties:
         field:
           type: string
-          description: 'The field name these mappings apply to'
-          example: 'originCountry'
+          description: "The field name these mappings apply to"
+          example: "originCountry"
         mappings:
           type: array
-          description: 'Array of value-to-icon mappings'
+          description: "Array of value-to-icon mappings"
           items:
-            $ref: '#/components/schemas/IconMapping'
+            $ref: "#/components/schemas/IconMapping"
         hasDefaults:
           type: boolean
-          description: 'Whether system defaults exist for this field'
+          description: "Whether system defaults exist for this field"
           example: true
         hasCustomMappings:
           type: boolean
-          description: 'Whether user has custom mappings for this field'
+          description: "Whether user has custom mappings for this field"
           example: false
         isUsingDefaults:
           type: boolean
-          description: 'Whether currently using system defaults (hasDefaults && !hasCustomMappings)'
+          description: "Whether currently using system defaults (hasDefaults && !hasCustomMappings)"
           example: true
 
     OverlayLibraryConfig:
       type: object
-      description: 'Configuration for which overlay templates are applied to a specific library'
+      description: "Configuration for which overlay templates are applied to a specific library"
       properties:
         id:
           type: integer
           readOnly: true
-          description: 'Unique identifier'
+          description: "Unique identifier"
           example: 1
         libraryId:
           type: string
-          description: 'Plex library ID (unique constraint)'
-          example: '1'
+          description: "Plex library ID (unique constraint)"
+          example: "1"
         libraryName:
           type: string
-          description: 'Library display name'
-          example: 'Movies'
+          description: "Library display name"
+          example: "Movies"
         mediaType:
           type: string
-          enum: ['movie', 'show']
-          description: 'Media type of library'
-          example: 'movie'
+          enum: ["movie", "show"]
+          description: "Media type of library"
+          example: "movie"
         enabledOverlays:
           type: array
-          description: 'List of enabled overlay templates with layer ordering'
+          description: "List of enabled overlay templates with layer ordering"
           items:
             type: object
             properties:
               templateId:
                 type: integer
-                description: 'OverlayTemplate ID'
+                description: "OverlayTemplate ID"
                 example: 1
               enabled:
                 type: boolean
-                description: 'Whether this overlay is active'
+                description: "Whether this overlay is active"
                 example: true
               layerOrder:
                 type: integer
-                description: 'Stacking order (0 = bottom layer, higher = top)'
+                description: "Stacking order (0 = bottom layer, higher = top)"
                 example: 0
               config:
                 type: object
-                description: 'Optional per-overlay configuration'
+                description: "Optional per-overlay configuration"
                 properties:
                   daysThreshold:
                     type: number
-                    description: 'For Coming Soon overlays - show if days until release is less than this'
+                    description: "For Coming Soon overlays - show if days until release is less than this"
                     example: 30
                   timeWindowDays:
                     type: number
-                    description: 'For New Release badge - show for X days after download'
+                    description: "For New Release badge - show for X days after download"
                     example: 7
                   minimumRating:
                     type: number
-                    description: 'For rating badges - minimum rating to display'
+                    description: "For rating badges - minimum rating to display"
                     example: 7.0
         tmdbLanguage:
           type: string
           nullable: true
-          description: 'ISO language code for TMDB poster metadata (e.g., en, fr, pt-BR). If not set, uses global setting.'
-          example: 'en'
+          description: "ISO language code for TMDB poster metadata (e.g., en, fr, pt-BR). If not set, uses global setting."
+          example: "en"
         createdAt:
           type: string
           format: date-time
           readOnly: true
-          description: 'Creation timestamp'
+          description: "Creation timestamp"
         updatedAt:
           type: string
           format: date-time
           readOnly: true
-          description: 'Last update timestamp'
+          description: "Last update timestamp"
       required:
         - libraryId
         - libraryName
@@ -4009,16 +4009,16 @@ components:
       properties:
         protocol:
           type: string
-          example: 'https'
+          example: "https"
         address:
           type: string
-          example: '127.0.0.1'
+          example: "127.0.0.1"
         port:
           type: number
           example: 32400
         uri:
           type: string
-          example: 'https://127-0-0-1.2ab6ce1a093d465e910def96cf4e4799.plex.direct:32400'
+          example: "https://127-0-0-1.2ab6ce1a093d465e910def96cf4e4799.plex.direct:32400"
         local:
           type: boolean
           example: true
@@ -4027,7 +4027,7 @@ components:
           example: 200
         message:
           type: string
-          example: 'OK'
+          example: "OK"
       required:
         - protocol
         - address
@@ -4039,54 +4039,54 @@ components:
       properties:
         name:
           type: string
-          example: 'My Plex Server'
+          example: "My Plex Server"
         product:
           type: string
-          example: 'Plex Media Server'
+          example: "Plex Media Server"
         productVersion:
           type: string
-          example: '1.21'
+          example: "1.21"
         platform:
           type: string
-          example: 'Linux'
+          example: "Linux"
         platformVersion:
           type: string
-          example: 'default/linux/amd64/17.1/systemd'
+          example: "default/linux/amd64/17.1/systemd"
         device:
           type: string
-          example: 'PC'
+          example: "PC"
         clientIdentifier:
           type: string
-          example: '85a943ce-a0cc-4d2a-a4ec-f74f06e40feb'
+          example: "85a943ce-a0cc-4d2a-a4ec-f74f06e40feb"
         createdAt:
           type: string
-          example: '2021-01-01T00:00:00.000Z'
+          example: "2021-01-01T00:00:00.000Z"
         lastSeenAt:
           type: string
-          example: '2021-01-01T00:00:00.000Z'
+          example: "2021-01-01T00:00:00.000Z"
         provides:
           type: array
           items:
             type: string
-            example: 'server'
+            example: "server"
         owned:
           type: boolean
           example: true
         ownerID:
           type: string
-          example: '12345'
+          example: "12345"
         home:
           type: boolean
           example: true
         sourceTitle:
           type: string
-          example: 'xyzabc'
+          example: "xyzabc"
         accessToken:
           type: string
-          example: 'supersecretaccesstoken'
+          example: "supersecretaccesstoken"
         publicAddress:
           type: string
-          example: '127.0.0.1'
+          example: "127.0.0.1"
         httpsRequired:
           type: boolean
           example: true
@@ -4111,7 +4111,7 @@ components:
         connection:
           type: array
           items:
-            $ref: '#/components/schemas/PlexConnection'
+            $ref: "#/components/schemas/PlexConnection"
       required:
         - name
         - product
@@ -4130,7 +4130,7 @@ components:
         hostname:
           type: string
           nullable: true
-          example: 'tautulli.example.com'
+          example: "tautulli.example.com"
         port:
           type: number
           nullable: true
@@ -4141,7 +4141,7 @@ components:
         urlBase:
           type: string
           nullable: true
-          example: '/tautulli'
+          example: "/tautulli"
         apiKey:
           type: string
           nullable: true
@@ -4154,7 +4154,7 @@ components:
         hostname:
           type: string
           nullable: true
-          example: 'maintainerr.example.com'
+          example: "maintainerr.example.com"
         port:
           type: number
           nullable: true
@@ -4165,7 +4165,7 @@ components:
         urlBase:
           type: string
           nullable: true
-          example: ''
+          example: ""
         apiKey:
           type: string
           nullable: true
@@ -4178,54 +4178,54 @@ components:
         clientId:
           type: string
           nullable: true
-          description: 'Trakt client ID'
-          example: 'your-trakt-client-id'
+          description: "Trakt client ID"
+          example: "your-trakt-client-id"
         clientSecret:
           type: string
           nullable: true
-          description: 'Trakt client secret'
-          example: 'your-trakt-client-secret'
+          description: "Trakt client secret"
+          example: "your-trakt-client-secret"
         accessToken:
           type: string
           nullable: true
-          description: 'Trakt personal access token'
-          example: 'your-trakt-access-token'
+          description: "Trakt personal access token"
+          example: "your-trakt-access-token"
         refreshToken:
           type: string
           nullable: true
-          description: 'Trakt refresh token'
-          example: 'your-trakt-refresh-token'
+          description: "Trakt refresh token"
+          example: "your-trakt-refresh-token"
         tokenExpiresAt:
           type: integer
           format: int64
           nullable: true
-          description: 'Unix epoch milliseconds when the current access token expires'
+          description: "Unix epoch milliseconds when the current access token expires"
         apiKey:
           type: string
           nullable: true
           deprecated: true
-          description: 'Legacy Trakt client ID field (deprecated)'
+          description: "Legacy Trakt client ID field (deprecated)"
     MDBListSettings:
       type: object
       properties:
         apiKey:
           type: string
           nullable: true
-          example: 'your-mdblist-api-key-here'
+          example: "your-mdblist-api-key-here"
     MyAnimeListSettings:
       type: object
       properties:
         apiKey:
           type: string
           nullable: true
-          example: 'your-myanimelist-api-key-here'
+          example: "your-myanimelist-api-key-here"
     OverseerrSettings:
       type: object
       properties:
         hostname:
           type: string
           nullable: true
-          example: 'overseerr.example.com'
+          example: "overseerr.example.com"
         port:
           type: number
           nullable: true
@@ -4237,67 +4237,67 @@ components:
         urlBase:
           type: string
           nullable: true
-          example: '/overseerr'
+          example: "/overseerr"
         apiKey:
           type: string
           nullable: true
-          example: 'your-agregarr-api-key-here'
+          example: "your-agregarr-api-key-here"
         externalUrl:
           type: string
           nullable: true
-          example: 'https://overseerr.example.com:5055'
+          example: "https://overseerr.example.com:5055"
         radarrServerId:
           type: number
           nullable: true
           example: 1
-          description: 'Default Radarr server ID for movie requests'
+          description: "Default Radarr server ID for movie requests"
         radarrProfileId:
           type: number
           nullable: true
           example: 1
-          description: 'Default Radarr quality profile ID for movie requests'
+          description: "Default Radarr quality profile ID for movie requests"
         radarrRootFolder:
           type: string
           nullable: true
-          example: '/data/media/movies'
-          description: 'Default Radarr root folder path for movie requests'
+          example: "/data/media/movies"
+          description: "Default Radarr root folder path for movie requests"
         radarrTags:
           type: array
           items:
             type: integer
           nullable: true
           example: [1, 2]
-          description: 'Default Radarr tags for movie requests'
+          description: "Default Radarr tags for movie requests"
         sonarrServerId:
           type: number
           nullable: true
           example: 2
-          description: 'Default Sonarr server ID for TV requests'
+          description: "Default Sonarr server ID for TV requests"
         sonarrProfileId:
           type: number
           nullable: true
           example: 1
-          description: 'Default Sonarr quality profile ID for TV requests'
+          description: "Default Sonarr quality profile ID for TV requests"
         sonarrRootFolder:
           type: string
           nullable: true
-          example: '/data/media/tv'
-          description: 'Default Sonarr root folder path for TV requests'
+          example: "/data/media/tv"
+          description: "Default Sonarr root folder path for TV requests"
         sonarrTags:
           type: array
           items:
             type: integer
           nullable: true
           example: [1, 2]
-          description: 'Default Sonarr tags for TV requests'
+          description: "Default Sonarr tags for TV requests"
     ServiceUserSettings:
       type: object
       properties:
         userCreationMode:
           type: string
-          enum: ['single', 'per-service', 'granular']
-          example: 'per-service'
-          description: 'How to create service users - single (one Agregarr user), per-service (TraktAgregarr, TMDbAgregarr), or granular (TraktTrendingAgregarr, TMDbPopularAgregarr)'
+          enum: ["single", "per-service", "granular"]
+          example: "per-service"
+          description: "How to create service users - single (one Agregarr user), per-service (TraktAgregarr, TMDbAgregarr), or granular (TraktTrendingAgregarr, TMDbPopularAgregarr)"
     RadarrSettings:
       type: object
       properties:
@@ -4307,16 +4307,16 @@ components:
           readOnly: true
         name:
           type: string
-          example: 'Radarr Main'
+          example: "Radarr Main"
         hostname:
           type: string
-          example: '127.0.0.1'
+          example: "127.0.0.1"
         port:
           type: number
           example: 7878
         apiKey:
           type: string
-          example: 'exampleapikey'
+          example: "exampleapikey"
         useSsl:
           type: boolean
           example: false
@@ -4330,10 +4330,10 @@ components:
           example: 720p/1080p
         activeDirectory:
           type: string
-          example: '/movies'
+          example: "/movies"
         minimumAvailability:
           type: string
-          example: 'In Cinema'
+          example: "In Cinema"
         isDefault:
           type: boolean
           example: false
@@ -4348,7 +4348,7 @@ components:
           example: false
         pathMappings:
           type: array
-          description: 'Path mappings for cross-platform/remote setups (e.g., Windows Radarr → Linux Agregarr)'
+          description: "Path mappings for cross-platform/remote setups (e.g., Windows Radarr → Linux Agregarr)"
           items:
             type: object
             properties:
@@ -4359,7 +4359,7 @@ components:
               to:
                 type: string
                 description: 'Local path accessible by Agregarr (e.g., "/mnt/serverdata/media")'
-                example: '/mnt/serverdata/media'
+                example: "/mnt/serverdata/media"
             required:
               - from
               - to
@@ -4382,16 +4382,16 @@ components:
           readOnly: true
         name:
           type: string
-          example: 'Sonarr Main'
+          example: "Sonarr Main"
         hostname:
           type: string
-          example: '127.0.0.1'
+          example: "127.0.0.1"
         port:
           type: number
           example: 8989
         apiKey:
           type: string
-          example: 'exampleapikey'
+          example: "exampleapikey"
         useSsl:
           type: boolean
           example: false
@@ -4405,7 +4405,7 @@ components:
           example: 720p/1080p
         activeDirectory:
           type: string
-          example: '/tv/'
+          example: "/tv/"
         activeLanguageProfileId:
           type: number
           example: 1
@@ -4458,7 +4458,7 @@ components:
           example: off
         pathMappings:
           type: array
-          description: 'Path mappings for cross-platform/remote setups (e.g., Windows Sonarr → Linux Agregarr)'
+          description: "Path mappings for cross-platform/remote setups (e.g., Windows Sonarr → Linux Agregarr)"
           items:
             type: object
             properties:
@@ -4469,7 +4469,7 @@ components:
               to:
                 type: string
                 description: 'Local path accessible by Agregarr (e.g., "/mnt/serverdata/tv")'
-                example: '/mnt/serverdata/tv'
+                example: "/mnt/serverdata/tv"
             required:
               - from
               - to
@@ -4629,10 +4629,10 @@ components:
             type: number
         overview:
           type: string
-          example: 'Overview of the movie'
+          example: "Overview of the movie"
         originalLanguage:
           type: string
-          example: 'en'
+          example: "en"
         title:
           type: string
           example: Movie Title
@@ -4672,10 +4672,10 @@ components:
             type: number
         overview:
           type: string
-          example: 'Overview of the movie'
+          example: "Overview of the movie"
         originalLanguage:
           type: string
-          example: 'en'
+          example: "en"
         name:
           type: string
           example: TV Show Name
@@ -4701,13 +4701,13 @@ components:
           example: false
         mediaType:
           type: string
-          default: 'person'
+          default: "person"
         knownFor:
           type: array
           items:
             oneOf:
-              - $ref: '#/components/schemas/MovieResult'
-              - $ref: '#/components/schemas/TvResult'
+              - $ref: "#/components/schemas/MovieResult"
+              - $ref: "#/components/schemas/TvResult"
     Genre:
       type: object
       properties:
@@ -4783,7 +4783,7 @@ components:
         site:
           type: string
           enum:
-            - 'YouTube'
+            - "YouTube"
     MovieDetails:
       type: object
       properties:
@@ -4793,7 +4793,7 @@ components:
           readOnly: true
         imdbId:
           type: string
-          example: 'tt123'
+          example: "tt123"
         adult:
           type: boolean
         backdropPath:
@@ -4806,13 +4806,13 @@ components:
         genres:
           type: array
           items:
-            $ref: '#/components/schemas/Genre'
+            $ref: "#/components/schemas/Genre"
         homepage:
           type: string
         relatedVideos:
           type: array
           items:
-            $ref: '#/components/schemas/RelatedVideo'
+            $ref: "#/components/schemas/RelatedVideo"
         originalLanguage:
           type: string
         originalTitle:
@@ -4824,7 +4824,7 @@ components:
         productionCompanies:
           type: array
           items:
-            $ref: '#/components/schemas/ProductionCompany'
+            $ref: "#/components/schemas/ProductionCompany"
         productionCountries:
           type: array
           items:
@@ -4846,7 +4846,7 @@ components:
                 properties:
                   iso_3166_1:
                     type: string
-                    example: 'US'
+                    example: "US"
                   rating:
                     type: string
                     nullable: true
@@ -4857,17 +4857,17 @@ components:
                       properties:
                         certification:
                           type: string
-                          example: 'PG-13'
+                          example: "PG-13"
                         iso_639_1:
                           type: string
                           nullable: true
                         note:
                           type: string
                           nullable: true
-                          example: 'Blu ray'
+                          example: "Blu ray"
                         release_date:
                           type: string
-                          example: '2017-07-12T00:00:00.000Z'
+                          example: "2017-07-12T00:00:00.000Z"
                         type:
                           type: number
                           example: 1
@@ -4902,11 +4902,11 @@ components:
             backdropPath:
               type: string
         externalIds:
-          $ref: '#/components/schemas/ExternalIds'
+          $ref: "#/components/schemas/ExternalIds"
         watchProviders:
           type: array
           items:
-            $ref: '#/components/schemas/WatchProviders'
+            $ref: "#/components/schemas/WatchProviders"
     Episode:
       type: object
       properties:
@@ -4955,7 +4955,7 @@ components:
         episodes:
           type: array
           items:
-            $ref: '#/components/schemas/Episode'
+            $ref: "#/components/schemas/Episode"
     TvDetails:
       type: object
       properties:
@@ -4976,10 +4976,10 @@ components:
                 properties:
                   iso_3166_1:
                     type: string
-                    example: 'US'
+                    example: "US"
                   rating:
                     type: string
-                    example: 'TV-14'
+                    example: "TV-14"
         createdBy:
           type: array
           items:
@@ -5003,7 +5003,7 @@ components:
         genres:
           type: array
           items:
-            $ref: '#/components/schemas/Genre'
+            $ref: "#/components/schemas/Genre"
         homepage:
           type: string
         inProduction:
@@ -5015,15 +5015,15 @@ components:
         lastAirDate:
           type: string
         lastEpisodeToAir:
-          $ref: '#/components/schemas/Episode'
+          $ref: "#/components/schemas/Episode"
         name:
           type: string
         nextEpisodeToAir:
-          $ref: '#/components/schemas/Episode'
+          $ref: "#/components/schemas/Episode"
         networks:
           type: array
           items:
-            $ref: '#/components/schemas/ProductionCompany'
+            $ref: "#/components/schemas/ProductionCompany"
         numberOfEpisodes:
           type: number
         numberOfSeason:
@@ -5043,7 +5043,7 @@ components:
         productionCompanies:
           type: array
           items:
-            $ref: '#/components/schemas/ProductionCompany'
+            $ref: "#/components/schemas/ProductionCompany"
         productionCountries:
           type: array
           items:
@@ -5056,7 +5056,7 @@ components:
         seasons:
           type: array
           items:
-            $ref: '#/components/schemas/Season'
+            $ref: "#/components/schemas/Season"
         status:
           type: string
         tagline:
@@ -5068,15 +5068,15 @@ components:
         voteCount:
           type: number
         externalIds:
-          $ref: '#/components/schemas/ExternalIds'
+          $ref: "#/components/schemas/ExternalIds"
         keywords:
           type: array
           items:
-            $ref: '#/components/schemas/Keyword'
+            $ref: "#/components/schemas/Keyword"
         watchProviders:
           type: array
           items:
-            $ref: '#/components/schemas/WatchProviders'
+            $ref: "#/components/schemas/WatchProviders"
     ExternalIds:
       type: object
       properties:
@@ -5142,14 +5142,14 @@ components:
           example: A Job Name
         cronSchedule:
           type: string
-          example: '0 */15 * * * *'
+          example: "0 */15 * * * *"
         nextExecutionTime:
           type: string
-          example: '2020-09-02T05:02:23.000Z'
+          example: "2020-09-02T05:02:23.000Z"
         followingExecutionTime:
           type: string
           nullable: true
-          example: '2020-09-02T05:17:23.000Z'
+          example: "2020-09-02T05:17:23.000Z"
         running:
           type: boolean
           example: false
@@ -5161,7 +5161,7 @@ components:
           example: 1
         name:
           type: string
-          example: 'anime'
+          example: "anime"
     SonarrSeries:
       type: object
       properties:
@@ -5303,10 +5303,10 @@ components:
           buy:
             type: array
             items:
-              $ref: '#/components/schemas/WatchProviderDetails'
+              $ref: "#/components/schemas/WatchProviderDetails"
           flatrate:
             items:
-              $ref: '#/components/schemas/WatchProviderDetails'
+              $ref: "#/components/schemas/WatchProviderDetails"
     WatchProviderDetails:
       type: object
       properties:
@@ -5342,18 +5342,18 @@ components:
           example: movie
         title:
           type: string
-          example: 'Fight Club'
+          example: "Fight Club"
         posterPath:
           type: string
           nullable: true
-          example: '/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg'
+          example: "/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg"
         year:
           type: integer
           nullable: true
           example: 1999
         collectionName:
           type: string
-          example: 'Trending Movies'
+          example: "Trending Movies"
         collectionSource:
           type: string
           enum:
@@ -5375,19 +5375,19 @@ components:
               filtered_hub,
               multi-source,
             ]
-          example: 'trakt'
+          example: "trakt"
         collectionSubtype:
           type: string
           nullable: true
-          example: 'trending'
+          example: "trending"
         requestService:
           type: string
           enum: [overseerr, radarr, sonarr]
-          example: 'overseerr'
+          example: "overseerr"
         requestMethod:
           type: string
           enum: [auto, manual]
-          example: 'auto'
+          example: "auto"
         requestStatus:
           type: string
           enum:
@@ -5400,7 +5400,7 @@ components:
               failed,
               partially_available,
             ]
-          example: 'approved'
+          example: "approved"
         overseerrRequestId:
           type: integer
           nullable: true
@@ -5414,23 +5414,23 @@ components:
               example: 1
             displayName:
               type: string
-              example: 'TraktAgregarr'
+              example: "TraktAgregarr"
         createdAt:
           type: string
           format: date-time
-          example: '2023-12-01T10:30:00Z'
+          example: "2023-12-01T10:30:00Z"
         requestedAt:
           type: string
           format: date-time
           nullable: true
-          example: '2023-12-01T10:35:00Z'
+          example: "2023-12-01T10:35:00Z"
     MissingItemsResponse:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/MissingItemRequest'
+            $ref: "#/components/schemas/MissingItemRequest"
         total:
           type: integer
           example: 150
@@ -5563,14 +5563,14 @@ components:
         timestamp:
           type: string
           format: date-time
-          example: '2024-01-15T10:30:00Z'
+          example: "2024-01-15T10:30:00Z"
     CollectionStatsResponse:
       type: object
       properties:
         collections:
           type: array
           items:
-            $ref: '#/components/schemas/CollectionStats'
+            $ref: "#/components/schemas/CollectionStats"
         metadata:
           type: object
           properties:
@@ -5580,32 +5580,32 @@ components:
             statType:
               type: string
               enum: [plays, duration]
-              example: 'plays'
+              example: "plays"
             days:
               type: integer
               example: 30
             timestamp:
               type: string
               format: date-time
-              example: '2024-01-15T10:30:00Z'
+              example: "2024-01-15T10:30:00Z"
     CollectionStats:
       type: object
       properties:
         rating_key:
           type: string
-          example: '12345'
+          example: "12345"
         title:
           type: string
-          example: 'Marvel Movies'
+          example: "Marvel Movies"
         media_type:
           type: string
-          example: 'collection'
+          example: "collection"
         section_id:
           type: integer
           example: 1
         section_name:
           type: string
-          example: 'Movies'
+          example: "Movies"
         item_count:
           type: integer
           example: 28
@@ -5644,7 +5644,7 @@ components:
             properties:
               friendly_name:
                 type: string
-                example: 'John Doe'
+                example: "John Doe"
               user_id:
                 type: integer
                 example: 1
@@ -5683,40 +5683,40 @@ components:
             timestamp:
               type: string
               format: date-time
-              example: '2024-01-15T10:30:00Z'
+              example: "2024-01-15T10:30:00Z"
     # Discovery-specific schemas that allow collectionType to be sent (not readOnly)
     PlexHubConfigForDiscovery:
       type: object
-      description: 'PlexHubConfig schema for discovery operations - allows collectionType to be sent'
+      description: "PlexHubConfig schema for discovery operations - allows collectionType to be sent"
       properties:
         id:
           type: string
-          description: 'Unique hub identifier (libraryId-hubIdentifier)'
-          example: '1-movie.recentlyadded'
+          description: "Unique hub identifier (libraryId-hubIdentifier)"
+          example: "1-movie.recentlyadded"
         hubIdentifier:
           type: string
-          description: 'Plex built-in hub identifier'
-          example: 'movie.recentlyadded'
+          description: "Plex built-in hub identifier"
+          example: "movie.recentlyadded"
         name:
           type: string
-          description: 'Display name for the hub'
-          example: 'Recently Added Movies'
+          description: "Display name for the hub"
+          example: "Recently Added Movies"
         libraryId:
           type: string
-          description: 'Plex library ID'
-          example: '1'
+          description: "Plex library ID"
+          example: "1"
         libraryName:
           type: string
-          description: 'Plex library display name'
-          example: 'Films'
+          description: "Plex library display name"
+          example: "Films"
         mediaType:
           type: string
-          enum: ['movie', 'tv', 'both']
-          description: 'Media type of the hub'
-          example: 'movie'
+          enum: ["movie", "tv", "both"]
+          description: "Media type of the hub"
+          example: "movie"
         sortOrderLibrary:
           type: integer
-          description: 'Position/order within the library'
+          description: "Position/order within the library"
           example: 0
         visibilityConfig:
           type: object
@@ -5731,7 +5731,7 @@ components:
               example: false
             libraryRecommended:
               type: boolean
-              description: 'Show in library recommended section'
+              description: "Show in library recommended section"
               example: false
           required:
             - usersHome
@@ -5739,25 +5739,25 @@ components:
             - libraryRecommended
         isActive:
           type: boolean
-          description: 'Whether hub is currently active'
+          description: "Whether hub is currently active"
           example: true
           readOnly: true
         collectionType:
           type: string
-          enum: ['default_plex_hub', 'agregarr_created', 'pre_existing']
-          description: 'Type of collection (determined during discovery)'
-          example: 'default_plex_hub'
+          enum: ["default_plex_hub", "agregarr_created", "pre_existing"]
+          description: "Type of collection (determined during discovery)"
+          example: "default_plex_hub"
         isLinked:
           type: boolean
-          description: 'True if hub is actively linked to other hubs'
+          description: "True if hub is actively linked to other hubs"
           example: false
         linkId:
           type: integer
-          description: 'Group ID for linked hubs'
+          description: "Group ID for linked hubs"
           example: 1
         isUnlinked:
           type: boolean
-          description: 'True if this hub was deliberately unlinked'
+          description: "True if this hub was deliberately unlinked"
           example: false
       required:
         - id
@@ -5772,42 +5772,42 @@ components:
 
     PlexHubManagementResponse:
       type: object
-      description: 'Raw Plex hub management API response with hub visibility and promotion data'
+      description: "Raw Plex hub management API response with hub visibility and promotion data"
       properties:
         MediaContainer:
           type: object
           properties:
             size:
               type: integer
-              description: 'Number of hubs in the response'
+              description: "Number of hubs in the response"
               example: 5
             Hub:
               type: array
-              description: 'Array of hub management data'
+              description: "Array of hub management data"
               items:
                 type: object
                 properties:
                   identifier:
                     type: string
-                    description: 'Plex hub identifier'
-                    example: 'movie.recentlyadded'
+                    description: "Plex hub identifier"
+                    example: "movie.recentlyadded"
                   title:
                     type: string
-                    description: 'Hub display title'
-                    example: 'Recently Added'
+                    description: "Hub display title"
+                    example: "Recently Added"
                   recommendationsVisibility:
                     type: string
-                    enum: ['all', 'none']
-                    description: 'Visibility in recommendations section'
-                    example: 'all'
+                    enum: ["all", "none"]
+                    description: "Visibility in recommendations section"
+                    example: "all"
                   homeVisibility:
                     type: string
-                    enum: ['all', 'none', 'admin']
-                    description: 'Visibility on home screen'
-                    example: 'all'
+                    enum: ["all", "none", "admin"]
+                    description: "Visibility on home screen"
+                    example: "all"
                   promotedToRecommended:
                     type: boolean
-                    description: 'Whether hub is promoted to recommended section'
+                    description: "Whether hub is promoted to recommended section"
                     example: true
                   promotedToOwnHome:
                     type: boolean
@@ -5819,7 +5819,7 @@ components:
                     example: true
                   deletable:
                     type: boolean
-                    description: 'Whether hub can be deleted (only for custom collections)'
+                    description: "Whether hub can be deleted (only for custom collections)"
                     example: true
                 required:
                   - identifier
@@ -5837,40 +5837,40 @@ components:
 
     PreExistingCollectionConfigForDiscovery:
       type: object
-      description: 'PreExistingCollectionConfig schema for discovery operations - allows collectionType to be sent'
+      description: "PreExistingCollectionConfig schema for discovery operations - allows collectionType to be sent"
       properties:
         id:
           type: string
-          description: 'Unique collection identifier (libraryId-collectionRatingKey)'
-          example: '1-35954'
+          description: "Unique collection identifier (libraryId-collectionRatingKey)"
+          example: "1-35954"
         collectionRatingKey:
           type: string
-          description: 'Plex collection rating key'
-          example: '35954'
+          description: "Plex collection rating key"
+          example: "35954"
         name:
           type: string
-          description: 'Display name from Plex'
-          example: 'Action Movies'
+          description: "Display name from Plex"
+          example: "Action Movies"
         libraryId:
           type: string
-          description: 'Plex library ID'
-          example: '1'
+          description: "Plex library ID"
+          example: "1"
         libraryName:
           type: string
-          description: 'Plex library display name'
-          example: 'Films'
+          description: "Plex library display name"
+          example: "Films"
         mediaType:
           type: string
-          enum: ['movie', 'tv', 'both']
-          description: 'Media type based on collection contents'
-          example: 'movie'
+          enum: ["movie", "tv", "both"]
+          description: "Media type based on collection contents"
+          example: "movie"
         sortOrderHome:
           type: integer
-          description: 'Position on Plex home screen'
+          description: "Position on Plex home screen"
           example: 0
         sortOrderLibrary:
           type: integer
-          description: 'Position in library'
+          description: "Position in library"
           example: 0
         visibilityConfig:
           type: object
@@ -5885,7 +5885,7 @@ components:
               example: false
             libraryRecommended:
               type: boolean
-              description: 'Show in library recommended section'
+              description: "Show in library recommended section"
               example: false
           required:
             - usersHome
@@ -5893,25 +5893,25 @@ components:
             - libraryRecommended
         isActive:
           type: boolean
-          description: 'Whether collection is currently active'
+          description: "Whether collection is currently active"
           example: true
           readOnly: true
         collectionType:
           type: string
-          enum: ['default_plex_hub', 'agregarr_created', 'pre_existing']
-          description: 'Type of collection (determined during discovery)'
-          example: 'pre_existing'
+          enum: ["default_plex_hub", "agregarr_created", "pre_existing"]
+          description: "Type of collection (determined during discovery)"
+          example: "pre_existing"
         isLinked:
           type: boolean
-          description: 'True if collection is actively linked to other collections'
+          description: "True if collection is actively linked to other collections"
           example: false
         linkId:
           type: integer
-          description: 'Group ID for linked collections'
+          description: "Group ID for linked collections"
           example: 1
         isUnlinked:
           type: boolean
-          description: 'True if this collection was deliberately unlinked'
+          description: "True if this collection was deliberately unlinked"
           example: false
         timeRestriction:
           type: object
@@ -5926,12 +5926,12 @@ components:
                 properties:
                   startDate:
                     type: string
-                    description: 'DD-MM format'
-                    example: '05-12'
+                    description: "DD-MM format"
+                    example: "05-12"
                   endDate:
                     type: string
-                    description: 'DD-MM format'
-                    example: '26-12'
+                    description: "DD-MM format"
+                    example: "26-12"
               nullable: true
             weeklySchedule:
               type: object
@@ -5954,11 +5954,11 @@ components:
           nullable: true
         customPoster:
           type: string
-          description: 'Custom poster filename'
+          description: "Custom poster filename"
           nullable: true
         autoPoster:
           type: boolean
-          description: 'Auto-generate poster during sync'
+          description: "Auto-generate poster during sync"
           example: true
           nullable: true
       required:
@@ -5975,48 +5975,48 @@ components:
 
     NetworksCountryOption:
       type: object
-      description: 'Country option for Networks collections'
+      description: "Country option for Networks collections"
       properties:
         value:
           type: string
-          description: 'Country code/identifier'
-          example: 'united-states'
+          description: "Country code/identifier"
+          example: "united-states"
         label:
           type: string
-          description: 'Display name for country'
-          example: 'United States'
+          description: "Display name for country"
+          example: "United States"
       required:
         - value
         - label
 
     NetworksPlatformOption:
       type: object
-      description: 'Platform option for Networks collections'
+      description: "Platform option for Networks collections"
       properties:
         value:
           type: string
-          description: 'Platform identifier for Networks collections'
-          example: 'netflix_top_10'
+          description: "Platform identifier for Networks collections"
+          example: "netflix_top_10"
         label:
           type: string
-          description: 'Display name for platform'
-          example: 'Netflix Top 10'
+          description: "Display name for platform"
+          example: "Netflix Top 10"
       required:
         - value
         - label
 
     OriginalsPlatformOption:
       type: object
-      description: 'Streaming service provider option for Originals collections'
+      description: "Streaming service provider option for Originals collections"
       properties:
         value:
           type: string
-          description: 'Provider identifier for Originals collections'
-          example: 'netflix_originals'
+          description: "Provider identifier for Originals collections"
+          example: "netflix_originals"
         label:
           type: string
-          description: 'Display name for streaming service provider'
-          example: 'Netflix Originals'
+          description: "Display name for streaming service provider"
+          example: "Netflix Originals"
       required:
         - value
         - label
@@ -6031,7 +6031,7 @@ components:
             properties:
               message:
                 type: string
-                example: 'not found'
+                example: "not found"
               errors:
                 type: array
                 items:
@@ -6039,10 +6039,10 @@ components:
                   properties:
                     path:
                       type: string
-                      example: '/api/v1/source-colors'
+                      example: "/api/v1/source-colors"
                     message:
                       type: string
-                      example: 'not found'
+                      example: "not found"
                   required:
                     - path
                     - message
@@ -6076,7 +6076,7 @@ paths:
             example: en-US
           description: Language to return genres in (TMDB locale).
       responses:
-        '200':
+        "200":
           description: Movie genres
           content:
             application/json:
@@ -6094,7 +6094,7 @@ paths:
                         name:
                           type: string
                           example: Action
-        '500':
+        "500":
           description: Unable to retrieve movie genres
 
   /discover/genres/tv:
@@ -6112,7 +6112,7 @@ paths:
             example: en-US
           description: Language to return genres in (TMDB locale).
       responses:
-        '200':
+        "200":
           description: TV genres
           content:
             application/json:
@@ -6130,7 +6130,7 @@ paths:
                         name:
                           type: string
                           example: Action & Adventure
-        '500':
+        "500":
           description: Unable to retrieve TV genres
 
   /countries:
@@ -6140,7 +6140,7 @@ paths:
       tags:
         - tmdb
       responses:
-        '200':
+        "200":
           description: Countries list
           content:
             application/json:
@@ -6158,7 +6158,7 @@ paths:
                     native_name:
                       type: string
                       example: United States
-        '500':
+        "500":
           description: Unable to retrieve countries
 
   /discover/watch-providers/movie:
@@ -6176,7 +6176,7 @@ paths:
             example: US
           description: ISO 3166-1 region code (defaults to US).
       responses:
-        '200':
+        "200":
           description: Movie watch providers
           content:
             application/json:
@@ -6199,7 +6199,7 @@ paths:
                       type: integer
                       nullable: true
                       example: 1
-        '500':
+        "500":
           description: Unable to retrieve movie watch providers
 
   /discover/watch-providers/tv:
@@ -6217,7 +6217,7 @@ paths:
             example: US
           description: ISO 3166-1 region code (defaults to US).
       responses:
-        '200':
+        "200":
           description: TV watch providers
           content:
             application/json:
@@ -6240,7 +6240,7 @@ paths:
                       type: integer
                       nullable: true
                       example: 1
-        '500':
+        "500":
           description: Unable to retrieve TV watch providers
 
   /genres/combined:
@@ -6250,7 +6250,7 @@ paths:
       tags:
         - tmdb
       responses:
-        '200':
+        "200":
           description: Combined genres list
           content:
             application/json:
@@ -6272,7 +6272,7 @@ paths:
       tags:
         - tmdb
       responses:
-        '200':
+        "200":
           description: Combined countries list
           content:
             application/json:
@@ -6294,7 +6294,7 @@ paths:
       tags:
         - tmdb
       responses:
-        '200':
+        "200":
           description: Combined languages list
           content:
             application/json:
@@ -6323,7 +6323,7 @@ paths:
             type: string
           description: Search query for keywords
       responses:
-        '200':
+        "200":
           description: Keyword search results
           content:
             application/json:
@@ -6351,9 +6351,9 @@ paths:
           schema:
             type: string
           description: Comma-separated list of TMDB keyword IDs
-          example: '210024,818'
+          example: "210024,818"
       responses:
-        '200':
+        "200":
           description: Resolved keywords
           content:
             application/json:
@@ -6382,7 +6382,7 @@ paths:
             type: integer
           description: TMDB movie ID
       responses:
-        '200':
+        "200":
           description: Movie details
           content:
             application/json:
@@ -6399,7 +6399,7 @@ paths:
                   poster_path:
                     type: string
                     nullable: true
-        '500':
+        "500":
           description: Unable to retrieve movie
   /tv/{id}:
     get:
@@ -6415,7 +6415,7 @@ paths:
             type: integer
           description: TMDB TV show ID
       responses:
-        '200':
+        "200":
           description: TV show details
           content:
             application/json:
@@ -6448,7 +6448,7 @@ paths:
                         air_date:
                           type: string
                           nullable: true
-        '500':
+        "500":
           description: Unable to retrieve TV show
   /status:
     get:
@@ -6458,7 +6458,7 @@ paths:
       tags:
         - public
       responses:
-        '200':
+        "200":
           description: Returned status
           content:
             application/json:
@@ -6484,7 +6484,7 @@ paths:
       tags:
         - public
       responses:
-        '200':
+        "200":
           description: Application data volume status and path
           content:
             application/json:
@@ -6512,7 +6512,7 @@ paths:
           description: Directory path to browse (defaults to /)
           example: /data/media
       responses:
-        '200':
+        "200":
           description: Directory listing
           content:
             application/json:
@@ -6540,11 +6540,11 @@ paths:
                         isDirectory:
                           type: boolean
                           example: true
-        '400':
+        "400":
           description: Path is not a directory
-        '404':
+        "404":
           description: Directory not found or not accessible
-        '500':
+        "500":
           description: Failed to browse directory
   /exclusions:
     get:
@@ -6553,7 +6553,7 @@ paths:
       tags:
         - exclusions
       responses:
-        '200':
+        "200":
           description: Global exclusions retrieved successfully with TMDB metadata
           content:
             application/json:
@@ -6627,7 +6627,7 @@ paths:
                   enum: [movie, tv]
                   example: movie
       responses:
-        '200':
+        "200":
           description: Item added to exclusions successfully
           content:
             application/json:
@@ -6648,7 +6648,7 @@ paths:
                         type:
                           type: string
                           enum: [tmdb, tvdb]
-        '400':
+        "400":
           description: Invalid request parameters
     delete:
       summary: Remove item from global exclusions
@@ -6677,7 +6677,7 @@ paths:
                   enum: [movie, tv]
                   example: movie
       responses:
-        '200':
+        "200":
           description: Item removed from exclusions successfully
           content:
             application/json:
@@ -6698,7 +6698,7 @@ paths:
                         type:
                           type: string
                           enum: [tmdb, tvdb]
-        '400':
+        "400":
           description: Invalid request parameters
   /collections:
     get:
@@ -6707,7 +6707,7 @@ paths:
       tags:
         - collections
       responses:
-        '200':
+        "200":
           description: Collection configurations retrieved successfully
           content:
             application/json:
@@ -6717,7 +6717,7 @@ paths:
                   collectionConfigs:
                     type: array
                     items:
-                      $ref: '#/components/schemas/CollectionConfig'
+                      $ref: "#/components/schemas/CollectionConfig"
     post:
       summary: Save collection configurations
       description: Updates collection configurations with the provided values.
@@ -6733,9 +6733,9 @@ paths:
                 collectionConfigs:
                   type: array
                   items:
-                    $ref: '#/components/schemas/CollectionConfig'
+                    $ref: "#/components/schemas/CollectionConfig"
       responses:
-        '200':
+        "200":
           description: Collection configurations saved successfully
           content:
             application/json:
@@ -6745,11 +6745,11 @@ paths:
                   collectionConfigs:
                     type: array
                     items:
-                      $ref: '#/components/schemas/CollectionConfig'
+                      $ref: "#/components/schemas/CollectionConfig"
                   message:
                     type: string
-                    example: 'Collection configurations saved successfully'
-        '500':
+                    example: "Collection configurations saved successfully"
+        "500":
           description: Failed to save collection configurations
   /collections/create:
     post:
@@ -6762,9 +6762,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CollectionConfigCreate'
+              $ref: "#/components/schemas/CollectionConfigCreate"
       responses:
-        '201':
+        "201":
           description: Collection created successfully
           content:
             application/json:
@@ -6772,11 +6772,11 @@ paths:
                 type: object
                 properties:
                   collectionConfig:
-                    $ref: '#/components/schemas/CollectionConfig'
+                    $ref: "#/components/schemas/CollectionConfig"
                   message:
                     type: string
-                    example: 'Collection created successfully'
-        '400':
+                    example: "Collection created successfully"
+        "400":
           description: Bad request (e.g., duplicate collection name in library)
           content:
             application/json:
@@ -6789,7 +6789,7 @@ paths:
                   message:
                     type: string
                     example: 'A collection with the name "Top 10 Movies" already exists in library "Movies". Please choose a different name or template.'
-        '500':
+        "500":
           description: Failed to create collection
   /collections/{id}/settings:
     put:
@@ -6804,15 +6804,15 @@ paths:
           description: Collection ID
           schema:
             type: string
-            example: 'collection-123'
+            example: "collection-123"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CollectionConfigUpdate'
+              $ref: "#/components/schemas/CollectionConfigUpdate"
       responses:
-        '200':
+        "200":
           description: Collection settings updated successfully
           content:
             application/json:
@@ -6820,11 +6820,11 @@ paths:
                 type: object
                 properties:
                   collectionConfig:
-                    $ref: '#/components/schemas/CollectionConfig'
+                    $ref: "#/components/schemas/CollectionConfig"
                   message:
                     type: string
-                    example: 'Collection settings updated successfully'
-        '400':
+                    example: "Collection settings updated successfully"
+        "400":
           description: Bad request (e.g., duplicate collection name in library)
           content:
             application/json:
@@ -6837,9 +6837,9 @@ paths:
                   message:
                     type: string
                     example: 'A collection with the name "Top 10 Movies" already exists in library "Movies". Please choose a different name or template.'
-        '404':
+        "404":
           description: Collection not found
-        '500':
+        "500":
           description: Failed to update collection settings
   /collections/{id}:
     delete:
@@ -6854,9 +6854,9 @@ paths:
           description: Collection ID
           schema:
             type: string
-            example: 'collection-123'
+            example: "collection-123"
       responses:
-        '200':
+        "200":
           description: Collection(s) deleted successfully
           content:
             application/json:
@@ -6865,7 +6865,7 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: '1 collection(s) deleted successfully'
+                    example: "1 collection(s) deleted successfully"
                   deletedConfigs:
                     type: array
                     items:
@@ -6875,7 +6875,7 @@ paths:
                           type: string
                         name:
                           type: string
-        '404':
+        "404":
           description: Collection not found
           content:
             application/json:
@@ -6884,11 +6884,11 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Collection not found'
+                    example: "Collection not found"
                   message:
                     type: string
                     example: 'Collection with id "collection-123" not found'
-        '500':
+        "500":
           description: Failed to delete collection
           content:
             application/json:
@@ -6897,7 +6897,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Failed to delete collection'
+                    example: "Failed to delete collection"
                   message:
                     type: string
   /collections/{id}/sync:
@@ -6913,9 +6913,9 @@ paths:
           description: Collection ID to sync
           schema:
             type: string
-            example: '10000'
+            example: "10000"
       responses:
-        '200':
+        "200":
           description: Collection sync started successfully
           content:
             application/json:
@@ -6924,17 +6924,17 @@ paths:
                 properties:
                   status:
                     type: string
-                    example: 'success'
+                    example: "success"
                   message:
                     type: string
                     example: 'Collection sync started for "Movie Collection"'
                   collectionId:
                     type: string
-                    example: '10000'
+                    example: "10000"
                   collectionName:
                     type: string
-                    example: 'Movie Collection'
-        '404':
+                    example: "Movie Collection"
+        "404":
           description: Collection not found
           content:
             application/json:
@@ -6943,11 +6943,11 @@ paths:
                 properties:
                   status:
                     type: string
-                    example: 'error'
+                    example: "error"
                   message:
                     type: string
-                    example: 'Collection with ID 10000 not found'
-        '500':
+                    example: "Collection with ID 10000 not found"
+        "500":
           description: Failed to start collection sync
           content:
             application/json:
@@ -6956,10 +6956,10 @@ paths:
                 properties:
                   status:
                     type: string
-                    example: 'error'
+                    example: "error"
                   message:
                     type: string
-                    example: 'Admin user not found'
+                    example: "Admin user not found"
   /collections/{id}/promote:
     patch:
       summary: Promote collection to top section
@@ -6973,9 +6973,9 @@ paths:
           description: Collection ID
           schema:
             type: string
-            example: 'collection-123'
+            example: "collection-123"
       responses:
-        '200':
+        "200":
           description: Collection promoted successfully
           content:
             application/json:
@@ -6986,8 +6986,8 @@ paths:
                     type: boolean
                     example: true
                   config:
-                    $ref: '#/components/schemas/CollectionConfig'
-        '400':
+                    $ref: "#/components/schemas/CollectionConfig"
+        "400":
           description: Collection is already in promoted section
           content:
             application/json:
@@ -6996,8 +6996,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Collection is already in promoted section'
-        '404':
+                    example: "Collection is already in promoted section"
+        "404":
           description: Collection not found
           content:
             application/json:
@@ -7006,8 +7006,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Collection not found'
-        '500':
+                    example: "Collection not found"
+        "500":
           description: Failed to promote collection
           content:
             application/json:
@@ -7016,7 +7016,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Failed to promote collection'
+                    example: "Failed to promote collection"
   /collections/{id}/demote:
     patch:
       summary: Demote collection to A-Z section
@@ -7030,9 +7030,9 @@ paths:
           description: Collection ID
           schema:
             type: string
-            example: 'collection-123'
+            example: "collection-123"
       responses:
-        '200':
+        "200":
           description: Collection demoted successfully
           content:
             application/json:
@@ -7043,8 +7043,8 @@ paths:
                     type: boolean
                     example: true
                   config:
-                    $ref: '#/components/schemas/CollectionConfig'
-        '400':
+                    $ref: "#/components/schemas/CollectionConfig"
+        "400":
           description: Collection is already in A-Z section
           content:
             application/json:
@@ -7053,8 +7053,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Collection is already in A-Z section'
-        '404':
+                    example: "Collection is already in A-Z section"
+        "404":
           description: Collection not found
           content:
             application/json:
@@ -7063,8 +7063,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Collection not found'
-        '500':
+                    example: "Collection not found"
+        "500":
           description: Failed to demote collection
           content:
             application/json:
@@ -7073,7 +7073,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Failed to demote collection'
+                    example: "Failed to demote collection"
   /collections/sync:
     get:
       summary: Get collections sync status
@@ -7081,7 +7081,7 @@ paths:
       tags:
         - collections
       responses:
-        '200':
+        "200":
           description: Sync status retrieved successfully
           content:
             application/json:
@@ -7093,14 +7093,14 @@ paths:
                     example: false
                   message:
                     type: string
-                    example: 'Not running'
+                    example: "Not running"
     post:
       summary: Start collection sync
       description: Starts a collection synchronization process in the background.
       tags:
         - collections
       responses:
-        '200':
+        "200":
           description: Collection sync started successfully
           content:
             application/json:
@@ -7109,13 +7109,13 @@ paths:
                 properties:
                   status:
                     type: string
-                    example: 'success'
+                    example: "success"
                   message:
                     type: string
-                    example: 'Collections sync started in background'
-        '400':
+                    example: "Collections sync started in background"
+        "400":
           description: Bad request - missing configuration or connection issue
-        '500':
+        "500":
           description: Failed to start collection sync
   /collections/sync/status:
     get:
@@ -7124,7 +7124,7 @@ paths:
       tags:
         - collections
       responses:
-        '200':
+        "200":
           description: Detailed sync status retrieved successfully
           content:
             application/json:
@@ -7138,7 +7138,7 @@ paths:
                   currentStage:
                     type: string
                     description: Current stage of the sync process
-                    example: 'Processing collections...'
+                    example: "Processing collections..."
                   totalCollections:
                     type: integer
                     description: Total number of collections to process
@@ -7155,7 +7155,7 @@ paths:
                     type: string
                     format: date-time
                     description: ISO timestamp of last successful global sync
-                    example: '2024-01-15T10:30:00.000Z'
+                    example: "2024-01-15T10:30:00.000Z"
                   globalSyncError:
                     type: string
                     nullable: true
@@ -7180,17 +7180,17 @@ paths:
               properties:
                 template:
                   type: string
-                  example: '{{mediaType}} {{type}} Collection'
+                  example: "{{mediaType}} {{type}} Collection"
                 mediaType:
                   type: string
                   enum: [movie, tv]
-                  example: 'movie'
+                  example: "movie"
                 type:
                   type: string
-                  example: 'trakt'
+                  example: "trakt"
                 subtype:
                   type: string
-                  example: ''
+                  example: ""
                 customDays:
                   type: number
                   example: 30
@@ -7201,7 +7201,7 @@ paths:
                 - template
                 - mediaType
       responses:
-        '200':
+        "200":
           description: Template preview generated successfully
           content:
             application/json:
@@ -7210,13 +7210,13 @@ paths:
                 properties:
                   status:
                     type: string
-                    example: 'success'
+                    example: "success"
                   preview:
                     type: string
-                    example: 'Movie Trakt Collection'
-        '400':
+                    example: "Movie Trakt Collection"
+        "400":
           description: Bad request - invalid template or parameters
-        '500':
+        "500":
           description: Failed to generate template preview
   /collections/fetch-title:
     get:
@@ -7230,7 +7230,7 @@ paths:
           required: true
           schema:
             type: string
-          example: 'https://www.imdb.com/list/ls123456789/'
+          example: "https://www.imdb.com/list/ls123456789/"
           description: External collection URL
         - in: query
           name: type
@@ -7238,10 +7238,10 @@ paths:
           schema:
             type: string
             enum: [trakt, tmdb, imdb, letterboxd, mdblist, anilist]
-          example: 'imdb'
+          example: "imdb"
           description: Collection source type
       responses:
-        '200':
+        "200":
           description: Server-Sent Events stream with progress updates
           content:
             text/event-stream:
@@ -7258,11 +7258,11 @@ paths:
                 data: {"stage":"complete","message":"Complete!"}
 
                 data: {"status":"success","title":"My IMDb List","mediaType":"movie","contentTypes":["movies"]}
-        '400':
+        "400":
           description: Bad request - missing or invalid parameters
-        '429':
+        "429":
           description: Too many requests - rate limited
-        '500':
+        "500":
           description: Internal server error
   /collections/detect-media-type:
     post:
@@ -7279,16 +7279,16 @@ paths:
               properties:
                 url:
                   type: string
-                  example: 'https://trakt.tv/users/username/lists/my-list'
+                  example: "https://trakt.tv/users/username/lists/my-list"
                 type:
                   type: string
                   enum: [trakt, tmdb, imdb, mdblist, letterboxd]
-                  example: 'trakt'
+                  example: "trakt"
               required:
                 - url
                 - type
       responses:
-        '200':
+        "200":
           description: Media type detected successfully
           content:
             application/json:
@@ -7297,17 +7297,17 @@ paths:
                 properties:
                   status:
                     type: string
-                    example: 'success'
+                    example: "success"
                   mediaType:
                     type: string
                     enum: [movie, tv, both]
-                    example: 'both'
-                    description: 'Detected media type based on comprehensive list analysis'
-        '400':
+                    example: "both"
+                    description: "Detected media type based on comprehensive list analysis"
+        "400":
           description: Bad request - invalid URL, unsupported type, or failed to analyze list content
-        '429':
+        "429":
           description: Too many requests - rate limited
-        '500':
+        "500":
           description: Internal server error while detecting media type
   /collections/poster:
     post:
@@ -7329,7 +7329,7 @@ paths:
               required:
                 - poster
       responses:
-        '200':
+        "200":
           description: Poster uploaded successfully
           content:
             application/json:
@@ -7338,15 +7338,15 @@ paths:
                 properties:
                   filename:
                     type: string
-                    example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
+                    example: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
                   url:
                     type: string
-                    example: '/api/v1/collections/poster/f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
-        '400':
+                    example: "/api/v1/collections/poster/f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
+        "400":
           description: Bad request - invalid file or upload error
-        '403':
+        "403":
           description: Authentication required
-        '500':
+        "500":
           description: Internal server error
   /collections/generate-poster:
     post:
@@ -7367,28 +7367,28 @@ paths:
                 collectionName:
                   type: string
                   description: Name of the collection to generate poster for
-                  example: 'Top Trakt Movies'
+                  example: "Top Trakt Movies"
                 collectionType:
                   type: string
                   description: Type of collection (trakt, tmdb, imdb, mdblist, letterboxd, tautulli, overseerr, hub)
-                  example: 'trakt'
+                  example: "trakt"
                 collectionSubtype:
                   type: string
                   description: Subtype of the collection
-                  example: 'popular'
+                  example: "popular"
                 mediaType:
                   type: string
                   enum: [movie, tv]
                   description: Media type for the collection
-                  example: 'movie'
+                  example: "movie"
                 template:
                   type: string
                   description: Collection template for additional context
-                  example: 'Top {count} {type} from Trakt'
+                  example: "Top {count} {type} from Trakt"
               required:
                 - collectionName
       responses:
-        '200':
+        "200":
           description: Poster generated successfully
           content:
             application/json:
@@ -7397,18 +7397,18 @@ paths:
                 properties:
                   filename:
                     type: string
-                    example: 'generated_abc123def.jpg'
+                    example: "generated_abc123def.jpg"
                   url:
                     type: string
-                    example: '/api/v1/collections/poster/generated_abc123def.jpg'
+                    example: "/api/v1/collections/poster/generated_abc123def.jpg"
                   message:
                     type: string
-                    example: 'Poster generated successfully'
-        '400':
+                    example: "Poster generated successfully"
+        "400":
           description: Bad request - missing or invalid collection name
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Internal server error
   /collections/download-poster:
     post:
@@ -7430,11 +7430,11 @@ paths:
                   type: string
                   format: uri
                   description: URL of the poster image to download
-                  example: 'https://example.com/poster.jpg'
+                  example: "https://example.com/poster.jpg"
               required:
                 - url
       responses:
-        '200':
+        "200":
           description: Poster downloaded successfully
           content:
             application/json:
@@ -7443,14 +7443,14 @@ paths:
                 properties:
                   filename:
                     type: string
-                    example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
+                    example: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
                   url:
                     type: string
-                    example: '/api/v1/collections/poster/f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
+                    example: "/api/v1/collections/poster/f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
                   message:
                     type: string
-                    example: 'Poster downloaded successfully'
-        '400':
+                    example: "Poster downloaded successfully"
+        "400":
           description: Bad request - invalid URL, unsupported format, or file too large
           content:
             application/json:
@@ -7459,10 +7459,10 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Invalid URL format'
-        '401':
+                    example: "Invalid URL format"
+        "401":
           description: Authentication required
-        '429':
+        "429":
           description: Too many requests - rate limit exceeded
           content:
             application/json:
@@ -7471,8 +7471,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Too many requests. Please try again later.'
-        '500':
+                    example: "Too many requests. Please try again later."
+        "500":
           description: Internal server error
   /collections/posters:
     get:
@@ -7484,7 +7484,7 @@ paths:
         - cookieAuth: []
         - apiKeyAuth: []
       responses:
-        '200':
+        "200":
           description: List of poster files
           content:
             application/json:
@@ -7499,14 +7499,14 @@ paths:
                         filename:
                           type: string
                           description: The filename of the poster
-                          example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
+                          example: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
                         url:
                           type: string
                           description: The URL to access the poster
-                          example: '/api/v1/collections/poster/f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
-        '401':
+                          example: "/api/v1/collections/poster/f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Internal server error
   /collections/poster/{filename}:
     get:
@@ -7521,7 +7521,7 @@ paths:
           description: The filename of the resource to retrieve or delete.
           schema:
             type: string
-            example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
+            example: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
         - in: query
           name: v
           required: false
@@ -7529,16 +7529,16 @@ paths:
           schema:
             type: number
       responses:
-        '200':
+        "200":
           description: Poster image served successfully
           content:
             image/jpeg:
               schema:
                 type: string
                 format: binary
-        '404':
+        "404":
           description: Poster not found
-        '500':
+        "500":
           description: Internal server error
     delete:
       summary: Delete a poster image
@@ -7552,7 +7552,7 @@ paths:
           description: The filename of the resource to retrieve or delete.
           schema:
             type: string
-            example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
+            example: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
         - in: query
           name: force
           required: false
@@ -7561,7 +7561,7 @@ paths:
             type: boolean
             default: false
       responses:
-        '200':
+        "200":
           description: Poster deleted successfully
           content:
             application/json:
@@ -7570,12 +7570,12 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Poster deleted successfully'
-        '403':
+                    example: "Poster deleted successfully"
+        "403":
           description: Authentication required
-        '404':
+        "404":
           description: Poster not found
-        '409':
+        "409":
           description: Poster is currently in use by collections
           content:
             application/json:
@@ -7584,7 +7584,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Poster is currently in use'
+                    example: "Poster is currently in use"
                   inUse:
                     type: boolean
                     example: true
@@ -7596,17 +7596,17 @@ paths:
                         type:
                           type: string
                           enum: [collection, preExisting]
-                          example: 'collection'
+                          example: "collection"
                         id:
                           type: string
-                          example: 'col_123'
+                          example: "col_123"
                         name:
                           type: string
-                          example: 'Marvel Movies'
+                          example: "Marvel Movies"
                         libraryName:
                           type: string
-                          example: 'Movies'
-        '500':
+                          example: "Movies"
+        "500":
           description: Internal server error
   /collections/poster/{filename}/usage:
     get:
@@ -7621,9 +7621,9 @@ paths:
           description: The filename of the poster to check.
           schema:
             type: string
-            example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
+            example: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
       responses:
-        '200':
+        "200":
           description: Usage information retrieved successfully
           content:
             application/json:
@@ -7632,7 +7632,7 @@ paths:
                 properties:
                   filename:
                     type: string
-                    example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
+                    example: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
                   inUse:
                     type: boolean
                     example: true
@@ -7644,21 +7644,21 @@ paths:
                         type:
                           type: string
                           enum: [collection, preExisting]
-                          example: 'collection'
+                          example: "collection"
                         id:
                           type: string
-                          example: 'col_123'
+                          example: "col_123"
                         name:
                           type: string
-                          example: 'Marvel Movies'
+                          example: "Marvel Movies"
                         libraryName:
                           type: string
-                          example: 'Movies'
-        '403':
+                          example: "Movies"
+        "403":
           description: Authentication required
-        '404':
+        "404":
           description: Poster not found
-        '500':
+        "500":
           description: Internal server error
   /collections/cleanup-missing:
     delete:
@@ -7667,7 +7667,7 @@ paths:
       tags:
         - collections
       responses:
-        '200':
+        "200":
           description: Missing collections cleaned up successfully
           content:
             application/json:
@@ -7676,18 +7676,18 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: '3 missing collection configurations removed successfully (2 also deleted from Plex hubs)'
+                    example: "3 missing collection configurations removed successfully (2 also deleted from Plex hubs)"
                   cleanupCount:
                     type: integer
-                    description: 'Number of configurations that were removed'
+                    description: "Number of configurations that were removed"
                     example: 3
                   hubDeleteCount:
                     type: integer
-                    description: 'Number of collections that were deleted from Plex hubs'
+                    description: "Number of collections that were deleted from Plex hubs"
                     example: 2
-        '403':
+        "403":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to cleanup missing collections
           content:
             application/json:
@@ -7696,7 +7696,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Failed to cleanup missing collections'
+                    example: "Failed to cleanup missing collections"
   /collections/networks/countries:
     get:
       summary: Get available countries for Networks collections
@@ -7704,15 +7704,15 @@ paths:
       tags:
         - collections-utility
       responses:
-        '200':
+        "200":
           description: Countries retrieved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/NetworksCountryOption'
-        '500':
+                  $ref: "#/components/schemas/NetworksCountryOption"
+        "500":
           description: Failed to fetch countries
           content:
             application/json:
@@ -7721,7 +7721,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Failed to load available countries'
+                    example: "Failed to load available countries"
   /collections/networks/platforms:
     get:
       summary: Get available platforms for a country
@@ -7735,17 +7735,17 @@ paths:
           schema:
             type: string
           description: Country code to get platforms for
-          example: 'united-states'
+          example: "united-states"
       responses:
-        '200':
+        "200":
           description: Platforms retrieved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/NetworksPlatformOption'
-        '400':
+                  $ref: "#/components/schemas/NetworksPlatformOption"
+        "400":
           description: Country parameter is required
           content:
             application/json:
@@ -7754,8 +7754,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Country parameter is required'
-        '500':
+                    example: "Country parameter is required"
+        "500":
           description: Failed to fetch platforms
           content:
             application/json:
@@ -7764,7 +7764,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Failed to load platforms for country'
+                    example: "Failed to load platforms for country"
   /collections/originals/providers:
     get:
       summary: Get available streaming providers for Originals collections
@@ -7772,15 +7772,15 @@ paths:
       tags:
         - collections-utility
       responses:
-        '200':
+        "200":
           description: Providers retrieved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/OriginalsPlatformOption'
-        '500':
+                  $ref: "#/components/schemas/OriginalsPlatformOption"
+        "500":
           description: Failed to fetch originals providers
           content:
             application/json:
@@ -7789,7 +7789,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Failed to fetch originals providers'
+                    example: "Failed to fetch originals providers"
   /collections/preview:
     post:
       summary: Start a collection preview
@@ -7837,11 +7837,11 @@ paths:
                 libraryId:
                   type: string
                   description: Plex library ID to match items against
-                  example: '1'
+                  example: "1"
                 customUrl:
                   type: string
                   description: Custom list URL (for custom list types)
-                  example: 'https://www.imdb.com/list/ls123456789/'
+                  example: "https://www.imdb.com/list/ls123456789/"
                 maxItems:
                   type: number
                   description: Maximum number of items to fetch
@@ -7862,22 +7862,22 @@ paths:
                 network:
                   type: string
                   description: Network name for network collections
-                  example: 'Netflix'
+                  example: "Netflix"
                 country:
                   type: string
                   description: Country code for network collections
-                  example: 'us'
+                  example: "us"
                 provider:
                   type: string
                   description: Provider name for originals collections
-                  example: 'netflix'
+                  example: "netflix"
                 tmdbAdvancedFilters:
                   type: object
                   description: Advanced TMDB discover filters configuration
                   additionalProperties: true
                 tmdbMovieSortBy:
                   type: string
-                  description: 'TMDB /discover/movie sort_by (only for TMDB Custom Advanced Filters)'
+                  description: "TMDB /discover/movie sort_by (only for TMDB Custom Advanced Filters)"
                   enum:
                     - original_title.asc
                     - original_title.desc
@@ -7897,7 +7897,7 @@ paths:
                   nullable: true
                 tmdbTvSortBy:
                   type: string
-                  description: 'TMDB /discover/tv sort_by (only for TMDB Custom Advanced Filters)'
+                  description: "TMDB /discover/tv sort_by (only for TMDB Custom Advanced Filters)"
                   enum:
                     - first_air_date.asc
                     - first_air_date.desc
@@ -7930,7 +7930,7 @@ paths:
                       id:
                         type: string
                         description: Unique identifier for this source
-                        example: 'source-1'
+                        example: "source-1"
                       type:
                         type: string
                         description: Collection source type
@@ -7952,20 +7952,20 @@ paths:
                             comingsoon,
                             filtered_hub,
                           ]
-                        example: 'imdb'
+                        example: "imdb"
                       subtype:
                         type: string
                         description: Collection sub-type
-                        example: 'top_250'
+                        example: "top_250"
                       customUrl:
                         type: string
                         description: Custom list URL for this source
-                        example: 'https://www.imdb.com/list/ls123456789/'
+                        example: "https://www.imdb.com/list/ls123456789/"
                       timePeriod:
                         type: string
                         description: Time period for Tautulli sources
                         enum: [daily, weekly, monthly, all, custom]
-                        example: 'weekly'
+                        example: "weekly"
                       priority:
                         type: number
                         description: Order priority when combining (0 = highest)
@@ -7981,7 +7981,7 @@ paths:
                       networksCountry:
                         type: string
                         description: Country code for network sources
-                        example: 'us'
+                        example: "us"
                       tmdbAdvancedFilters:
                         type: object
                         description: Advanced TMDB discover filters configuration
@@ -7990,14 +7990,14 @@ paths:
                   type: string
                   description: How to combine items from multiple sources
                   enum: [interleaved, list_order, randomised, cycle_lists]
-                  example: 'interleaved'
+                  example: "interleaved"
                 cycleIndex:
                   type: number
                   description: For cycle_lists mode, which source to show (0-based index)
                   example: 0
                   default: 0
       responses:
-        '202':
+        "202":
           description: Preview started successfully, poll /status/{sessionId} for progress
           content:
             application/json:
@@ -8006,11 +8006,11 @@ paths:
                 properties:
                   sessionId:
                     type: string
-                    example: 'preview-1234567890-abc123'
+                    example: "preview-1234567890-abc123"
                   message:
                     type: string
-                    example: 'Preview started, poll /status/:sessionId for progress'
-        '400':
+                    example: "Preview started, poll /status/:sessionId for progress"
+        "400":
           description: Bad request - missing required fields
           content:
             application/json:
@@ -8019,8 +8019,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Missing required fields: type and libraryId are required'
-        '500':
+                    example: "Missing required fields: type and libraryId are required"
+        "500":
           description: Failed to start preview
           content:
             application/json:
@@ -8029,7 +8029,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Failed to start preview'
+                    example: "Failed to start preview"
                   message:
                     type: string
   /collections/preview/status/{sessionId}:
@@ -8045,9 +8045,9 @@ paths:
           description: Session ID returned from POST /collections/preview
           schema:
             type: string
-            example: 'preview-1234567890-abc123'
+            example: "preview-1234567890-abc123"
       responses:
-        '200':
+        "200":
           description: Preview status
           content:
             application/json:
@@ -8061,7 +8061,7 @@ paths:
                   currentStage:
                     type: string
                     description: Current processing stage
-                    example: 'Fetching posters (75/250)...'
+                    example: "Fetching posters (75/250)..."
                   totalItems:
                     type: number
                     description: Total items to process
@@ -8094,10 +8094,10 @@ paths:
                           properties:
                             ratingKey:
                               type: string
-                              example: '12345'
+                              example: "12345"
                             title:
                               type: string
-                              example: 'The Shawshank Redemption'
+                              example: "The Shawshank Redemption"
                             year:
                               type: number
                               example: 1994
@@ -8110,7 +8110,7 @@ paths:
                               example: movie
                             posterUrl:
                               type: string
-                              example: 'https://image.tmdb.org/t/p/w500/q6y0Go1tsGEsmtFryDOJo3dEmqu.jpg'
+                              example: "https://image.tmdb.org/t/p/w500/q6y0Go1tsGEsmtFryDOJo3dEmqu.jpg"
                             inLibrary:
                               type: boolean
                               example: true
@@ -8123,7 +8123,7 @@ paths:
                       missingCount:
                         type: number
                         example: 50
-        '404':
+        "404":
           description: Preview session not found
           content:
             application/json:
@@ -8132,7 +8132,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Preview session not found'
+                    example: "Preview session not found"
   /collections/preview/download:
     post:
       summary: Download a missing item from preview
@@ -8191,7 +8191,7 @@ paths:
                   description: Collection source type for service user determination (optional)
                   example: trakt
       responses:
-        '200':
+        "200":
           description: Download request sent successfully
           content:
             application/json:
@@ -8242,7 +8242,7 @@ paths:
                       status:
                         type: number
                         example: 2
-        '400':
+        "400":
           description: Bad request
           content:
             application/json:
@@ -8251,8 +8251,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Missing required fields: tmdbId, mediaType, and service'
-        '500':
+                    example: "Missing required fields: tmdbId, mediaType, and service"
+        "500":
           description: Failed to download item
           content:
             application/json:
@@ -8261,7 +8261,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Failed to download item'
+                    example: "Failed to download item"
                   message:
                     type: string
   /collections/preexisting:
@@ -8271,7 +8271,7 @@ paths:
       tags:
         - collections
       responses:
-        '200':
+        "200":
           description: Pre-existing collections retrieved successfully
           content:
             application/json:
@@ -8285,31 +8285,31 @@ paths:
                       properties:
                         id:
                           type: string
-                          example: '12345'
+                          example: "12345"
                         name:
                           type: string
-                          example: 'My Collection'
+                          example: "My Collection"
                         summary:
                           type: string
-                          example: 'A collection of my favorite movies'
+                          example: "A collection of my favorite movies"
                         libraryId:
                           type: string
-                          example: '1'
+                          example: "1"
                         libraryTitle:
                           type: string
-                          example: 'Movies'
+                          example: "Movies"
                         itemCount:
                           type: number
                           example: 25
                         thumb:
                           type: string
-                          example: '/library/metadata/12345/thumb'
+                          example: "/library/metadata/12345/thumb"
                         art:
                           type: string
-                          example: '/library/metadata/12345/art'
+                          example: "/library/metadata/12345/art"
                         guid:
                           type: string
-                          example: 'com.plexapp.agents.none://12345'
+                          example: "com.plexapp.agents.none://12345"
                         updatedAt:
                           type: number
                           example: 1640995200
@@ -8320,9 +8320,9 @@ paths:
                           type: array
                           items:
                             type: object
-        '400':
+        "400":
           description: Bad request - Plex server not configured or no admin token
-        '500':
+        "500":
           description: Failed to fetch pre-existing collections
   /anilist/test-trending:
     get:
@@ -8331,7 +8331,7 @@ paths:
       tags:
         - other
       responses:
-        '200':
+        "200":
           description: Trending anime fetched successfully
           content:
             application/json:
@@ -8345,7 +8345,7 @@ paths:
                     type: array
                     items:
                       type: object
-        '500':
+        "500":
           description: Failed to fetch trending anime
   /anilist/list:
     get:
@@ -8362,7 +8362,7 @@ paths:
           required: true
           description: Type of anime list to fetch
       responses:
-        '200':
+        "200":
           description: AniList data fetched successfully
           content:
             application/json:
@@ -8376,9 +8376,9 @@ paths:
                     type: array
                     items:
                       type: object
-        '400':
+        "400":
           description: Invalid type parameter
-        '500':
+        "500":
           description: Failed to fetch AniList data
   /defaulthubs:
     get:
@@ -8387,15 +8387,15 @@ paths:
       tags:
         - default-hubs
       responses:
-        '200':
+        "200":
           description: Default hub configurations retrieved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/PlexHubConfig'
-        '500':
+                  $ref: "#/components/schemas/PlexHubConfig"
+        "500":
           description: Failed to retrieve hub configurations
     post:
       summary: Save default Plex hub configurations
@@ -8412,17 +8412,17 @@ paths:
                 hubConfigs:
                   type: array
                   items:
-                    $ref: '#/components/schemas/PlexHubConfig'
+                    $ref: "#/components/schemas/PlexHubConfig"
       responses:
-        '200':
+        "200":
           description: Hub configurations saved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/PlexHubConfig'
-        '500':
+                  $ref: "#/components/schemas/PlexHubConfig"
+        "500":
           description: Failed to save hub configurations
   /defaulthubs/{id}/settings:
     put:
@@ -8437,15 +8437,15 @@ paths:
           description: Default hub ID
           schema:
             type: string
-            example: '1-movie.recentlyadded'
+            example: "1-movie.recentlyadded"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PlexHubConfigUpdate'
+              $ref: "#/components/schemas/PlexHubConfigUpdate"
       responses:
-        '200':
+        "200":
           description: Default hub settings updated successfully
           content:
             application/json:
@@ -8453,13 +8453,13 @@ paths:
                 type: object
                 properties:
                   hubConfig:
-                    $ref: '#/components/schemas/PlexHubConfig'
+                    $ref: "#/components/schemas/PlexHubConfig"
                   message:
                     type: string
-                    example: 'Default hub settings updated successfully'
-        '404':
+                    example: "Default hub settings updated successfully"
+        "404":
           description: Default hub not found
-        '500':
+        "500":
           description: Failed to update default hub settings
   /defaulthubs/discover:
     post:
@@ -8477,9 +8477,9 @@ paths:
                 hubConfigs:
                   type: array
                   items:
-                    $ref: '#/components/schemas/PlexHubConfigForDiscovery'
+                    $ref: "#/components/schemas/PlexHubConfigForDiscovery"
       responses:
-        '200':
+        "200":
           description: Default hubs discovered successfully
           content:
             application/json:
@@ -8489,11 +8489,11 @@ paths:
                   hubConfigs:
                     type: array
                     items:
-                      $ref: '#/components/schemas/PlexHubConfig'
+                      $ref: "#/components/schemas/PlexHubConfig"
                   message:
                     type: string
-                    example: 'Default hubs discovered successfully'
-        '500':
+                    example: "Default hubs discovered successfully"
+        "500":
           description: Failed to discover default hubs
   /defaulthubs/append:
     post:
@@ -8511,9 +8511,9 @@ paths:
                 hubConfigs:
                   type: array
                   items:
-                    $ref: '#/components/schemas/PlexHubConfig'
+                    $ref: "#/components/schemas/PlexHubConfig"
       responses:
-        '200':
+        "200":
           description: Hub configurations appended successfully
           content:
             application/json:
@@ -8523,13 +8523,13 @@ paths:
                   hubConfigs:
                     type: array
                     items:
-                      $ref: '#/components/schemas/PlexHubConfig'
+                      $ref: "#/components/schemas/PlexHubConfig"
                   message:
                     type: string
-                    example: 'Default hub configurations appended successfully'
-        '400':
+                    example: "Default hub configurations appended successfully"
+        "400":
           description: Invalid request body
-        '500':
+        "500":
           description: Failed to append hub configurations
   /preexisting:
     get:
@@ -8538,15 +8538,15 @@ paths:
       tags:
         - pre-existing-collections
       responses:
-        '200':
+        "200":
           description: Pre-existing collection configurations retrieved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/PreExistingCollectionConfig'
-        '500':
+                  $ref: "#/components/schemas/PreExistingCollectionConfig"
+        "500":
           description: Failed to retrieve pre-existing collection configurations
     post:
       summary: Save pre-existing collection configurations
@@ -8563,17 +8563,17 @@ paths:
                 preExistingConfigs:
                   type: array
                   items:
-                    $ref: '#/components/schemas/PreExistingCollectionConfig'
+                    $ref: "#/components/schemas/PreExistingCollectionConfig"
       responses:
-        '200':
+        "200":
           description: Pre-existing collection configurations saved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/PreExistingCollectionConfig'
-        '500':
+                  $ref: "#/components/schemas/PreExistingCollectionConfig"
+        "500":
           description: Failed to save pre-existing collection configurations
   /preexisting/{id}/settings:
     put:
@@ -8588,15 +8588,15 @@ paths:
           description: Pre-existing collection ID
           schema:
             type: string
-            example: '1-35954'
+            example: "1-35954"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PreExistingCollectionConfigUpdate'
+              $ref: "#/components/schemas/PreExistingCollectionConfigUpdate"
       responses:
-        '200':
+        "200":
           description: Pre-existing collection settings updated successfully
           content:
             application/json:
@@ -8604,13 +8604,13 @@ paths:
                 type: object
                 properties:
                   preExistingCollectionConfig:
-                    $ref: '#/components/schemas/PreExistingCollectionConfig'
+                    $ref: "#/components/schemas/PreExistingCollectionConfig"
                   message:
                     type: string
-                    example: 'Pre-existing collection settings updated successfully'
-        '404':
+                    example: "Pre-existing collection settings updated successfully"
+        "404":
           description: Pre-existing collection not found
-        '500':
+        "500":
           description: Failed to update pre-existing collection settings
   /preexisting/{id}/promote:
     patch:
@@ -8625,9 +8625,9 @@ paths:
           description: Pre-existing collection ID
           schema:
             type: string
-            example: '1-35954'
+            example: "1-35954"
       responses:
-        '200':
+        "200":
           description: Pre-existing collection promoted successfully
           content:
             application/json:
@@ -8638,8 +8638,8 @@ paths:
                     type: boolean
                     example: true
                   config:
-                    $ref: '#/components/schemas/PreExistingCollectionConfig'
-        '400':
+                    $ref: "#/components/schemas/PreExistingCollectionConfig"
+        "400":
           description: Collection is already in promoted section
           content:
             application/json:
@@ -8648,8 +8648,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Collection is already in promoted section'
-        '404':
+                    example: "Collection is already in promoted section"
+        "404":
           description: Pre-existing collection not found
           content:
             application/json:
@@ -8658,8 +8658,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Pre-existing collection not found'
-        '500':
+                    example: "Pre-existing collection not found"
+        "500":
           description: Failed to promote pre-existing collection
           content:
             application/json:
@@ -8668,7 +8668,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Failed to promote pre-existing collection'
+                    example: "Failed to promote pre-existing collection"
   /preexisting/{id}/demote:
     patch:
       summary: Demote pre-existing collection to A-Z section
@@ -8682,9 +8682,9 @@ paths:
           description: Pre-existing collection ID
           schema:
             type: string
-            example: '1-35954'
+            example: "1-35954"
       responses:
-        '200':
+        "200":
           description: Pre-existing collection demoted successfully
           content:
             application/json:
@@ -8695,8 +8695,8 @@ paths:
                     type: boolean
                     example: true
                   config:
-                    $ref: '#/components/schemas/PreExistingCollectionConfig'
-        '400':
+                    $ref: "#/components/schemas/PreExistingCollectionConfig"
+        "400":
           description: Collection is already in A-Z section
           content:
             application/json:
@@ -8705,8 +8705,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Collection is already in A-Z section'
-        '404':
+                    example: "Collection is already in A-Z section"
+        "404":
           description: Pre-existing collection not found
           content:
             application/json:
@@ -8715,8 +8715,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Pre-existing collection not found'
-        '500':
+                    example: "Pre-existing collection not found"
+        "500":
           description: Failed to demote pre-existing collection
           content:
             application/json:
@@ -8725,7 +8725,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Failed to demote pre-existing collection'
+                    example: "Failed to demote pre-existing collection"
   /preexisting/discover:
     post:
       summary: Discover new pre-existing collections
@@ -8742,9 +8742,9 @@ paths:
                 preExistingCollectionConfigs:
                   type: array
                   items:
-                    $ref: '#/components/schemas/PreExistingCollectionConfigForDiscovery'
+                    $ref: "#/components/schemas/PreExistingCollectionConfigForDiscovery"
       responses:
-        '200':
+        "200":
           description: Pre-existing collections discovered successfully
           content:
             application/json:
@@ -8754,11 +8754,11 @@ paths:
                   preExistingCollectionConfigs:
                     type: array
                     items:
-                      $ref: '#/components/schemas/PreExistingCollectionConfig'
+                      $ref: "#/components/schemas/PreExistingCollectionConfig"
                   message:
                     type: string
-                    example: 'Pre-existing collections discovered successfully'
-        '500':
+                    example: "Pre-existing collections discovered successfully"
+        "500":
           description: Failed to discover pre-existing collections
   /preexisting/append:
     post:
@@ -8776,9 +8776,9 @@ paths:
                 preExistingCollectionConfigs:
                   type: array
                   items:
-                    $ref: '#/components/schemas/DiscoveredCollectionConfig'
+                    $ref: "#/components/schemas/DiscoveredCollectionConfig"
       responses:
-        '200':
+        "200":
           description: Pre-existing collection configurations appended successfully
           content:
             application/json:
@@ -8788,13 +8788,13 @@ paths:
                   preExistingCollectionConfigs:
                     type: array
                     items:
-                      $ref: '#/components/schemas/PreExistingCollectionConfig'
+                      $ref: "#/components/schemas/PreExistingCollectionConfig"
                   message:
                     type: string
-                    example: 'Pre-existing collection configurations appended successfully'
-        '400':
+                    example: "Pre-existing collection configurations appended successfully"
+        "400":
           description: Invalid request body
-        '500':
+        "500":
           description: Failed to append pre-existing collection configurations
   /ratings/movie/{tmdbId}:
     get:
@@ -8825,7 +8825,7 @@ paths:
             type: string
           description: IMDB ID (e.g. tt1234567) for IMDB rating lookup
       responses:
-        '200':
+        "200":
           description: Movie ratings
           content:
             application/json:
@@ -8867,9 +8867,9 @@ paths:
                         type: number
                       url:
                         type: string
-        '400':
+        "400":
           description: Invalid request
-        '500':
+        "500":
           description: Failed to fetch ratings
   /ratings/tv/{tmdbId}:
     get:
@@ -8900,7 +8900,7 @@ paths:
             type: string
           description: IMDB ID (e.g. tt1234567) for IMDB rating lookup
       responses:
-        '200':
+        "200":
           description: TV show ratings
           content:
             application/json:
@@ -8942,9 +8942,9 @@ paths:
                         type: number
                       url:
                         type: string
-        '400':
+        "400":
           description: Invalid request
-        '500':
+        "500":
           description: Failed to fetch ratings
   /reorder:
     post:
@@ -8961,24 +8961,24 @@ paths:
               properties:
                 libraryId:
                   type: string
-                  description: 'Plex library ID where reordering occurs'
-                  example: '1'
+                  description: "Plex library ID where reordering occurs"
+                  example: "1"
                 mixedItems:
                   type: array
-                  description: 'Array of mixed collection items in their new order'
+                  description: "Array of mixed collection items in their new order"
                   items:
                     type: object
                     properties:
                       id:
                         type: string
-                        description: 'Item ID'
+                        description: "Item ID"
                       configType:
                         type: string
-                        enum: ['collection', 'hub', 'preExisting']
-                        description: 'Type of collection item'
+                        enum: ["collection", "hub", "preExisting"]
+                        description: "Type of collection item"
                       position:
                         type: number
-                        description: 'Position in the mixed list'
+                        description: "Position in the mixed list"
                     additionalProperties: true
                     required:
                       - id
@@ -8986,15 +8986,15 @@ paths:
                       - position
                 context:
                   type: string
-                  enum: ['home', 'recommended', 'library']
-                  description: 'Context determining which sortOrder field to update'
-                  example: 'home'
+                  enum: ["home", "recommended", "library"]
+                  description: "Context determining which sortOrder field to update"
+                  example: "home"
               required:
                 - libraryId
                 - mixedItems
                 - context
       responses:
-        '200':
+        "200":
           description: Items reordered successfully
           content:
             application/json:
@@ -9006,18 +9006,18 @@ paths:
                     example: true
                   message:
                     type: string
-                    example: 'Successfully reordered 3 collections'
+                    example: "Successfully reordered 3 collections"
                   updatedItems:
                     type: array
-                    description: 'Items with updated sort orders'
+                    description: "Items with updated sort orders"
                     items:
                       oneOf:
-                        - $ref: '#/components/schemas/CollectionConfig'
-                        - $ref: '#/components/schemas/PlexHubConfig'
-                        - $ref: '#/components/schemas/PreExistingCollectionConfig'
-        '400':
+                        - $ref: "#/components/schemas/CollectionConfig"
+                        - $ref: "#/components/schemas/PlexHubConfig"
+                        - $ref: "#/components/schemas/PreExistingCollectionConfig"
+        "400":
           description: Invalid request parameters
-        '500':
+        "500":
           description: Failed to reorder items
   /settings/main:
     get:
@@ -9026,12 +9026,12 @@ paths:
       tags:
         - settings-general
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MainSettings'
+                $ref: "#/components/schemas/MainSettings"
     post:
       summary: Update main settings
       description: Updates main settings with the provided values.
@@ -9042,14 +9042,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MainSettings'
+              $ref: "#/components/schemas/MainSettings"
       responses:
-        '200':
-          description: 'Values were sucessfully updated'
+        "200":
+          description: "Values were sucessfully updated"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MainSettings'
+                $ref: "#/components/schemas/MainSettings"
   /settings/main/regenerate:
     post:
       summary: Get main settings with newly-generated API key
@@ -9057,12 +9057,12 @@ paths:
       tags:
         - settings-general
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MainSettings'
+                $ref: "#/components/schemas/MainSettings"
   /settings/youtube-cookies-status:
     get:
       summary: Check YouTube cookies file status
@@ -9070,7 +9070,7 @@ paths:
       tags:
         - settings-general
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -9088,7 +9088,7 @@ paths:
       tags:
         - settings
       responses:
-        '200':
+        "200":
           description: Reset completed successfully
           content:
             application/json:
@@ -9098,7 +9098,7 @@ paths:
                   success:
                     type: boolean
                     example: true
-        '500':
+        "500":
           description: Reset failed
           content:
             application/json:
@@ -9115,12 +9115,12 @@ paths:
       tags:
         - settings-plex
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PlexSettings'
+                $ref: "#/components/schemas/PlexSettings"
     post:
       summary: Update Plex settings
       description: Updates Plex settings with the provided values.
@@ -9131,14 +9131,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PlexSettings'
+              $ref: "#/components/schemas/PlexSettings"
       responses:
-        '200':
-          description: 'Values were successfully updated'
+        "200":
+          description: "Values were successfully updated"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PlexSettings'
+                $ref: "#/components/schemas/PlexSettings"
   /settings/plex/libraries:
     get:
       summary: Get Plex libraries directly from Plex server
@@ -9146,7 +9146,7 @@ paths:
       tags:
         - settings-plex
       responses:
-        '200':
+        "200":
           description: Plex libraries retrieved successfully
           content:
             application/json:
@@ -9158,23 +9158,23 @@ paths:
                     id:
                       type: string
                       description: Library ID from Plex
-                      example: '1'
+                      example: "1"
                     name:
                       type: string
                       description: Library name
-                      example: 'Movies'
+                      example: "Movies"
                     type:
                       type: string
                       enum: [movie, show]
                       description: Library media type
-                      example: 'movie'
+                      example: "movie"
                     enabled:
                       type: boolean
                       description: Always true for direct Plex libraries
                       example: true
-        '400':
+        "400":
           description: No admin Plex token found
-        '500':
+        "500":
           description: Failed to fetch Plex libraries
   /settings/plex/library:
     get:
@@ -9190,14 +9190,14 @@ paths:
             type: string
             nullable: true
       responses:
-        '200':
-          description: 'Plex libraries returned'
+        "200":
+          description: "Plex libraries returned"
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/PlexLibrary'
+                  $ref: "#/components/schemas/PlexLibrary"
   /settings/plex/sync:
     get:
       summary: Get status of full Plex library scan
@@ -9205,7 +9205,7 @@ paths:
       tags:
         - settings-plex
       responses:
-        '200':
+        "200":
           description: Status of Plex scan
           content:
             application/json:
@@ -9222,11 +9222,11 @@ paths:
                     type: number
                     example: 100
                   currentLibrary:
-                    $ref: '#/components/schemas/PlexLibrary'
+                    $ref: "#/components/schemas/PlexLibrary"
                   libraries:
                     type: array
                     items:
-                      $ref: '#/components/schemas/PlexLibrary'
+                      $ref: "#/components/schemas/PlexLibrary"
     post:
       summary: Start full Plex library scan
       description: Runs a full Plex library scan and returns the progress in a JSON array.
@@ -9245,7 +9245,7 @@ paths:
                   type: boolean
                   example: false
       responses:
-        '200':
+        "200":
           description: Status of Plex scan
           content:
             application/json:
@@ -9262,11 +9262,11 @@ paths:
                     type: number
                     example: 100
                   currentLibrary:
-                    $ref: '#/components/schemas/PlexLibrary'
+                    $ref: "#/components/schemas/PlexLibrary"
                   libraries:
                     type: array
                     items:
-                      $ref: '#/components/schemas/PlexLibrary'
+                      $ref: "#/components/schemas/PlexLibrary"
   /settings/plex/devices/servers:
     get:
       summary: Gets the user's available Plex servers
@@ -9274,14 +9274,14 @@ paths:
       tags:
         - settings-plex
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/PlexDevice'
+                  $ref: "#/components/schemas/PlexDevice"
   /settings/plex/users:
     get:
       summary: Get Plex users
@@ -9293,7 +9293,7 @@ paths:
         - settings-plex
         - users
       responses:
-        '200':
+        "200":
           description: Plex users
           content:
             application/json:
@@ -9353,7 +9353,7 @@ paths:
               required:
                 - poster
       responses:
-        '200':
+        "200":
           description: Poster uploaded successfully
           content:
             application/json:
@@ -9363,12 +9363,12 @@ paths:
                   filename:
                     type: string
                     description: The generated filename for the uploaded poster
-                    example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
+                    example: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
                   url:
                     type: string
                     description: The URL to access the uploaded poster
-                    example: '/api/v1/settings/collections/poster/f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
-        '400':
+                    example: "/api/v1/settings/collections/poster/f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
+        "400":
           description: Bad request - Invalid file or upload error
           content:
             application/json:
@@ -9378,15 +9378,15 @@ paths:
                   error:
                     type: string
                     enum:
-                      - 'No file uploaded'
-                      - 'Invalid file type. Only JPEG, PNG, and WebP are allowed.'
-                      - 'File extension does not match file type.'
-                      - 'File size too large. Maximum size: 10MB'
-                      - 'Invalid image format detected'
-                      - 'Image dimensions too large'
-                      - 'Failed to process poster'
-                    example: 'Invalid file type. Only JPEG, PNG, and WebP are allowed.'
-        '403':
+                      - "No file uploaded"
+                      - "Invalid file type. Only JPEG, PNG, and WebP are allowed."
+                      - "File extension does not match file type."
+                      - "File size too large. Maximum size: 10MB"
+                      - "Invalid image format detected"
+                      - "Image dimensions too large"
+                      - "Failed to process poster"
+                    example: "Invalid file type. Only JPEG, PNG, and WebP are allowed."
+        "403":
           description: Insufficient permissions
           content:
             application/json:
@@ -9395,8 +9395,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Insufficient permissions'
-        '500':
+                    example: "Insufficient permissions"
+        "500":
           description: Internal server error
           content:
             application/json:
@@ -9405,7 +9405,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Internal server error'
+                    example: "Internal server error"
   /settings/collections/poster/{filename}:
     get:
       summary: Serve collection poster image
@@ -9430,9 +9430,9 @@ paths:
           schema:
             type: string
             pattern: '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\.(jpg|jpeg|png|webp)$'
-            example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
+            example: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
       responses:
-        '200':
+        "200":
           description: Poster image served successfully
           content:
             image/jpeg:
@@ -9444,13 +9444,13 @@ paths:
               description: Caching directive
               schema:
                 type: string
-                example: 'public, max-age=31536000'
+                example: "public, max-age=31536000"
             Content-Type:
               description: Content type header
               schema:
                 type: string
-                example: 'image/jpeg'
-        '400':
+                example: "image/jpeg"
+        "400":
           description: Invalid filename format
           content:
             application/json:
@@ -9459,8 +9459,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Invalid filename'
-        '404':
+                    example: "Invalid filename"
+        "404":
           description: Poster not found
           content:
             application/json:
@@ -9469,8 +9469,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Poster not found'
-        '500':
+                    example: "Poster not found"
+        "500":
           description: Internal server error
           content:
             application/json:
@@ -9479,7 +9479,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Failed to serve poster'
+                    example: "Failed to serve poster"
     delete:
       summary: Delete collection poster image
       description: |
@@ -9507,9 +9507,9 @@ paths:
           schema:
             type: string
             pattern: '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\.(jpg|jpeg|png|webp)$'
-            example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg'
+            example: "f47ac10b-58cc-4372-a567-0e02b2c3d479.jpg"
       responses:
-        '200':
+        "200":
           description: Poster deleted successfully
           content:
             application/json:
@@ -9518,8 +9518,8 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Poster deleted successfully'
-        '400':
+                    example: "Poster deleted successfully"
+        "400":
           description: Invalid filename format
           content:
             application/json:
@@ -9528,8 +9528,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Invalid filename'
-        '403':
+                    example: "Invalid filename"
+        "403":
           description: Insufficient permissions
           content:
             application/json:
@@ -9538,8 +9538,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Insufficient permissions'
-        '404':
+                    example: "Insufficient permissions"
+        "404":
           description: Poster not found
           content:
             application/json:
@@ -9548,8 +9548,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Poster not found'
-        '500':
+                    example: "Poster not found"
+        "500":
           description: Internal server error
           content:
             application/json:
@@ -9558,7 +9558,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Internal server error'
+                    example: "Internal server error"
   /settings/tautulli:
     get:
       summary: Get Tautulli settings
@@ -9566,12 +9566,12 @@ paths:
       tags:
         - settings-integrations
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TautulliSettings'
+                $ref: "#/components/schemas/TautulliSettings"
     post:
       summary: Update Tautulli settings
       description: Updates Tautulli settings with the provided values.
@@ -9582,14 +9582,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TautulliSettings'
+              $ref: "#/components/schemas/TautulliSettings"
       responses:
-        '200':
-          description: 'Values were successfully updated'
+        "200":
+          description: "Values were successfully updated"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TautulliSettings'
+                $ref: "#/components/schemas/TautulliSettings"
   /settings/tautulli/test:
     post:
       summary: Test Tautulli connection
@@ -9605,25 +9605,25 @@ paths:
               properties:
                 hostname:
                   type: string
-                  example: 'tautulli.example.com'
+                  example: "tautulli.example.com"
                 port:
                   type: number
                   example: 8181
                 apiKey:
                   type: string
-                  example: 'your-api-key-here'
+                  example: "your-api-key-here"
                 useSsl:
                   type: boolean
                   example: false
                 urlBase:
                   type: string
-                  example: '/tautulli'
+                  example: "/tautulli"
               required:
                 - hostname
                 - apiKey
       responses:
-        '200':
-          description: 'Connection test successful'
+        "200":
+          description: "Connection test successful"
           content:
             application/json:
               schema:
@@ -9632,16 +9632,16 @@ paths:
                   success:
                     type: boolean
                     example: true
-        '400':
-          description: 'Invalid API key - Authentication failed (Tautulli returns 400 for bad API keys)'
-        '401':
-          description: 'Invalid API key - Authentication failed'
-        '403':
-          description: 'API key lacks required permissions'
-        '404':
-          description: 'Tautulli API not found at specified URL'
-        '500':
-          description: 'Connection test failed - Server error or network issue'
+        "400":
+          description: "Invalid API key - Authentication failed (Tautulli returns 400 for bad API keys)"
+        "401":
+          description: "Invalid API key - Authentication failed"
+        "403":
+          description: "API key lacks required permissions"
+        "404":
+          description: "Tautulli API not found at specified URL"
+        "500":
+          description: "Connection test failed - Server error or network issue"
   /settings/maintainerr:
     get:
       summary: Get Maintainerr settings
@@ -9649,12 +9649,12 @@ paths:
       tags:
         - settings-integrations
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MaintainerrSettings'
+                $ref: "#/components/schemas/MaintainerrSettings"
     post:
       summary: Update Maintainerr settings
       description: Updates Maintainerr settings with the provided values.
@@ -9665,14 +9665,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MaintainerrSettings'
+              $ref: "#/components/schemas/MaintainerrSettings"
       responses:
-        '200':
-          description: 'Values were successfully updated'
+        "200":
+          description: "Values were successfully updated"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MaintainerrSettings'
+                $ref: "#/components/schemas/MaintainerrSettings"
   /settings/maintainerr/test:
     post:
       summary: Test Maintainerr connection
@@ -9688,25 +9688,25 @@ paths:
               properties:
                 hostname:
                   type: string
-                  example: 'maintainerr.example.com'
+                  example: "maintainerr.example.com"
                 port:
                   type: number
                   example: 6246
                 apiKey:
                   type: string
-                  example: 'your-api-key-here'
+                  example: "your-api-key-here"
                 useSsl:
                   type: boolean
                   example: false
                 urlBase:
                   type: string
-                  example: ''
+                  example: ""
               required:
                 - hostname
                 - apiKey
       responses:
-        '200':
-          description: 'Connection test successful'
+        "200":
+          description: "Connection test successful"
           content:
             application/json:
               schema:
@@ -9715,16 +9715,16 @@ paths:
                   success:
                     type: boolean
                     example: true
-        '400':
-          description: 'Invalid API key - Authentication failed'
-        '401':
-          description: 'Invalid API key - Authentication failed'
-        '403':
-          description: 'API key lacks required permissions'
-        '404':
-          description: 'Maintainerr API not found at specified URL'
-        '500':
-          description: 'Connection test failed - Server error or network issue'
+        "400":
+          description: "Invalid API key - Authentication failed"
+        "401":
+          description: "Invalid API key - Authentication failed"
+        "403":
+          description: "API key lacks required permissions"
+        "404":
+          description: "Maintainerr API not found at specified URL"
+        "500":
+          description: "Connection test failed - Server error or network issue"
   /settings/trakt:
     get:
       summary: Get Trakt settings
@@ -9732,12 +9732,12 @@ paths:
       tags:
         - settings-integrations
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TraktSettings'
+                $ref: "#/components/schemas/TraktSettings"
     post:
       summary: Update Trakt settings
       description: Updates Trakt settings with the provided values.
@@ -9748,14 +9748,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TraktSettings'
+              $ref: "#/components/schemas/TraktSettings"
       responses:
-        '200':
-          description: 'Values were successfully updated'
+        "200":
+          description: "Values were successfully updated"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TraktSettings'
+                $ref: "#/components/schemas/TraktSettings"
   /settings/trakt/test:
     post:
       summary: Test Trakt connection
@@ -9784,8 +9784,8 @@ paths:
               required:
                 - clientId
       responses:
-        '200':
-          description: 'Connection test successful'
+        "200":
+          description: "Connection test successful"
           content:
             application/json:
               schema:
@@ -9794,10 +9794,10 @@ paths:
                   success:
                     type: boolean
                     example: true
-        '400':
-          description: 'Missing required parameters'
-        '500':
-          description: 'Connection test failed'
+        "400":
+          description: "Missing required parameters"
+        "500":
+          description: "Connection test failed"
   /settings/trakt/oauth/start:
     get:
       summary: Start Trakt OAuth flow
@@ -9805,8 +9805,8 @@ paths:
       tags:
         - settings-integrations
       responses:
-        '200':
-          description: 'Authorization URL generated'
+        "200":
+          description: "Authorization URL generated"
           content:
             application/json:
               schema:
@@ -9814,14 +9814,14 @@ paths:
                 properties:
                   url:
                     type: string
-                    description: 'Trakt OAuth authorization URL'
+                    description: "Trakt OAuth authorization URL"
                   state:
                     type: string
-                    description: 'Opaque state value for CSRF protection'
-        '400':
-          description: 'Client ID/Secret missing or application URL not configured'
-        '500':
-          description: 'Failed to create authorization URL'
+                    description: "Opaque state value for CSRF protection"
+        "400":
+          description: "Client ID/Secret missing or application URL not configured"
+        "500":
+          description: "Failed to create authorization URL"
   /settings/trakt/oauth/exchange:
     post:
       summary: Exchange Trakt authorization code for tokens
@@ -9847,8 +9847,8 @@ paths:
               required:
                 - code
       responses:
-        '200':
-          description: 'Tokens exchanged successfully'
+        "200":
+          description: "Tokens exchanged successfully"
           content:
             application/json:
               schema:
@@ -9864,10 +9864,10 @@ paths:
                   tokenExpiresAt:
                     type: integer
                     description: Expiration timestamp (ms since epoch)
-        '400':
-          description: 'Missing or invalid parameters'
-        '500':
-          description: 'Failed to exchange authorization code'
+        "400":
+          description: "Missing or invalid parameters"
+        "500":
+          description: "Failed to exchange authorization code"
   /trakt/oauth/exchange:
     post:
       summary: Exchange Trakt authorization code (public endpoint)
@@ -9893,8 +9893,8 @@ paths:
               required:
                 - code
       responses:
-        '200':
-          description: 'Tokens exchanged successfully'
+        "200":
+          description: "Tokens exchanged successfully"
           content:
             application/json:
               schema:
@@ -9910,10 +9910,10 @@ paths:
                   tokenExpiresAt:
                     type: integer
                     description: Expiration timestamp (ms since epoch)
-        '400':
-          description: 'Missing or invalid parameters'
-        '500':
-          description: 'Failed to exchange authorization code'
+        "400":
+          description: "Missing or invalid parameters"
+        "500":
+          description: "Failed to exchange authorization code"
   /settings/mdblist:
     get:
       summary: Get MDBList settings
@@ -9921,12 +9921,12 @@ paths:
       tags:
         - settings-integrations
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MDBListSettings'
+                $ref: "#/components/schemas/MDBListSettings"
     post:
       summary: Update MDBList settings
       description: Updates MDBList settings with the provided values.
@@ -9937,14 +9937,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MDBListSettings'
+              $ref: "#/components/schemas/MDBListSettings"
       responses:
-        '200':
-          description: 'Values were successfully updated'
+        "200":
+          description: "Values were successfully updated"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MDBListSettings'
+                $ref: "#/components/schemas/MDBListSettings"
   /settings/mdblist/test:
     post:
       summary: Test MDBList connection
@@ -9964,8 +9964,8 @@ paths:
               required:
                 - apiKey
       responses:
-        '200':
-          description: 'Connection test successful'
+        "200":
+          description: "Connection test successful"
           content:
             application/json:
               schema:
@@ -9974,10 +9974,10 @@ paths:
                   success:
                     type: boolean
                     example: true
-        '400':
-          description: 'Missing required parameters'
-        '500':
-          description: 'Connection test failed'
+        "400":
+          description: "Missing required parameters"
+        "500":
+          description: "Connection test failed"
   /settings/myanimelist:
     get:
       summary: Get MyAnimeList settings
@@ -9985,12 +9985,12 @@ paths:
       tags:
         - settings-integrations
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MyAnimeListSettings'
+                $ref: "#/components/schemas/MyAnimeListSettings"
     post:
       summary: Update MyAnimeList settings
       description: Updates MyAnimeList settings with the provided values.
@@ -10001,14 +10001,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MyAnimeListSettings'
+              $ref: "#/components/schemas/MyAnimeListSettings"
       responses:
-        '200':
-          description: 'Values were successfully updated'
+        "200":
+          description: "Values were successfully updated"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MyAnimeListSettings'
+                $ref: "#/components/schemas/MyAnimeListSettings"
   /settings/myanimelist/test:
     post:
       summary: Test MyAnimeList connection
@@ -10028,8 +10028,8 @@ paths:
               required:
                 - apiKey
       responses:
-        '200':
-          description: 'Connection test successful'
+        "200":
+          description: "Connection test successful"
           content:
             application/json:
               schema:
@@ -10038,10 +10038,10 @@ paths:
                   success:
                     type: boolean
                     example: true
-        '400':
-          description: 'Missing required parameters'
-        '500':
-          description: 'Connection test failed'
+        "400":
+          description: "Missing required parameters"
+        "500":
+          description: "Connection test failed"
   /settings/overseerr:
     get:
       summary: Get Overseerr settings
@@ -10049,12 +10049,12 @@ paths:
       tags:
         - settings-integrations
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OverseerrSettings'
+                $ref: "#/components/schemas/OverseerrSettings"
     post:
       summary: Update Overseerr settings
       description: Updates Overseerr connection settings and tests the connection.
@@ -10065,28 +10065,28 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OverseerrSettings'
+              $ref: "#/components/schemas/OverseerrSettings"
       responses:
-        '200':
-          description: 'Values were successfully updated'
+        "200":
+          description: "Values were successfully updated"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OverseerrSettings'
-        '500':
-          description: 'Connection test failed'
+                $ref: "#/components/schemas/OverseerrSettings"
+        "500":
+          description: "Connection test failed"
     delete:
       summary: Delete Overseerr settings
       description: Clears all Overseerr connection settings.
       tags:
         - settings-integrations
       responses:
-        '200':
-          description: 'Settings were successfully cleared'
+        "200":
+          description: "Settings were successfully cleared"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OverseerrSettings'
+                $ref: "#/components/schemas/OverseerrSettings"
   /overseerr/test:
     post:
       summary: Test Overseerr connection
@@ -10102,27 +10102,27 @@ paths:
               properties:
                 hostname:
                   type: string
-                  example: 'overseerr.example.com'
+                  example: "overseerr.example.com"
                 port:
                   type: number
                   example: 5055
                 apiKey:
                   type: string
-                  example: 'your-api-key-here'
+                  example: "your-api-key-here"
                 useSsl:
                   type: boolean
                   example: false
                 urlBase:
                   type: string
                   nullable: true
-                  example: '/overseerr'
+                  example: "/overseerr"
               required:
                 - hostname
                 - port
                 - apiKey
       responses:
-        '200':
-          description: 'Connection test successful with all server options'
+        "200":
+          description: "Connection test successful with all server options"
           content:
             application/json:
               schema:
@@ -10134,11 +10134,11 @@ paths:
                   templateDataSuccess:
                     type: boolean
                     example: true
-                    description: 'Whether template variables were successfully fetched'
+                    description: "Whether template variables were successfully fetched"
                   templateDataMessage:
                     type: string
-                    example: 'Template variables updated: Overseerr (https://overseerr.example.com)'
-                    description: 'Message about template variable fetch result'
+                    example: "Template variables updated: Overseerr (https://overseerr.example.com)"
+                    description: "Message about template variable fetch result"
                   servers:
                     type: object
                     properties:
@@ -10152,10 +10152,10 @@ paths:
                               example: 0
                             name:
                               type: string
-                              example: 'Radarr'
+                              example: "Radarr"
                             hostname:
                               type: string
-                              example: '192.168.0.236'
+                              example: "192.168.0.236"
                             port:
                               type: number
                               example: 7878
@@ -10175,10 +10175,10 @@ paths:
                               example: 0
                             name:
                               type: string
-                              example: 'Sonarr'
+                              example: "Sonarr"
                             hostname:
                               type: string
-                              example: '192.168.0.236'
+                              example: "192.168.0.236"
                             port:
                               type: number
                               example: 8989
@@ -10190,7 +10190,7 @@ paths:
                               example: true
                   radarrServerOptions:
                     type: object
-                    description: 'Quality profiles and root folders for all Radarr servers, keyed by server ID'
+                    description: "Quality profiles and root folders for all Radarr servers, keyed by server ID"
                     additionalProperties:
                       type: object
                       properties:
@@ -10204,7 +10204,7 @@ paths:
                                 example: 8
                               name:
                                 type: string
-                                example: '1080p Quality'
+                                example: "1080p Quality"
                         rootFolders:
                           type: array
                           items:
@@ -10215,10 +10215,10 @@ paths:
                                 example: 4
                               path:
                                 type: string
-                                example: '/data/media/movies'
+                                example: "/data/media/movies"
                   sonarrServerOptions:
                     type: object
-                    description: 'Quality profiles and root folders for all Sonarr servers, keyed by server ID'
+                    description: "Quality profiles and root folders for all Sonarr servers, keyed by server ID"
                     additionalProperties:
                       type: object
                       properties:
@@ -10232,7 +10232,7 @@ paths:
                                 example: 14
                               name:
                                 type: string
-                                example: '1080p Quality'
+                                example: "1080p Quality"
                         rootFolders:
                           type: array
                           items:
@@ -10243,17 +10243,17 @@ paths:
                                 example: 3
                               path:
                                 type: string
-                                example: '/data/media/series'
-        '400':
-          description: 'Missing required parameters'
-        '401':
-          description: 'Invalid API key - Authentication failed'
-        '403':
-          description: 'API key lacks required permissions'
-        '404':
-          description: 'Overseerr API not found at specified URL'
-        '500':
-          description: 'Connection test failed - Server error or network issue'
+                                example: "/data/media/series"
+        "400":
+          description: "Missing required parameters"
+        "401":
+          description: "Invalid API key - Authentication failed"
+        "403":
+          description: "API key lacks required permissions"
+        "404":
+          description: "Overseerr API not found at specified URL"
+        "500":
+          description: "Connection test failed - Server error or network issue"
   /settings/serviceuser:
     get:
       summary: Get service user settings
@@ -10261,12 +10261,12 @@ paths:
       tags:
         - settings-general
       responses:
-        '200':
-          description: 'Service user settings returned successfully'
+        "200":
+          description: "Service user settings returned successfully"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ServiceUserSettings'
+                $ref: "#/components/schemas/ServiceUserSettings"
     post:
       summary: Update service user settings
       description: Updates service user creation settings.
@@ -10277,16 +10277,16 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ServiceUserSettings'
+              $ref: "#/components/schemas/ServiceUserSettings"
       responses:
-        '200':
-          description: 'Service user settings updated successfully'
+        "200":
+          description: "Service user settings updated successfully"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ServiceUserSettings'
-        '500':
-          description: 'Settings update failed'
+                $ref: "#/components/schemas/ServiceUserSettings"
+        "500":
+          description: "Settings update failed"
   /settings/radarr:
     get:
       summary: Get Radarr settings
@@ -10294,14 +10294,14 @@ paths:
       tags:
         - settings-services
       responses:
-        '200':
-          description: 'Values were returned'
+        "200":
+          description: "Values were returned"
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/RadarrSettings'
+                  $ref: "#/components/schemas/RadarrSettings"
     post:
       summary: Create Radarr instance
       description: Creates a new Radarr instance from the request body.
@@ -10312,14 +10312,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RadarrSettings'
+              $ref: "#/components/schemas/RadarrSettings"
       responses:
-        '201':
-          description: 'New Radarr instance created'
+        "201":
+          description: "New Radarr instance created"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RadarrSettings'
+                $ref: "#/components/schemas/RadarrSettings"
   /settings/radarr/test:
     post:
       summary: Test Radarr configuration
@@ -10335,7 +10335,7 @@ paths:
               properties:
                 hostname:
                   type: string
-                  example: '127.0.0.1'
+                  example: "127.0.0.1"
                 port:
                   type: number
                   example: 7878
@@ -10351,7 +10351,7 @@ paths:
                 - hostname
                 - apiKey
       responses:
-        '200':
+        "200":
           description: Succesfully connected to Radarr instance
           content:
             application/json:
@@ -10361,7 +10361,7 @@ paths:
                   profiles:
                     type: array
                     items:
-                      $ref: '#/components/schemas/ServiceProfile'
+                      $ref: "#/components/schemas/ServiceProfile"
   /settings/radarr/alltags:
     get:
       summary: Get all Radarr tags from all instances
@@ -10369,14 +10369,14 @@ paths:
       tags:
         - settings-services
       responses:
-        '200':
+        "200":
           description: List of tags from all Radarr instances
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ServarrTag'
+                  $ref: "#/components/schemas/ServarrTag"
   /settings/radarr/{radarrId}:
     put:
       summary: Update Radarr instance
@@ -10395,14 +10395,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RadarrSettings'
+              $ref: "#/components/schemas/RadarrSettings"
       responses:
-        '200':
-          description: 'Radarr instance updated'
+        "200":
+          description: "Radarr instance updated"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RadarrSettings'
+                $ref: "#/components/schemas/RadarrSettings"
     delete:
       summary: Delete Radarr instance
       description: Deletes an existing Radarr instance based on the radarrId parameter.
@@ -10416,12 +10416,12 @@ paths:
             type: integer
           description: Radarr instance ID
       responses:
-        '200':
-          description: 'Radarr instance updated'
+        "200":
+          description: "Radarr instance updated"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RadarrSettings'
+                $ref: "#/components/schemas/RadarrSettings"
   /settings/radarr/{radarrId}/profiles:
     get:
       summary: Get available Radarr profiles
@@ -10436,14 +10436,14 @@ paths:
             type: integer
           description: Radarr instance ID
       responses:
-        '200':
+        "200":
           description: Returned list of profiles
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ServiceProfile'
+                  $ref: "#/components/schemas/ServiceProfile"
   /settings/radarr/{radarrId}/rootfolders:
     get:
       summary: Get available Radarr root folders
@@ -10458,7 +10458,7 @@ paths:
             type: integer
           description: Radarr instance ID
       responses:
-        '200':
+        "200":
           description: Returned list of root folders
           content:
             application/json:
@@ -10485,14 +10485,14 @@ paths:
             type: integer
           description: Radarr instance ID
       responses:
-        '200':
+        "200":
           description: Returned list of tags
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ServarrTag'
+                  $ref: "#/components/schemas/ServarrTag"
     post:
       summary: Create a new Radarr tag
       description: Creates a new tag in the Radarr instance and returns the created tag with its ID.
@@ -10519,15 +10519,15 @@ paths:
                   description: Tag label/name
                   example: agregarr-watchlist
       responses:
-        '201':
+        "201":
           description: Tag created successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ServarrTag'
-        '404':
+                $ref: "#/components/schemas/ServarrTag"
+        "404":
           description: Radarr instance not found
-        '500':
+        "500":
           description: Failed to create tag
   /settings/radarr/{radarrId}/autotag:
     get:
@@ -10574,7 +10574,7 @@ paths:
             type: string
           description: Collection name (used as fallback if subtype not provided)
       responses:
-        '200':
+        "200":
           description: Auto-generated tag label (null if tag mode is off)
           content:
             application/json:
@@ -10586,7 +10586,7 @@ paths:
                     nullable: true
                     description: The auto-generated tag label, or null if tagging is disabled
                     example: trakt-trending-agregarr
-        '404':
+        "404":
           description: Radarr instance not found
   /settings/sonarr:
     get:
@@ -10595,14 +10595,14 @@ paths:
       tags:
         - settings-services
       responses:
-        '200':
-          description: 'Values were returned'
+        "200":
+          description: "Values were returned"
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SonarrSettings'
+                  $ref: "#/components/schemas/SonarrSettings"
     post:
       summary: Create Sonarr instance
       description: Creates a new Sonarr instance from the request body.
@@ -10613,14 +10613,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SonarrSettings'
+              $ref: "#/components/schemas/SonarrSettings"
       responses:
-        '201':
-          description: 'New Sonarr instance created'
+        "201":
+          description: "New Sonarr instance created"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SonarrSettings'
+                $ref: "#/components/schemas/SonarrSettings"
   /settings/sonarr/test:
     post:
       summary: Test Sonarr configuration
@@ -10636,7 +10636,7 @@ paths:
               properties:
                 hostname:
                   type: string
-                  example: '127.0.0.1'
+                  example: "127.0.0.1"
                 port:
                   type: number
                   example: 8989
@@ -10652,7 +10652,7 @@ paths:
                 - hostname
                 - apiKey
       responses:
-        '200':
+        "200":
           description: Succesfully connected to Sonarr instance
           content:
             application/json:
@@ -10662,7 +10662,7 @@ paths:
                   profiles:
                     type: array
                     items:
-                      $ref: '#/components/schemas/ServiceProfile'
+                      $ref: "#/components/schemas/ServiceProfile"
   /settings/sonarr/alltags:
     get:
       summary: Get all Sonarr tags from all instances
@@ -10670,14 +10670,14 @@ paths:
       tags:
         - settings-services
       responses:
-        '200':
+        "200":
           description: List of tags from all Sonarr instances
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ServarrTag'
+                  $ref: "#/components/schemas/ServarrTag"
   /settings/sonarr/{sonarrId}:
     put:
       summary: Update Sonarr instance
@@ -10696,14 +10696,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SonarrSettings'
+              $ref: "#/components/schemas/SonarrSettings"
       responses:
-        '200':
-          description: 'Sonarr instance updated'
+        "200":
+          description: "Sonarr instance updated"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SonarrSettings'
+                $ref: "#/components/schemas/SonarrSettings"
     delete:
       summary: Delete Sonarr instance
       description: Deletes an existing Sonarr instance based on the sonarrId parameter.
@@ -10717,12 +10717,12 @@ paths:
             type: integer
           description: Sonarr instance ID
       responses:
-        '200':
-          description: 'Sonarr instance updated'
+        "200":
+          description: "Sonarr instance updated"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SonarrSettings'
+                $ref: "#/components/schemas/SonarrSettings"
   /settings/sonarr/{sonarrId}/profiles:
     get:
       summary: Get available Sonarr profiles
@@ -10737,14 +10737,14 @@ paths:
             type: integer
           description: Sonarr instance ID
       responses:
-        '200':
+        "200":
           description: Returned list of profiles
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ServiceProfile'
+                  $ref: "#/components/schemas/ServiceProfile"
   /settings/sonarr/{sonarrId}/rootfolders:
     get:
       summary: Get available Sonarr root folders
@@ -10759,7 +10759,7 @@ paths:
             type: integer
           description: Sonarr instance ID
       responses:
-        '200':
+        "200":
           description: Returned list of root folders
           content:
             application/json:
@@ -10786,14 +10786,14 @@ paths:
             type: integer
           description: Sonarr instance ID
       responses:
-        '200':
+        "200":
           description: Returned list of tags
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ServarrTag'
+                  $ref: "#/components/schemas/ServarrTag"
     post:
       summary: Create a new Sonarr tag
       description: Creates a new tag in the Sonarr instance and returns the created tag with its ID.
@@ -10820,15 +10820,15 @@ paths:
                   description: Tag label/name
                   example: agregarr-watchlist
       responses:
-        '201':
+        "201":
           description: Tag created successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ServarrTag'
-        '404':
+                $ref: "#/components/schemas/ServarrTag"
+        "404":
           description: Sonarr instance not found
-        '500':
+        "500":
           description: Failed to create tag
   /settings/sonarr/{sonarrId}/autotag:
     get:
@@ -10875,7 +10875,7 @@ paths:
             type: string
           description: Collection name (used as fallback if subtype not provided)
       responses:
-        '200':
+        "200":
           description: Auto-generated tag label (null if tag mode is off)
           content:
             application/json:
@@ -10887,7 +10887,7 @@ paths:
                     nullable: true
                     description: The auto-generated tag label, or null if tagging is disabled
                     example: trakt-trending-agregarr
-        '404':
+        "404":
           description: Sonarr instance not found
   /settings/watchlistsync:
     get:
@@ -10896,12 +10896,12 @@ paths:
       tags:
         - settings-services
       responses:
-        '200':
+        "200":
           description: Watchlist sync settings returned
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WatchlistSyncSettings'
+                $ref: "#/components/schemas/WatchlistSyncSettings"
     post:
       summary: Update watchlist sync settings
       description: Updates the Plex watchlist sync settings including enable flags and Radarr/Sonarr configurations.
@@ -10912,14 +10912,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/WatchlistSyncSettings'
+              $ref: "#/components/schemas/WatchlistSyncSettings"
       responses:
-        '200':
+        "200":
           description: Watchlist sync settings updated
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WatchlistSyncSettings'
+                $ref: "#/components/schemas/WatchlistSyncSettings"
   /settings/public:
     get:
       summary: Get public settings
@@ -10928,12 +10928,12 @@ paths:
       tags:
         - settings-general
       responses:
-        '200':
+        "200":
           description: Public settings returned
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PublicSettings'
+                $ref: "#/components/schemas/PublicSettings"
   /settings/initialize:
     post:
       summary: Initialize application
@@ -10941,12 +10941,12 @@ paths:
       tags:
         - settings-general
       responses:
-        '200':
+        "200":
           description: Public settings returned
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PublicSettings'
+                $ref: "#/components/schemas/PublicSettings"
   /settings/jobs:
     get:
       summary: Get scheduled jobs
@@ -10954,14 +10954,14 @@ paths:
       tags:
         - settings-system
       responses:
-        '200':
+        "200":
           description: Scheduled jobs returned
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Job'
+                  $ref: "#/components/schemas/Job"
   /settings/jobs/{jobId}/run:
     post:
       summary: Invoke a specific job
@@ -10976,12 +10976,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Invoked job returned
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Job'
+                $ref: "#/components/schemas/Job"
   /settings/jobs/{jobId}/cancel:
     post:
       summary: Cancel a specific job
@@ -10996,12 +10996,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Canceled job returned
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Job'
+                $ref: "#/components/schemas/Job"
   /settings/jobs/{jobId}/schedule:
     post:
       summary: Modify job schedule
@@ -11024,14 +11024,14 @@ paths:
               properties:
                 schedule:
                   type: string
-                  example: '0 */5 * * * *'
+                  example: "0 */5 * * * *"
       responses:
-        '200':
+        "200":
           description: Rescheduled job
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Job'
+                $ref: "#/components/schemas/Job"
   /settings/cache:
     get:
       summary: Get a list of active caches
@@ -11039,7 +11039,7 @@ paths:
       tags:
         - settings-system
       responses:
-        '200':
+        "200":
           description: Caches returned
           content:
             application/json:
@@ -11096,8 +11096,8 @@ paths:
           schema:
             type: string
       responses:
-        '204':
-          description: 'Flushed cache'
+        "204":
+          description: "Flushed cache"
   /settings/logs:
     get:
       summary: Returns logs
@@ -11135,7 +11135,7 @@ paths:
             nullable: true
             example: plex
       responses:
-        '200':
+        "200":
           description: Server log returned
           content:
             application/json:
@@ -11155,7 +11155,7 @@ paths:
                       example: Server ready on port 5055
                     timestamp:
                       type: string
-                      example: '2020-12-15T16:20:00.069Z'
+                      example: "2020-12-15T16:20:00.069Z"
   /settings/export-debug:
     post:
       summary: Export debugging information
@@ -11182,7 +11182,7 @@ paths:
                   description: Include logs directory in export
                   example: true
       responses:
-        '200':
+        "200":
           description: Debug export zip file
           content:
             application/zip:
@@ -11194,9 +11194,9 @@ paths:
               schema:
                 type: string
                 example: 'attachment; filename="agregarr-debug-2025-12-19T10-30-45.zip"'
-        '400':
+        "400":
           description: Invalid request (no items selected)
-        '500':
+        "500":
           description: Server error during export
   /settings/about:
     get:
@@ -11205,7 +11205,7 @@ paths:
       tags:
         - settings-general
       responses:
-        '200':
+        "200":
           description: Returned about settings
           content:
             application/json:
@@ -11214,7 +11214,7 @@ paths:
                 properties:
                   version:
                     type: string
-                    example: '1.0.0'
+                    example: "1.0.0"
                   totalRequests:
                     type: number
                     example: 100
@@ -11236,12 +11236,12 @@ paths:
         - auth
         - users
       responses:
-        '200':
+        "200":
           description: Object containing the logged-in user in JSON
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: "#/components/schemas/User"
   /auth/plex:
     post:
       summary: Sign in using a Plex token
@@ -11250,12 +11250,12 @@ paths:
       tags:
         - auth
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: "#/components/schemas/User"
       requestBody:
         required: true
         content:
@@ -11275,12 +11275,12 @@ paths:
       tags:
         - auth
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: "#/components/schemas/User"
       requestBody:
         required: true
         content:
@@ -11302,7 +11302,7 @@ paths:
       tags:
         - auth
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -11311,7 +11311,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    example: 'ok'
+                    example: "ok"
   /auth/reset-password:
     post:
       summary: Send a reset password email
@@ -11320,7 +11320,7 @@ paths:
       tags:
         - users
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -11329,7 +11329,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    example: 'ok'
+                    example: "ok"
       requestBody:
         required: true
         content:
@@ -11355,9 +11355,9 @@ paths:
           description: The globally unique identifier for the media item.
           schema:
             type: string
-            example: '9afef5a7-ec89-4d5f-9397-261e96970b50'
+            example: "9afef5a7-ec89-4d5f-9397-261e96970b50"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -11366,7 +11366,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    example: 'ok'
+                    example: "ok"
       requestBody:
         required: true
         content:
@@ -11407,7 +11407,7 @@ paths:
             enum: [created, updated, requests, displayname]
             default: created
       responses:
-        '200':
+        "200":
           description: A JSON array of all users
           content:
             application/json:
@@ -11415,11 +11415,11 @@ paths:
                 type: object
                 properties:
                   pageInfo:
-                    $ref: '#/components/schemas/PageInfo'
+                    $ref: "#/components/schemas/PageInfo"
                   results:
                     type: array
                     items:
-                      $ref: '#/components/schemas/User'
+                      $ref: "#/components/schemas/User"
     post:
       summary: Create new user
       description: |
@@ -11435,18 +11435,18 @@ paths:
               properties:
                 email:
                   type: string
-                  example: 'hey@itsme.com'
+                  example: "hey@itsme.com"
                 username:
                   type: string
                 permissions:
                   type: number
       responses:
-        '201':
+        "201":
           description: The created user
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: "#/components/schemas/User"
     put:
       summary: Update batch of users
       description: |
@@ -11469,14 +11469,14 @@ paths:
                 permissions:
                   type: integer
       responses:
-        '200':
+        "200":
           description: Successfully updated user details
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/User'
+                  $ref: "#/components/schemas/User"
   /user/import-from-plex:
     post:
       summary: Import all users from Plex
@@ -11498,14 +11498,14 @@ paths:
                   items:
                     type: string
       responses:
-        '201':
+        "201":
           description: A list of the newly created users
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/User'
+                  $ref: "#/components/schemas/User"
   /movie/{movieId}:
     get:
       summary: Get movie details
@@ -11527,12 +11527,12 @@ paths:
             type: string
             example: en
       responses:
-        '200':
+        "200":
           description: Movie details
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MovieDetails'
+                $ref: "#/components/schemas/MovieDetails"
   /movie/{movieId}/recommendations:
     get:
       summary: Get recommended movies
@@ -11561,7 +11561,7 @@ paths:
             type: string
             example: en
       responses:
-        '200':
+        "200":
           description: List of movies
           content:
             application/json:
@@ -11580,7 +11580,7 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: '#/components/schemas/MovieResult'
+                      $ref: "#/components/schemas/MovieResult"
   /movie/{movieId}/similar:
     get:
       summary: Get similar movies
@@ -11609,7 +11609,7 @@ paths:
             type: string
             example: en
       responses:
-        '200':
+        "200":
           description: List of movies
           content:
             application/json:
@@ -11628,7 +11628,7 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: '#/components/schemas/MovieResult'
+                      $ref: "#/components/schemas/MovieResult"
   /movie/{movieId}/ratings:
     get:
       summary: Get movie ratings
@@ -11644,7 +11644,7 @@ paths:
             type: number
             example: 337401
       responses:
-        '200':
+        "200":
           description: Ratings returned
           content:
             application/json:
@@ -11659,19 +11659,19 @@ paths:
                     example: 2020
                   url:
                     type: string
-                    example: 'http://www.rottentomatoes.com/m/mulan_2020/'
+                    example: "http://www.rottentomatoes.com/m/mulan_2020/"
                   criticsScore:
                     type: number
                     example: 85
                   criticsRating:
                     type: string
-                    enum: ['Rotten', 'Fresh', 'Certified Fresh']
+                    enum: ["Rotten", "Fresh", "Certified Fresh"]
                   audienceScore:
                     type: number
                     example: 65
                   audienceRating:
                     type: string
-                    enum: ['Spilled', 'Upright']
+                    enum: ["Spilled", "Upright"]
   /movie/{movieId}/ratingscombined:
     get:
       summary: Get RT and IMDB movie ratings combined
@@ -11687,7 +11687,7 @@ paths:
             type: number
             example: 337401
       responses:
-        '200':
+        "200":
           description: Ratings returned
           content:
             application/json:
@@ -11705,19 +11705,19 @@ paths:
                         example: 2020
                       url:
                         type: string
-                        example: 'http://www.rottentomatoes.com/m/mulan_2020/'
+                        example: "http://www.rottentomatoes.com/m/mulan_2020/"
                       criticsScore:
                         type: number
                         example: 85
                       criticsRating:
                         type: string
-                        enum: ['Rotten', 'Fresh', 'Certified Fresh']
+                        enum: ["Rotten", "Fresh", "Certified Fresh"]
                       audienceScore:
                         type: number
                         example: 65
                       audienceRating:
                         type: string
-                        enum: ['Spilled', 'Upright']
+                        enum: ["Spilled", "Upright"]
                   imdb:
                     type: object
                     properties:
@@ -11726,7 +11726,7 @@ paths:
                         example: I am Legend
                       url:
                         type: string
-                        example: 'https://www.imdb.com/title/tt0480249'
+                        example: "https://www.imdb.com/title/tt0480249"
                       criticsScore:
                         type: number
                         example: 6.5
@@ -11751,12 +11751,12 @@ paths:
             type: string
             example: en
       responses:
-        '200':
+        "200":
           description: TV details
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TvDetails'
+                $ref: "#/components/schemas/TvDetails"
   /tv/{tvId}/season/{seasonId}:
     get:
       summary: Get season details and episode list
@@ -11785,12 +11785,12 @@ paths:
             type: string
             example: en
       responses:
-        '200':
+        "200":
           description: TV details
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Season'
+                $ref: "#/components/schemas/Season"
   /media:
     get:
       summary: Get media
@@ -11836,7 +11836,7 @@ paths:
             enum: [added, modified, mediaAdded]
             default: added
       responses:
-        '200':
+        "200":
           description: Returned media
           content:
             application/json:
@@ -11844,7 +11844,7 @@ paths:
                 type: object
                 properties:
                   pageInfo:
-                    $ref: '#/components/schemas/PageInfo'
+                    $ref: "#/components/schemas/PageInfo"
                   results:
                     type: array
   /media/{mediaId}:
@@ -11858,11 +11858,11 @@ paths:
           name: mediaId
           description: Media ID
           required: true
-          example: '1'
+          example: "1"
           schema:
             type: string
       responses:
-        '204':
+        "204":
           description: Succesfully removed media item
   /media/{mediaId}/{status}:
     post:
@@ -11875,7 +11875,7 @@ paths:
           name: mediaId
           description: Media ID
           required: true
-          example: '1'
+          example: "1"
           schema:
             type: string
         - in: path
@@ -11896,7 +11896,7 @@ paths:
                   type: boolean
                   example: false
       responses:
-        '200':
+        "200":
           description: Returned media
   /media/{mediaId}/watch_data:
     get:
@@ -11912,11 +11912,11 @@ paths:
           name: mediaId
           description: Media ID
           required: true
-          example: '1'
+          example: "1"
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Users
           content:
             application/json:
@@ -11935,7 +11935,7 @@ paths:
                       users:
                         type: array
                         items:
-                          $ref: '#/components/schemas/User'
+                          $ref: "#/components/schemas/User"
                   data4k:
                     type: object
                     properties:
@@ -11948,7 +11948,7 @@ paths:
                       users:
                         type: array
                         items:
-                          $ref: '#/components/schemas/User'
+                          $ref: "#/components/schemas/User"
   /service/radarr:
     get:
       summary: Get non-sensitive Radarr server list
@@ -11956,14 +11956,14 @@ paths:
       tags:
         - service
       responses:
-        '200':
+        "200":
           description: Request successful
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/RadarrSettings'
+                  $ref: "#/components/schemas/RadarrSettings"
   /service/radarr/{radarrId}:
     get:
       summary: Get Radarr server quality profiles and root folders
@@ -11979,7 +11979,7 @@ paths:
             type: number
             example: 0
       responses:
-        '200':
+        "200":
           description: Request successful
           content:
             application/json:
@@ -11987,9 +11987,9 @@ paths:
                 type: object
                 properties:
                   server:
-                    $ref: '#/components/schemas/RadarrSettings'
+                    $ref: "#/components/schemas/RadarrSettings"
                   profiles:
-                    $ref: '#/components/schemas/ServiceProfile'
+                    $ref: "#/components/schemas/ServiceProfile"
   /service/sonarr:
     get:
       summary: Get non-sensitive Sonarr server list
@@ -11997,14 +11997,14 @@ paths:
       tags:
         - service
       responses:
-        '200':
+        "200":
           description: Request successful
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SonarrSettings'
+                  $ref: "#/components/schemas/SonarrSettings"
   /service/sonarr/{sonarrId}:
     get:
       summary: Get Sonarr server quality profiles and root folders
@@ -12020,7 +12020,7 @@ paths:
             type: number
             example: 0
       responses:
-        '200':
+        "200":
           description: Request successful
           content:
             application/json:
@@ -12028,9 +12028,9 @@ paths:
                 type: object
                 properties:
                   server:
-                    $ref: '#/components/schemas/SonarrSettings'
+                    $ref: "#/components/schemas/SonarrSettings"
                   profiles:
-                    $ref: '#/components/schemas/ServiceProfile'
+                    $ref: "#/components/schemas/ServiceProfile"
   /service/sonarr/lookup/{tmdbId}:
     get:
       summary: Get series from Sonarr
@@ -12046,14 +12046,14 @@ paths:
             type: number
             example: 0
       responses:
-        '200':
+        "200":
           description: Request successful
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SonarrSeries'
+                  $ref: "#/components/schemas/SonarrSeries"
   /backdrops:
     get:
       summary: Get backdrops of trending items
@@ -12062,7 +12062,7 @@ paths:
       tags:
         - tmdb
       responses:
-        '200':
+        "200":
           description: Results
           content:
             application/json:
@@ -12085,7 +12085,7 @@ paths:
             example: Rachel McAdams
           description: The search query string.
       responses:
-        '200':
+        "200":
           description: Person search results
           content:
             application/json:
@@ -12117,7 +12117,7 @@ paths:
                         profile_path:
                           type: string
                           nullable: true
-        '500':
+        "500":
           description: Unable to search for people
   /search/keyword:
     get:
@@ -12134,7 +12134,7 @@ paths:
             example: superhero
           description: The search query string.
       responses:
-        '200':
+        "200":
           description: Keyword search results
           content:
             application/json:
@@ -12158,7 +12158,7 @@ paths:
                         name:
                           type: string
                           example: superhero
-        '500':
+        "500":
           description: Unable to search for keywords
   /search/company:
     get:
@@ -12175,7 +12175,7 @@ paths:
             example: Marvel
           description: The search query string.
       responses:
-        '200':
+        "200":
           description: Company search results
           content:
             application/json:
@@ -12202,7 +12202,7 @@ paths:
                         logo_path:
                           type: string
                           nullable: true
-        '500':
+        "500":
           description: Unable to search for companies
   /keyword/{keywordId}:
     get:
@@ -12220,12 +12220,12 @@ paths:
             type: number
             example: 1
       responses:
-        '200':
+        "200":
           description: Keyword returned
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Keyword'
+                $ref: "#/components/schemas/Keyword"
   /person/{personId}:
     get:
       summary: Get person
@@ -12242,7 +12242,7 @@ paths:
             type: number
             example: 543530
       responses:
-        '200':
+        "200":
           description: Person returned
           content:
             application/json:
@@ -12333,12 +12333,12 @@ paths:
             enum: [overseerr, radarr, sonarr]
           description: Filter by request service
       responses:
-        '200':
+        "200":
           description: Missing item requests returned
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MissingItemsResponse'
+                $ref: "#/components/schemas/MissingItemsResponse"
   /missing-items/recent:
     get:
       summary: Get recent missing item requests
@@ -12356,7 +12356,7 @@ paths:
             maximum: 20
           description: Number of recent items to return
       responses:
-        '200':
+        "200":
           description: Recent missing item requests returned
           content:
             application/json:
@@ -12366,7 +12366,7 @@ paths:
                   results:
                     type: array
                     items:
-                      $ref: '#/components/schemas/MissingItemRequest'
+                      $ref: "#/components/schemas/MissingItemRequest"
   /missing-items/stats:
     get:
       summary: Get missing item statistics
@@ -12375,12 +12375,12 @@ paths:
       tags:
         - missing-items
       responses:
-        '200':
+        "200":
           description: Missing item statistics returned
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MissingItemStats'
+                $ref: "#/components/schemas/MissingItemStats"
   /missing-items/sync:
     post:
       summary: Sync missing item status
@@ -12391,7 +12391,7 @@ paths:
       tags:
         - missing-items
       responses:
-        '200':
+        "200":
           description: Missing item status sync completed successfully
           content:
             application/json:
@@ -12400,8 +12400,8 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Missing item status sync completed'
-        '500':
+                    example: "Missing item status sync completed"
+        "500":
           description: Failed to sync missing item status
           content:
             application/json:
@@ -12410,7 +12410,7 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Failed to sync missing item status'
+                    example: "Failed to sync missing item status"
   /dashboard/stats:
     get:
       summary: Get dashboard statistics
@@ -12419,13 +12419,13 @@ paths:
       tags:
         - dashboard
       responses:
-        '200':
+        "200":
           description: Dashboard statistics returned successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DashboardStats'
-        '500':
+                $ref: "#/components/schemas/DashboardStats"
+        "500":
           description: Failed to get dashboard statistics
           content:
             application/json:
@@ -12434,10 +12434,10 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Failed to get dashboard stats'
+                    example: "Failed to get dashboard stats"
                   message:
                     type: string
-                    example: 'Tautulli connection failed'
+                    example: "Tautulli connection failed"
   /dashboard/collections:
     get:
       summary: Get collection statistics
@@ -12470,13 +12470,13 @@ paths:
             maximum: 365
           description: Number of days to include in statistics
       responses:
-        '200':
+        "200":
           description: Collection statistics returned successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CollectionStatsResponse'
-        '400':
+                $ref: "#/components/schemas/CollectionStatsResponse"
+        "400":
           description: Tautulli not configured
           content:
             application/json:
@@ -12485,11 +12485,11 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Tautulli not configured'
+                    example: "Tautulli not configured"
                   message:
                     type: string
-                    example: 'Tautulli settings are required to fetch collection statistics'
-        '500':
+                    example: "Tautulli settings are required to fetch collection statistics"
+        "500":
           description: Failed to get collection statistics
           content:
             application/json:
@@ -12498,10 +12498,10 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Failed to get collection statistics'
+                    example: "Failed to get collection statistics"
                   message:
                     type: string
-                    example: 'Tautulli API error'
+                    example: "Tautulli API error"
   /dashboard/activity:
     get:
       summary: Get activity statistics
@@ -12527,13 +12527,13 @@ paths:
             maximum: 50
           description: Number of items to return
       responses:
-        '200':
+        "200":
           description: Activity statistics returned successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ActivityStatsResponse'
-        '400':
+                $ref: "#/components/schemas/ActivityStatsResponse"
+        "400":
           description: Tautulli not configured
           content:
             application/json:
@@ -12542,11 +12542,11 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Tautulli not configured'
+                    example: "Tautulli not configured"
                   message:
                     type: string
-                    example: 'Tautulli settings are required to fetch activity statistics'
-        '500':
+                    example: "Tautulli settings are required to fetch activity statistics"
+        "500":
           description: Failed to get activity statistics
           content:
             application/json:
@@ -12555,10 +12555,10 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Failed to get activity statistics'
+                    example: "Failed to get activity statistics"
                   message:
                     type: string
-                    example: 'Tautulli API error'
+                    example: "Tautulli API error"
 
   # Hub Management Endpoints
   /hubs/configs:
@@ -12568,7 +12568,7 @@ paths:
       tags:
         - hubs
       responses:
-        '200':
+        "200":
           description: Hub configurations returned successfully
           content:
             application/json:
@@ -12578,12 +12578,12 @@ paths:
                   hubConfigs:
                     type: array
                     items:
-                      $ref: '#/components/schemas/PlexHubConfig'
+                      $ref: "#/components/schemas/PlexHubConfig"
                   preExistingCollectionConfigs:
                     type: array
                     items:
-                      $ref: '#/components/schemas/PlexHubConfig'
-        '500':
+                      $ref: "#/components/schemas/PlexHubConfig"
+        "500":
           description: Failed to get hub configurations
     post:
       summary: Save Plex hub configurations
@@ -12600,17 +12600,17 @@ paths:
                 hubConfigs:
                   type: array
                   items:
-                    $ref: '#/components/schemas/PlexHubConfig'
+                    $ref: "#/components/schemas/PlexHubConfig"
                 preExistingCollectionConfigs:
                   type: array
                   items:
-                    $ref: '#/components/schemas/PlexHubConfig'
+                    $ref: "#/components/schemas/PlexHubConfig"
       responses:
-        '200':
+        "200":
           description: Configurations saved successfully
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Failed to save configurations
 
   /hubs/configs/append:
@@ -12629,17 +12629,17 @@ paths:
                 hubConfigs:
                   type: array
                   items:
-                    $ref: '#/components/schemas/PlexHubConfig'
+                    $ref: "#/components/schemas/PlexHubConfig"
                 preExistingCollectionConfigs:
                   type: array
                   items:
-                    $ref: '#/components/schemas/PlexHubConfig'
+                    $ref: "#/components/schemas/PlexHubConfig"
       responses:
-        '200':
+        "200":
           description: Configurations appended successfully
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Failed to append configurations
 
   /hubs/libraries/{sectionId}/move:
@@ -12671,11 +12671,11 @@ paths:
               required:
                 - hubId
       responses:
-        '200':
+        "200":
           description: Hub moved successfully
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Failed to move hub
 
   /hubs/libraries/{sectionId}/reorder:
@@ -12706,11 +12706,11 @@ paths:
               required:
                 - hubOrder
       responses:
-        '200':
+        "200":
           description: Hubs reordered successfully
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Failed to reorder hubs
 
   /hubs/libraries/{sectionId}/visibility:
@@ -12743,11 +12743,11 @@ paths:
                 - hubId
                 - visibility
       responses:
-        '200':
+        "200":
           description: Hub visibility updated successfully
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Failed to update hub visibility
 
   # Discovery Endpoints
@@ -12758,17 +12758,17 @@ paths:
       tags:
         - search
       responses:
-        '200':
+        "200":
           description: Library hubs returned successfully
           content:
             application/json:
               schema:
                 type: object
-                description: 'Object with library section IDs as keys and hub data as values'
+                description: "Object with library section IDs as keys and hub data as values"
                 additionalProperties:
                   type: object
-                  description: 'Raw Plex hub response data for a library section'
-        '500':
+                  description: "Raw Plex hub response data for a library section"
+        "500":
           description: Failed to fetch library hubs
 
   /discovery/hubs/libraries/{sectionId}:
@@ -12785,14 +12785,14 @@ paths:
             type: string
           description: Plex library section ID
       responses:
-        '200':
+        "200":
           description: Library hubs returned successfully
           content:
             application/json:
               schema:
                 type: object
-                description: 'Raw Plex hub response data for the specified library section'
-        '500':
+                description: "Raw Plex hub response data for the specified library section"
+        "500":
           description: Failed to fetch library hubs
 
   /discovery/hubs/libraries/{sectionId}/manage:
@@ -12809,13 +12809,13 @@ paths:
             type: string
           description: Plex library section ID
       responses:
-        '200':
+        "200":
           description: Hub management data returned successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PlexHubManagementResponse'
-        '500':
+                $ref: "#/components/schemas/PlexHubManagementResponse"
+        "500":
           description: Failed to fetch hub management data
 
   /discovery/hubs/scan:
@@ -12825,7 +12825,7 @@ paths:
       tags:
         - search
       responses:
-        '200':
+        "200":
           description: Hub discovery completed successfully
           content:
             application/json:
@@ -12837,18 +12837,18 @@ paths:
                   discoveredHubConfigs:
                     type: array
                     items:
-                      $ref: '#/components/schemas/PlexHubConfig'
+                      $ref: "#/components/schemas/PlexHubConfig"
                   discoveredPreExistingConfigs:
                     type: array
                     items:
-                      $ref: '#/components/schemas/PlexHubConfig'
+                      $ref: "#/components/schemas/PlexHubConfig"
                   totalHubsFound:
                     type: integer
                   totalPreExistingCollectionsFound:
                     type: integer
                   totalActualCollections:
                     type: integer
-        '500':
+        "500":
           description: Failed to discover Plex hubs
 
   /discovery/hubs/status:
@@ -12858,7 +12858,7 @@ paths:
       tags:
         - search
       responses:
-        '200':
+        "200":
           description: Hub management status returned successfully
           content:
             application/json:
@@ -12882,7 +12882,7 @@ paths:
                         type: boolean
                       collectionHubManagement:
                         type: boolean
-        '500':
+        "500":
           description: Failed to get hub management status
 
   # Poster Management Endpoints
@@ -12893,7 +12893,7 @@ paths:
       tags:
         - poster-templates
       responses:
-        '200':
+        "200":
           description: Templates retrieved successfully
           content:
             application/json:
@@ -12910,10 +12910,10 @@ paths:
                           example: 1
                         name:
                           type: string
-                          example: 'Classic Movie Poster'
+                          example: "Classic Movie Poster"
                         description:
                           type: string
-                          example: 'A classic movie poster template with text overlays'
+                          example: "A classic movie poster template with text overlays"
                         isDefault:
                           type: boolean
                           example: false
@@ -12932,16 +12932,16 @@ paths:
                                 type:
                                   type: string
                                   enum: [color, gradient, radial]
-                                  example: 'gradient'
+                                  example: "gradient"
                                 color:
                                   type: string
-                                  example: '#6366f1'
+                                  example: "#6366f1"
                                 secondaryColor:
                                   type: string
-                                  example: '#1e1b4b'
+                                  example: "#1e1b4b"
                                 intensity:
                                   type: number
-                                  description: 'Gradient spread intensity (0-100)'
+                                  description: "Gradient spread intensity (0-100)"
                                   example: 50
                                 useSourceColors:
                                   type: boolean
@@ -12949,21 +12949,21 @@ paths:
                             # New unified layering system (preferred)
                             elements:
                               type: array
-                              description: 'Unified element list with custom layer ordering (used when migrated=true)'
+                              description: "Unified element list with custom layer ordering (used when migrated=true)"
                               items:
                                 type: object
                                 properties:
                                   id:
                                     type: string
-                                    example: 'element-1'
+                                    example: "element-1"
                                   layerOrder:
                                     type: number
-                                    description: 'Layer order - lower numbers render behind higher numbers'
+                                    description: "Layer order - lower numbers render behind higher numbers"
                                     example: 20
                                   type:
                                     type: string
                                     enum: [text, raster, svg, content-grid]
-                                    example: 'text'
+                                    example: "text"
                                   x:
                                     type: number
                                     example: 50
@@ -12978,10 +12978,10 @@ paths:
                                     example: 60
                                   properties:
                                     type: object
-                                    description: 'Type-specific properties based on element type'
+                                    description: "Type-specific properties based on element type"
                                     oneOf:
                                       - type: object
-                                        title: 'Text Element Properties'
+                                        title: "Text Element Properties"
                                         properties:
                                           elementType:
                                             type: string
@@ -13007,12 +13007,12 @@ paths:
                                           maxLines:
                                             type: number
                                       - type: object
-                                        title: 'Raster Element Properties'
+                                        title: "Raster Element Properties"
                                         properties:
                                           imagePath:
                                             type: string
                                       - type: object
-                                        title: 'SVG Element Properties'
+                                        title: "SVG Element Properties"
                                         properties:
                                           iconType:
                                             type: string
@@ -13022,7 +13022,7 @@ paths:
                                           grayscale:
                                             type: boolean
                                       - type: object
-                                        title: 'Content Grid Properties'
+                                        title: "Content Grid Properties"
                                         properties:
                                           columns:
                                             type: number
@@ -13034,25 +13034,25 @@ paths:
                                             type: number
                             migrated:
                               type: boolean
-                              description: 'Flag indicating if template has been migrated to unified layering system'
+                              description: "Flag indicating if template has been migrated to unified layering system"
                               example: true
                             # Legacy structure (for backward compatibility)
                             textElements:
                               type: array
-                              description: 'Legacy text elements (used when migrated=false)'
+                              description: "Legacy text elements (used when migrated=false)"
                               items:
                                 type: object
                                 properties:
                                   id:
                                     type: string
-                                    example: 'text-1'
+                                    example: "text-1"
                                   type:
                                     type: string
                                     enum: [collection-title, custom-text]
-                                    example: 'collection-title'
+                                    example: "collection-title"
                                   text:
                                     type: string
-                                    example: 'Collection Name'
+                                    example: "Collection Name"
                                   x:
                                     type: number
                                     example: 50
@@ -13070,41 +13070,41 @@ paths:
                                     example: 32
                                   fontFamily:
                                     type: string
-                                    example: 'Arial, sans-serif'
+                                    example: "Arial, sans-serif"
                                   fontWeight:
                                     type: string
                                     enum: [normal, bold]
-                                    example: 'bold'
+                                    example: "bold"
                                   fontStyle:
                                     type: string
                                     enum: [normal, italic]
-                                    example: 'normal'
+                                    example: "normal"
                                   color:
                                     type: string
-                                    example: '#ffffff'
+                                    example: "#ffffff"
                                   textAlign:
                                     type: string
                                     enum: [left, center, right]
-                                    example: 'center'
+                                    example: "center"
                                   maxLines:
                                     type: number
                                     example: 2
                             iconElements:
                               type: array
-                              description: 'Legacy icon elements (used when migrated=false)'
+                              description: "Legacy icon elements (used when migrated=false)"
                               items:
                                 type: object
                                 properties:
                                   id:
                                     type: string
-                                    example: 'icon-1'
+                                    example: "icon-1"
                                   type:
                                     type: string
                                     enum: [source-logo, custom-icon]
-                                    example: 'source-logo'
+                                    example: "source-logo"
                                   iconPath:
                                     type: string
-                                    example: '/icons/tmdb-logo.svg'
+                                    example: "/icons/tmdb-logo.svg"
                                   x:
                                     type: number
                                     example: 25
@@ -13122,20 +13122,20 @@ paths:
                                     example: false
                             rasterElements:
                               type: array
-                              description: 'Legacy raster image elements (used when migrated=false)'
+                              description: "Legacy raster image elements (used when migrated=false)"
                               items:
                                 type: object
                                 properties:
                                   id:
                                     type: string
-                                    example: 'raster-1'
+                                    example: "raster-1"
                                   type:
                                     type: string
                                     enum: [raster-image]
-                                    example: 'raster-image'
+                                    example: "raster-image"
                                   imagePath:
                                     type: string
-                                    example: '/uploads/background.jpg'
+                                    example: "/uploads/background.jpg"
                                   x:
                                     type: number
                                     example: 0
@@ -13150,20 +13150,20 @@ paths:
                                     example: 300
                             svgElements:
                               type: array
-                              description: 'Legacy SVG elements (used when migrated=false)'
+                              description: "Legacy SVG elements (used when migrated=false)"
                               items:
                                 type: object
                                 properties:
                                   id:
                                     type: string
-                                    example: 'svg-1'
+                                    example: "svg-1"
                                   type:
                                     type: string
                                     enum: [source-logo, svg-icon]
-                                    example: 'svg-icon'
+                                    example: "svg-icon"
                                   iconPath:
                                     type: string
-                                    example: '/icons/custom.svg'
+                                    example: "/icons/custom.svg"
                                   x:
                                     type: number
                                     example: 25
@@ -13181,11 +13181,11 @@ paths:
                                     example: false
                             contentGrid:
                               type: object
-                              description: 'Legacy content grid (used when migrated=false)'
+                              description: "Legacy content grid (used when migrated=false)"
                               properties:
                                 id:
                                   type: string
-                                  example: 'grid-1'
+                                  example: "grid-1"
                                 x:
                                   type: number
                                   example: 50
@@ -13216,7 +13216,7 @@ paths:
                         updatedAt:
                           type: string
                           format: date-time
-        '500':
+        "500":
           description: Failed to fetch poster templates
     post:
       summary: Create new poster template
@@ -13235,26 +13235,26 @@ paths:
               properties:
                 name:
                   type: string
-                  example: 'My Custom Template'
+                  example: "My Custom Template"
                 description:
                   type: string
-                  example: 'A custom poster template'
+                  example: "A custom poster template"
                 templateData:
                   type: object
-                  description: 'Template configuration data (same structure as in GET response)'
+                  description: "Template configuration data (same structure as in GET response)"
       responses:
-        '201':
+        "201":
           description: Template created successfully
           content:
             application/json:
               schema:
                 type: object
-                description: 'Same structure as template object in GET response'
-        '400':
+                description: "Same structure as template object in GET response"
+        "400":
           description: Invalid template data or validation failed
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to create poster template
 
   /posters/templates/{id}:
@@ -13284,17 +13284,17 @@ paths:
                 templateData:
                   type: object
       responses:
-        '200':
+        "200":
           description: Template updated successfully
-        '400':
+        "400":
           description: Invalid template data
-        '401':
+        "401":
           description: Authentication required
-        '403':
+        "403":
           description: Permission denied
-        '404':
+        "404":
           description: Template not found
-        '500':
+        "500":
           description: Failed to update poster template
     delete:
       summary: Delete poster template
@@ -13309,15 +13309,15 @@ paths:
             type: integer
           description: Template ID
       responses:
-        '204':
+        "204":
           description: Template deleted successfully
-        '401':
+        "401":
           description: Authentication required
-        '403':
+        "403":
           description: Permission denied or cannot delete default template
-        '404':
+        "404":
           description: Template not found
-        '500':
+        "500":
           description: Failed to delete poster template
 
   /posters/templates/{id}/set-default:
@@ -13335,7 +13335,7 @@ paths:
           description: Template ID
           example: 1
       responses:
-        '200':
+        "200":
           description: Template set as default successfully
           content:
             application/json:
@@ -13344,7 +13344,7 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Template set as default successfully'
+                    example: "Template set as default successfully"
                   template:
                     type: object
                     properties:
@@ -13353,15 +13353,15 @@ paths:
                         example: 1
                       name:
                         type: string
-                        example: 'My Custom Template'
+                        example: "My Custom Template"
                       isDefault:
                         type: boolean
                         example: true
-        '401':
+        "401":
           description: Authentication required
-        '404':
+        "404":
           description: Template not found
-        '500':
+        "500":
           description: Failed to set template as default
 
   /posters/templates/{id}/preview:
@@ -13381,7 +13381,7 @@ paths:
           in: query
           schema:
             type: string
-            default: 'Preview Collection'
+            default: "Preview Collection"
           description: Collection name to use in preview
         - name: collectionType
           in: query
@@ -13401,16 +13401,16 @@ paths:
             type: string
           description: Cache-busting timestamp parameter
       responses:
-        '200':
+        "200":
           description: Preview image generated successfully
           content:
             image/png:
               schema:
                 type: string
                 format: binary
-        '400':
+        "400":
           description: Invalid template ID or failed to generate preview
-        '500':
+        "500":
           description: Failed to generate template preview
 
   /posters/templates/validate:
@@ -13430,9 +13430,9 @@ paths:
               properties:
                 templateData:
                   type: object
-                  description: 'Template data to validate'
+                  description: "Template data to validate"
       responses:
-        '200':
+        "200":
           description: Validation completed
           content:
             application/json:
@@ -13454,10 +13454,10 @@ paths:
                     example: []
                   sanitizedData:
                     type: object
-                    description: 'Sanitized template data (only present if isValid is true)'
-        '400':
+                    description: "Sanitized template data (only present if isValid is true)"
+        "400":
           description: Template data is required
-        '500':
+        "500":
           description: Failed to validate template data
 
   /posters/templates/{id}/export:
@@ -13475,7 +13475,7 @@ paths:
             type: integer
             example: 1
       responses:
-        '200':
+        "200":
           description: Template exported successfully as ZIP file
           content:
             application/zip:
@@ -13483,11 +13483,11 @@ paths:
                 type: string
                 format: binary
                 description: ZIP file containing template.json and assets/ folder with custom icons and images
-        '400':
+        "400":
           description: Invalid template ID
-        '404':
+        "404":
           description: Template not found
-        '500':
+        "500":
           description: Failed to export template
 
   /posters/templates/import:
@@ -13510,7 +13510,7 @@ paths:
                   format: binary
                   description: ZIP file containing template.json and assets
       responses:
-        '201':
+        "201":
           description: Template imported successfully
           content:
             application/json:
@@ -13522,27 +13522,27 @@ paths:
                     example: 5
                   name:
                     type: string
-                    example: 'Imported Template'
+                    example: "Imported Template"
                   description:
                     type: string
-                    example: 'A template imported from another instance'
+                    example: "A template imported from another instance"
                   isDefault:
                     type: boolean
                     example: false
                   templateData:
                     type: object
-                    description: 'Complete template configuration data'
+                    description: "Complete template configuration data"
                   createdAt:
                     type: string
                     format: date-time
                   updatedAt:
                     type: string
                     format: date-time
-        '400':
+        "400":
           description: Invalid template data or unsupported version
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to import template
 
   /posters/saved:
@@ -13552,7 +13552,7 @@ paths:
       tags:
         - poster-saved
       responses:
-        '200':
+        "200":
           description: Saved posters retrieved successfully
           content:
             application/json:
@@ -13569,28 +13569,28 @@ paths:
                           example: 1
                         name:
                           type: string
-                          example: 'My Custom Poster'
+                          example: "My Custom Poster"
                         description:
                           type: string
-                          example: 'A custom poster for my collection'
+                          example: "A custom poster for my collection"
                         filename:
                           type: string
-                          example: 'poster-abc123.jpg'
+                          example: "poster-abc123.jpg"
                         thumbnailFilename:
                           type: string
-                          example: 'thumb-abc123.jpg'
+                          example: "thumb-abc123.jpg"
                         posterData:
                           type: object
-                          description: 'Poster configuration data'
+                          description: "Poster configuration data"
                         createdAt:
                           type: string
                           format: date-time
                         updatedAt:
                           type: string
                           format: date-time
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to fetch saved posters
     post:
       summary: Create saved poster
@@ -13609,27 +13609,27 @@ paths:
               properties:
                 name:
                   type: string
-                  example: 'My Saved Poster'
+                  example: "My Saved Poster"
                 description:
                   type: string
-                  example: 'Description of my poster'
+                  example: "Description of my poster"
                 posterData:
                   type: object
-                  description: 'Poster configuration data'
+                  description: "Poster configuration data"
                 filename:
                   type: string
-                  example: 'poster-abc123.jpg'
+                  example: "poster-abc123.jpg"
                 thumbnailFilename:
                   type: string
-                  example: 'thumb-abc123.jpg'
+                  example: "thumb-abc123.jpg"
       responses:
-        '201':
+        "201":
           description: Saved poster created successfully
-        '400':
+        "400":
           description: Poster name and data are required
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to create saved poster
 
   /posters/saved/{id}:
@@ -13663,13 +13663,13 @@ paths:
                 thumbnailFilename:
                   type: string
       responses:
-        '200':
+        "200":
           description: Saved poster updated successfully
-        '401':
+        "401":
           description: Authentication required
-        '404':
+        "404":
           description: Poster not found
-        '500':
+        "500":
           description: Failed to update saved poster
     delete:
       summary: Delete saved poster
@@ -13685,7 +13685,7 @@ paths:
               - type: integer
                 description: Database poster ID
               - type: string
-                pattern: '^file-.+$'
+                pattern: "^file-.+$"
                 description: File-based poster ID (starts with 'file-')
           description: Poster ID (integer for database posters, or string starting with 'file-' for file-based posters)
         - in: query
@@ -13696,13 +13696,13 @@ paths:
             type: boolean
             default: false
       responses:
-        '204':
+        "204":
           description: Saved poster deleted successfully
-        '401':
+        "401":
           description: Authentication required
-        '404':
+        "404":
           description: Poster not found
-        '409':
+        "409":
           description: Poster is currently in use by collections
           content:
             application/json:
@@ -13711,7 +13711,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Poster is currently in use'
+                    example: "Poster is currently in use"
                   inUse:
                     type: boolean
                     example: true
@@ -13723,17 +13723,17 @@ paths:
                         type:
                           type: string
                           enum: [collection, preExisting]
-                          example: 'collection'
+                          example: "collection"
                         id:
                           type: string
-                          example: 'col_123'
+                          example: "col_123"
                         name:
                           type: string
-                          example: 'Marvel Movies'
+                          example: "Marvel Movies"
                         libraryName:
                           type: string
-                          example: 'Movies'
-        '500':
+                          example: "Movies"
+        "500":
           description: Failed to delete saved poster
 
   /posters/icons/upload:
@@ -13754,21 +13754,21 @@ paths:
                 icon:
                   type: string
                   format: binary
-                  description: 'Icon file (JPEG, PNG, WebP, SVG, max 10MB)'
+                  description: "Icon file (JPEG, PNG, WebP, SVG, max 10MB)"
                 name:
                   type: string
-                  description: 'Name for the icon'
+                  description: "Name for the icon"
                 category:
                   type: string
-                  description: 'Category for the icon'
+                  description: "Category for the icon"
                 tags:
                   type: string
-                  description: 'Comma-separated tags'
+                  description: "Comma-separated tags"
                 description:
                   type: string
-                  description: 'Description of the icon'
+                  description: "Description of the icon"
       responses:
-        '201':
+        "201":
           description: Icon uploaded successfully
           content:
             application/json:
@@ -13792,9 +13792,9 @@ paths:
                           type: string
                       description:
                         type: string
-        '400':
+        "400":
           description: No file uploaded or invalid file type
-        '500':
+        "500":
           description: Failed to upload icon
 
   /posters/icons/download:
@@ -13815,7 +13815,7 @@ paths:
                 url:
                   type: string
                   format: uri
-                  example: 'https://example.com/icon.png'
+                  example: "https://example.com/icon.png"
                 name:
                   type: string
                 category:
@@ -13827,11 +13827,11 @@ paths:
                 description:
                   type: string
       responses:
-        '201':
+        "201":
           description: Icon downloaded successfully
-        '400':
+        "400":
           description: URL is required or download failed
-        '500':
+        "500":
           description: Failed to download icon
 
   /posters/icons:
@@ -13865,7 +13865,7 @@ paths:
             type: string
           description: Search in name and description
       responses:
-        '200':
+        "200":
           description: Icons retrieved successfully
           content:
             application/json:
@@ -13894,7 +13894,7 @@ paths:
                         type:
                           type: string
                           enum: [user, system]
-        '500':
+        "500":
           description: Failed to list icons
 
   /fonts:
@@ -13904,7 +13904,7 @@ paths:
       tags:
         - poster-assets
       responses:
-        '200':
+        "200":
           description: Fonts retrieved successfully
           content:
             application/json:
@@ -13923,18 +13923,18 @@ paths:
                           type: array
                           items:
                             type: string
-                          example: ['Regular', 'Bold', 'Light', 'Medium']
+                          example: ["Regular", "Bold", "Light", "Medium"]
                         cssValue:
                           type: string
                           example: "'DejaVu Sans'"
                         fontUrl:
                           type: string
                           description: URL to font file for web loading
-                          example: '/fonts/truetype/dejavu/DejaVuSans.ttf'
+                          example: "/fonts/truetype/dejavu/DejaVuSans.ttf"
                   count:
                     type: integer
                     example: 25
-        '500':
+        "500":
           description: Failed to retrieve fonts
   /posters/icons/categories:
     get:
@@ -13943,7 +13943,7 @@ paths:
       tags:
         - poster-assets
       responses:
-        '200':
+        "200":
           description: Categories retrieved successfully
           content:
             application/json:
@@ -13963,7 +13963,7 @@ paths:
                           type: string
                         iconCount:
                           type: integer
-        '500':
+        "500":
           description: Failed to list icon categories
 
   /posters/icons/{id}:
@@ -13980,13 +13980,13 @@ paths:
             type: string
           description: Icon ID
       responses:
-        '204':
+        "204":
           description: Icon deleted successfully
-        '400':
+        "400":
           description: Icon ID is required
-        '404':
+        "404":
           description: Icon not found
-        '500':
+        "500":
           description: Failed to delete icon
 
   /posters/files/{filename}:
@@ -14009,18 +14009,18 @@ paths:
           schema:
             type: number
       responses:
-        '200':
+        "200":
           description: Poster image served successfully
           content:
             image/jpeg:
               schema:
                 type: string
                 format: binary
-        '400':
+        "400":
           description: Filename is required
-        '404':
+        "404":
           description: Poster file not found
-        '500':
+        "500":
           description: Failed to serve poster file
 
   /posters/thumbnails/{filename}:
@@ -14043,18 +14043,18 @@ paths:
           schema:
             type: number
       responses:
-        '200':
+        "200":
           description: Thumbnail image served successfully
           content:
             image/jpeg:
               schema:
                 type: string
                 format: binary
-        '400':
+        "400":
           description: Filename is required
-        '404':
+        "404":
           description: Thumbnail not found
-        '500':
+        "500":
           description: Failed to serve thumbnail file
 
   /posters/icons/{type}/{filename}:
@@ -14078,18 +14078,18 @@ paths:
             type: string
           description: Icon filename
       responses:
-        '200':
+        "200":
           description: Icon file served successfully
           content:
             image/*:
               schema:
                 type: string
                 format: binary
-        '400':
+        "400":
           description: Invalid icon type or filename required
-        '404':
+        "404":
           description: Icon file not found
-        '500':
+        "500":
           description: Failed to serve icon file
 
   /posters/collection-posters/{id}:
@@ -14121,7 +14121,7 @@ paths:
             default: 12
           description: Maximum number of poster URLs to return
       responses:
-        '200':
+        "200":
           description: Poster URLs retrieved successfully
           content:
             application/json:
@@ -14134,17 +14134,17 @@ paths:
                       type: string
                     description: Array of TMDB poster URLs
                     example:
-                      - 'https://image.tmdb.org/t/p/w300_and_h450_face/poster1.jpg'
-                      - 'https://image.tmdb.org/t/p/w300_and_h450_face/poster2.jpg'
+                      - "https://image.tmdb.org/t/p/w300_and_h450_face/poster1.jpg"
+                      - "https://image.tmdb.org/t/p/w300_and_h450_face/poster2.jpg"
                   totalItems:
                     type: integer
                     description: Total number of items in the collection
                     example: 25
-        '400':
+        "400":
           description: Collection ID required or Plex not configured
-        '404':
+        "404":
           description: Collection not found or not synced to Plex yet
-        '500':
+        "500":
           description: Failed to fetch collection item posters
 
   /source-colors:
@@ -14154,7 +14154,7 @@ paths:
       tags:
         - source-colors
       responses:
-        '200':
+        "200":
           description: Source colors retrieved successfully
           content:
             application/json:
@@ -14165,27 +14165,27 @@ paths:
                   properties:
                     primaryColor:
                       type: string
-                      example: '#01b4e4'
+                      example: "#01b4e4"
                     secondaryColor:
                       type: string
-                      example: '#0d253f'
+                      example: "#0d253f"
                     textColor:
                       type: string
-                      example: '#ffffff'
+                      example: "#ffffff"
                 example:
                   tmdb:
-                    primaryColor: '#01b4e4'
-                    secondaryColor: '#0d253f'
-                    textColor: '#ffffff'
+                    primaryColor: "#01b4e4"
+                    secondaryColor: "#0d253f"
+                    textColor: "#ffffff"
                   trakt:
-                    primaryColor: '#ed2224'
-                    secondaryColor: '#1f1a1a'
-                    textColor: '#ffffff'
+                    primaryColor: "#ed2224"
+                    secondaryColor: "#1f1a1a"
+                    textColor: "#ffffff"
                   mdblist:
-                    primaryColor: '#4283c9'
-                    secondaryColor: '#1a2e42'
-                    textColor: '#ffffff'
-        '500':
+                    primaryColor: "#4283c9"
+                    secondaryColor: "#1a2e42"
+                    textColor: "#ffffff"
+        "500":
           description: Failed to get source colors
 
   /source-colors/{sourceType}:
@@ -14203,7 +14203,7 @@ paths:
             type: string
           example: tmdb
       responses:
-        '200':
+        "200":
           description: Source color scheme retrieved successfully
           content:
             application/json:
@@ -14212,14 +14212,14 @@ paths:
                 properties:
                   primaryColor:
                     type: string
-                    example: '#01b4e4'
+                    example: "#01b4e4"
                   secondaryColor:
                     type: string
-                    example: '#0d253f'
+                    example: "#0d253f"
                   textColor:
                     type: string
-                    example: '#ffffff'
-        '500':
+                    example: "#ffffff"
+        "500":
           description: Failed to get source colors
 
     put:
@@ -14248,18 +14248,18 @@ paths:
               properties:
                 primaryColor:
                   type: string
-                  pattern: '^#[0-9a-fA-F]{6}$'
-                  example: '#01b4e4'
+                  pattern: "^#[0-9a-fA-F]{6}$"
+                  example: "#01b4e4"
                 secondaryColor:
                   type: string
-                  pattern: '^#[0-9a-fA-F]{6}$'
-                  example: '#0d253f'
+                  pattern: "^#[0-9a-fA-F]{6}$"
+                  example: "#0d253f"
                 textColor:
                   type: string
-                  pattern: '^#[0-9a-fA-F]{6}$'
-                  example: '#ffffff'
+                  pattern: "^#[0-9a-fA-F]{6}$"
+                  example: "#ffffff"
       responses:
-        '200':
+        "200":
           description: Source colors updated successfully
           content:
             application/json:
@@ -14268,22 +14268,22 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Source colors updated for tmdb'
+                    example: "Source colors updated for tmdb"
                   colors:
                     type: object
                     properties:
                       primaryColor:
                         type: string
-                        example: '#01b4e4'
+                        example: "#01b4e4"
                       secondaryColor:
                         type: string
-                        example: '#0d253f'
+                        example: "#0d253f"
                       textColor:
                         type: string
-                        example: '#ffffff'
-        '400':
+                        example: "#ffffff"
+        "400":
           description: Invalid input - missing fields or invalid hex colors
-        '500':
+        "500":
           description: Failed to update source colors
 
     delete:
@@ -14300,7 +14300,7 @@ paths:
             type: string
           example: tmdb
       responses:
-        '200':
+        "200":
           description: Source colors reset successfully
           content:
             application/json:
@@ -14309,20 +14309,20 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Source colors reset to defaults for tmdb'
+                    example: "Source colors reset to defaults for tmdb"
                   colors:
                     type: object
                     properties:
                       primaryColor:
                         type: string
-                        example: '#01b4e4'
+                        example: "#01b4e4"
                       secondaryColor:
                         type: string
-                        example: '#0d253f'
+                        example: "#0d253f"
                       textColor:
                         type: string
-                        example: '#ffffff'
-        '500':
+                        example: "#ffffff"
+        "500":
           description: Failed to reset source colors
 
   /source-colors/reset:
@@ -14332,7 +14332,7 @@ paths:
       tags:
         - source-colors
       responses:
-        '200':
+        "200":
           description: All source colors reset successfully
           content:
             application/json:
@@ -14341,7 +14341,7 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'All source colors reset to defaults'
+                    example: "All source colors reset to defaults"
                   colors:
                     type: object
                     additionalProperties:
@@ -14353,7 +14353,7 @@ paths:
                           type: string
                         textColor:
                           type: string
-        '500':
+        "500":
           description: Failed to reset source colors
 
   /source-colors/export:
@@ -14363,7 +14363,7 @@ paths:
       tags:
         - source-colors
       responses:
-        '200':
+        "200":
           description: Source colors exported successfully
           content:
             application/json:
@@ -14377,21 +14377,21 @@ paths:
                       properties:
                         primaryColor:
                           type: string
-                          example: '#ed2224'
+                          example: "#ed2224"
                         secondaryColor:
                           type: string
-                          example: '#1f1a1a'
+                          example: "#1f1a1a"
                         textColor:
                           type: string
-                          example: '#ffffff'
+                          example: "#ffffff"
                   exportedAt:
                     type: string
                     format: date-time
-                    example: '2023-10-25T10:30:00.000Z'
+                    example: "2023-10-25T10:30:00.000Z"
                   version:
                     type: string
-                    example: '1.0'
-        '500':
+                    example: "1.0"
+        "500":
           description: Failed to export source colors
 
   /source-colors/import:
@@ -14416,18 +14416,18 @@ paths:
                     properties:
                       primaryColor:
                         type: string
-                        example: '#ed2224'
+                        example: "#ed2224"
                       secondaryColor:
                         type: string
-                        example: '#1f1a1a'
+                        example: "#1f1a1a"
                       textColor:
                         type: string
-                        example: '#ffffff'
+                        example: "#ffffff"
                 version:
                   type: string
-                  example: '1.0'
+                  example: "1.0"
       responses:
-        '200':
+        "200":
           description: Source colors imported successfully
           content:
             application/json:
@@ -14436,7 +14436,7 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Successfully imported 5 source color schemes'
+                    example: "Successfully imported 5 source color schemes"
                   importCount:
                     type: integer
                     example: 5
@@ -14451,11 +14451,11 @@ paths:
                           type: string
                         textColor:
                           type: string
-        '400':
+        "400":
           description: Invalid source colors data or unsupported version
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to import source colors
 
   /overlay-templates:
@@ -14465,7 +14465,7 @@ paths:
       tags:
         - overlays
       responses:
-        '200':
+        "200":
           description: Overlay templates retrieved successfully
           content:
             application/json:
@@ -14475,10 +14475,10 @@ paths:
                   templates:
                     type: array
                     items:
-                      $ref: '#/components/schemas/OverlayTemplate'
-        '401':
+                      $ref: "#/components/schemas/OverlayTemplate"
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to fetch overlay templates
 
     post:
@@ -14495,33 +14495,33 @@ paths:
               properties:
                 name:
                   type: string
-                  example: 'My Custom Badge'
+                  example: "My Custom Badge"
                 description:
                   type: string
-                  example: 'Custom rating badge'
+                  example: "Custom rating badge"
                 type:
                   type: string
-                  enum: ['rating', 'metadata', 'technical', 'status', 'generic']
-                  example: 'rating'
+                  enum: ["rating", "metadata", "technical", "status", "generic"]
+                  example: "rating"
                 templateData:
                   type: object
-                  description: 'Template design data with states containing elements'
+                  description: "Template design data with states containing elements"
               required:
                 - name
                 - type
                 - templateData
       responses:
-        '201':
+        "201":
           description: Template created successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OverlayTemplate'
-        '400':
+                $ref: "#/components/schemas/OverlayTemplate"
+        "400":
           description: Invalid request body
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to create template
 
   /overlay-templates/{id}:
@@ -14550,25 +14550,25 @@ paths:
                   type: string
                 type:
                   type: string
-                  enum: ['rating', 'metadata', 'technical', 'status', 'generic']
+                  enum: ["rating", "metadata", "technical", "status", "generic"]
                 templateData:
                   type: object
       responses:
-        '200':
+        "200":
           description: Template updated successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OverlayTemplate'
-        '400':
+                $ref: "#/components/schemas/OverlayTemplate"
+        "400":
           description: Invalid request body
-        '401':
+        "401":
           description: Authentication required
-        '403':
+        "403":
           description: Cannot edit system default templates
-        '404':
+        "404":
           description: Template not found
-        '500':
+        "500":
           description: Failed to update template
 
     delete:
@@ -14584,7 +14584,7 @@ paths:
             type: integer
           description: Template ID
       responses:
-        '200':
+        "200":
           description: Template deleted successfully
           content:
             application/json:
@@ -14593,14 +14593,14 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Template deleted successfully'
-        '401':
+                    example: "Template deleted successfully"
+        "401":
           description: Authentication required
-        '403':
+        "403":
           description: Cannot delete system default templates
-        '404':
+        "404":
           description: Template not found
-        '500':
+        "500":
           description: Failed to delete template
 
   /overlay-templates/{id}/preview:
@@ -14617,16 +14617,16 @@ paths:
             type: integer
           description: Template ID
       responses:
-        '200':
+        "200":
           description: Preview image generated successfully
           content:
             image/webp:
               schema:
                 type: string
                 format: binary
-        '404':
+        "404":
           description: Template not found
-        '500':
+        "500":
           description: Failed to generate preview
 
   /overlay-templates/combined-preview:
@@ -14651,18 +14651,18 @@ paths:
                   description: Array of template IDs to render in order
                   example: [1, 2, 3]
       responses:
-        '200':
+        "200":
           description: Combined preview image generated successfully
           content:
             image/webp:
               schema:
                 type: string
                 format: binary
-        '400':
+        "400":
           description: Invalid request - templateIds array required
-        '404':
+        "404":
           description: No templates found
-        '500':
+        "500":
           description: Failed to generate combined preview
 
   /overlay-templates/presets/create:
@@ -14672,7 +14672,7 @@ paths:
       tags:
         - overlays
       responses:
-        '200':
+        "200":
           description: Preset templates created successfully
           content:
             application/json:
@@ -14681,10 +14681,10 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Preset templates created successfully'
-        '401':
+                    example: "Preset templates created successfully"
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to create preset templates
 
   /overlay-templates/copy:
@@ -14712,7 +14712,7 @@ paths:
                     type: number
                   description: Array of template IDs to copy to
       responses:
-        '200':
+        "200":
           description: Design copied successfully
           content:
             application/json:
@@ -14723,13 +14723,13 @@ paths:
                     type: string
                   copiedCount:
                     type: number
-        '400':
+        "400":
           description: Invalid request
-        '401':
+        "401":
           description: Authentication required
-        '404':
+        "404":
           description: Source template not found
-        '500':
+        "500":
           description: Failed to copy template design
 
   /overlay-templates/bulk-edit:
@@ -14773,7 +14773,7 @@ paths:
                     opacity:
                       type: number
       responses:
-        '200':
+        "200":
           description: Templates updated successfully
           content:
             application/json:
@@ -14784,11 +14784,11 @@ paths:
                     type: string
                   updatedCount:
                     type: number
-        '400':
+        "400":
           description: Invalid request
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to bulk edit templates
 
   /overlay-templates/preview-posters:
@@ -14798,7 +14798,7 @@ paths:
       tags:
         - overlays
       responses:
-        '200':
+        "200":
           description: Preview posters listed successfully
           content:
             application/json:
@@ -14812,26 +14812,26 @@ paths:
                       properties:
                         id:
                           type: string
-                          example: 'movie_550'
+                          example: "movie_550"
                         type:
                           type: string
-                          enum: ['movie', 'tv']
-                          example: 'movie'
+                          enum: ["movie", "tv"]
+                          example: "movie"
                         tmdbId:
                           type: integer
                           example: 550
                         filename:
                           type: string
-                          example: 'movie_550.jpg'
+                          example: "movie_550.jpg"
                         url:
                           type: string
-                          example: '/preview-posters/movie_550.jpg'
+                          example: "/preview-posters/movie_550.jpg"
                   count:
                     type: integer
                     example: 102
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to list preview posters
 
   /overlay-templates/preview-metadata/{posterId}:
@@ -14847,9 +14847,9 @@ paths:
           schema:
             type: string
           description: Poster ID in format movie_123 or tv_456
-          example: 'movie_550'
+          example: "movie_550"
       responses:
-        '200':
+        "200":
           description: Metadata retrieved successfully
           content:
             application/json:
@@ -14858,7 +14858,7 @@ paths:
                 properties:
                   title:
                     type: string
-                    example: 'Fight Club'
+                    example: "Fight Club"
                   year:
                     type: integer
                     example: 1999
@@ -14873,40 +14873,40 @@ paths:
                     example: 96
                   director:
                     type: string
-                    example: 'David Fincher'
+                    example: "David Fincher"
                   studio:
                     type: string
-                    example: '20th Century Fox'
+                    example: "20th Century Fox"
                   network:
                     type: string
-                    example: 'AMC'
+                    example: "AMC"
                   resolution:
                     type: string
-                    example: '4K'
+                    example: "4K"
                   audioFormat:
                     type: string
-                    example: 'Dolby Atmos'
+                    example: "Dolby Atmos"
                   videoCodec:
                     type: string
-                    example: 'HEVC'
+                    example: "HEVC"
                   status:
                     type: string
-                    example: 'Available'
+                    example: "Available"
                   releaseDate:
                     type: string
-                    example: '1999-10-15'
+                    example: "1999-10-15"
                   runtime:
                     type: integer
                     example: 139
                   daysUntilAction:
                     type: integer
                     example: 5
-                    description: 'Days until Maintainerr takes action on this item (negative = overdue)'
-        '400':
+                    description: "Days until Maintainerr takes action on this item (negative = overdue)"
+        "400":
           description: Invalid poster ID format
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to fetch preview poster metadata
 
   /overlay-mappings/{field}:
@@ -14924,13 +14924,13 @@ paths:
           description: Field name (e.g., originCountry, audioLanguages, resolution)
           example: originCountry
       responses:
-        '200':
+        "200":
           description: Mappings retrieved successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OverlayMappingsResponse'
-        '401':
+                $ref: "#/components/schemas/OverlayMappingsResponse"
+        "401":
           description: Authentication required
     put:
       summary: Save icon mappings for a field
@@ -14957,9 +14957,9 @@ paths:
                 mappings:
                   type: array
                   items:
-                    $ref: '#/components/schemas/IconMapping'
+                    $ref: "#/components/schemas/IconMapping"
       responses:
-        '200':
+        "200":
           description: Mappings saved successfully
           content:
             application/json:
@@ -14975,9 +14975,9 @@ paths:
                   mappingCount:
                     type: integer
                     example: 256
-        '400':
+        "400":
           description: Invalid request body
-        '401':
+        "401":
           description: Authentication required
     delete:
       summary: Reset mappings to defaults
@@ -14993,13 +14993,13 @@ paths:
           description: Field name
           example: originCountry
       responses:
-        '200':
+        "200":
           description: Mappings reset to defaults
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OverlayMappingsResponse'
-        '401':
+                $ref: "#/components/schemas/OverlayMappingsResponse"
+        "401":
           description: Authentication required
 
   /overlay-library-configs:
@@ -15009,7 +15009,7 @@ paths:
       tags:
         - overlays
       responses:
-        '200':
+        "200":
           description: Library configurations retrieved successfully
           content:
             application/json:
@@ -15019,10 +15019,10 @@ paths:
                   configs:
                     type: array
                     items:
-                      $ref: '#/components/schemas/OverlayLibraryConfig'
-        '401':
+                      $ref: "#/components/schemas/OverlayLibraryConfig"
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to fetch library configs
 
   /overlay-library-configs/{libraryId}:
@@ -15039,15 +15039,15 @@ paths:
             type: string
           description: Plex library ID
       responses:
-        '200':
+        "200":
           description: Library configuration retrieved successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OverlayLibraryConfig'
-        '401':
+                $ref: "#/components/schemas/OverlayLibraryConfig"
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to fetch library config
 
     post:
@@ -15071,11 +15071,11 @@ paths:
               properties:
                 libraryName:
                   type: string
-                  example: 'Movies'
+                  example: "Movies"
                 mediaType:
                   type: string
-                  enum: ['movie', 'show']
-                  example: 'movie'
+                  enum: ["movie", "show"]
+                  example: "movie"
                 enabledOverlays:
                   type: array
                   items:
@@ -15104,23 +15104,23 @@ paths:
                   type: string
                   nullable: true
                   description: ISO language code for TMDB poster metadata (e.g., en, fr, pt-BR). If not set, uses global setting.
-                  example: 'en'
+                  example: "en"
               required:
                 - libraryName
                 - mediaType
                 - enabledOverlays
       responses:
-        '200':
+        "200":
           description: Library configuration saved successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OverlayLibraryConfig'
-        '400':
+                $ref: "#/components/schemas/OverlayLibraryConfig"
+        "400":
           description: Invalid request body
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to save library config
 
     delete:
@@ -15136,7 +15136,7 @@ paths:
             type: string
           description: Plex library ID
       responses:
-        '200':
+        "200":
           description: Configuration deleted successfully
           content:
             application/json:
@@ -15145,12 +15145,12 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Configuration deleted successfully'
-        '401':
+                    example: "Configuration deleted successfully"
+        "401":
           description: Authentication required
-        '404':
+        "404":
           description: Configuration not found
-        '500':
+        "500":
           description: Failed to delete configuration
 
   /overlay-library-configs/{libraryId}/apply:
@@ -15167,7 +15167,7 @@ paths:
             type: string
           description: Plex library ID
       responses:
-        '202':
+        "202":
           description: Overlay application started (runs in background)
           content:
             application/json:
@@ -15176,13 +15176,13 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Overlay application started'
+                    example: "Overlay application started"
                   libraryId:
                     type: string
-                    example: '1'
-        '401':
+                    example: "1"
+        "401":
           description: Authentication required
-        '409':
+        "409":
           description: Conflict - another overlay operation is already running
           content:
             application/json:
@@ -15191,13 +15191,84 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Full overlay sync is currently running. Please wait for it to complete or cancel it before syncing individual libraries.'
+                    example: "Full overlay sync is currently running. Please wait for it to complete or cancel it before syncing individual libraries."
                   conflictType:
                     type: string
                     enum: [full-sync-running, library-already-running]
-                    example: 'full-sync-running'
-        '500':
+                    example: "full-sync-running"
+        "500":
           description: Failed to start overlay application
+
+  /overlay-library-configs/{libraryId}/apply-items:
+    post:
+      summary: Apply overlays to a specific library item
+      description: Applies configured overlay templates to a single poster item in a library (runs asynchronously).
+      tags:
+        - overlays
+      parameters:
+        - name: libraryId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Plex library ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ratingKey:
+                  type: string
+                  example: "12345"
+              required:
+                - ratingKey
+      responses:
+        "202":
+          description: Overlay application started for item (runs in background)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Overlay application started for item"
+                  libraryId:
+                    type: string
+                    example: "1"
+                  ratingKey:
+                    type: string
+                    example: "12345"
+        "400":
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "ratingKey is required and must be a string"
+        "401":
+          description: Authentication required
+        "409":
+          description: Conflict - another overlay operation is already running
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Full overlay sync is currently running. Please wait for it to complete or cancel it before syncing individual items."
+                  conflictType:
+                    type: string
+                    enum: [full-sync-running, library-already-running]
+                    example: "full-sync-running"
+        "500":
+          description: Failed to start single item overlay application
 
   /overlay-library-configs/{libraryId}/status:
     get:
@@ -15213,7 +15284,7 @@ paths:
             type: string
           description: Plex library ID
       responses:
-        '200':
+        "200":
           description: Status retrieved successfully
           content:
             application/json:
@@ -15227,7 +15298,7 @@ paths:
                   libraryName:
                     type: string
                     description: Name of the library (only present if running)
-                    example: 'Movies'
+                    example: "Movies"
                   startTime:
                     type: number
                     description: Timestamp when the job started (only present if running)
@@ -15240,7 +15311,7 @@ paths:
       tags:
         - overlays
       responses:
-        '200':
+        "200":
           description: Running libraries retrieved successfully
           content:
             application/json:
@@ -15254,10 +15325,10 @@ paths:
                       properties:
                         libraryId:
                           type: string
-                          example: '1'
+                          example: "1"
                         libraryName:
                           type: string
-                          example: 'Movies'
+                          example: "Movies"
                         startTime:
                           type: number
                           example: 1640000000000
@@ -15269,7 +15340,7 @@ paths:
       tags:
         - overlays
       responses:
-        '200':
+        "200":
           description: Overlay settings retrieved
           content:
             application/json:
@@ -15280,12 +15351,12 @@ paths:
                     type: string
                     enum: [tmdb, plex, local]
                     description: Default poster source for overlays
-                    example: 'tmdb'
+                    example: "tmdb"
                   initialSetupComplete:
                     type: boolean
                     description: Whether initial setup wizard has been completed
                     example: false
-        '401':
+        "401":
           description: Authentication required
     put:
       summary: Update overlay settings
@@ -15305,9 +15376,9 @@ paths:
                   type: string
                   enum: [tmdb, plex, local]
                   description: Default poster source for overlays
-                  example: 'tmdb'
+                  example: "tmdb"
       responses:
-        '200':
+        "200":
           description: Settings updated successfully
           content:
             application/json:
@@ -15319,9 +15390,9 @@ paths:
                     enum: [tmdb, plex, local]
                   initialSetupComplete:
                     type: boolean
-        '400':
+        "400":
           description: Invalid poster source
-        '401':
+        "401":
           description: Authentication required
 
   /overlay-settings/download-base-posters:
@@ -15331,7 +15402,7 @@ paths:
       tags:
         - overlays
       responses:
-        '202':
+        "202":
           description: Download job started
           content:
             application/json:
@@ -15340,7 +15411,7 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Base poster download started'
+                    example: "Base poster download started"
                   status:
                     type: object
                     properties:
@@ -15361,9 +15432,9 @@ paths:
                             type: number
                           percentage:
                             type: number
-        '401':
+        "401":
           description: Authentication required
-        '409':
+        "409":
           description: Download job already running or overlay application is running
 
   /overlay-settings/download-status:
@@ -15373,7 +15444,7 @@ paths:
       tags:
         - overlays
       responses:
-        '200':
+        "200":
           description: Download status retrieved
           content:
             application/json:
@@ -15408,7 +15479,7 @@ paths:
                         type: number
                       percentage:
                         type: number
-        '401':
+        "401":
           description: Authentication required
 
   /overlay-settings/cancel-download:
@@ -15418,7 +15489,7 @@ paths:
       tags:
         - overlays
       responses:
-        '200':
+        "200":
           description: Cancellation requested
           content:
             application/json:
@@ -15427,10 +15498,10 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Download job cancellation requested'
-        '400':
+                    example: "Download job cancellation requested"
+        "400":
           description: No download job running
-        '401':
+        "401":
           description: Authentication required
 
   /overlay-settings/reset-library-posters:
@@ -15451,9 +15522,9 @@ paths:
                 libraryId:
                   type: string
                   description: The Plex library ID to reset posters for
-                  example: '1'
+                  example: "1"
       responses:
-        '202':
+        "202":
           description: Poster reset job started
           content:
             application/json:
@@ -15462,7 +15533,7 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Poster reset started'
+                    example: "Poster reset started"
                   status:
                     type: object
                     properties:
@@ -15480,11 +15551,11 @@ paths:
                         type: number
                       failed:
                         type: number
-        '400':
+        "400":
           description: Library ID not provided
-        '401':
+        "401":
           description: Authentication required
-        '409':
+        "409":
           description: Reset job already running, or overlay application/download is running
 
   /overlay-settings/reset-status:
@@ -15494,7 +15565,7 @@ paths:
       tags:
         - overlays
       responses:
-        '200':
+        "200":
           description: Reset status retrieved
           content:
             application/json:
@@ -15522,7 +15593,7 @@ paths:
                   failed:
                     type: number
                     description: Number of items that failed to reset
-        '401':
+        "401":
           description: Authentication required
 
   /overlay-settings/cancel-reset:
@@ -15532,7 +15603,7 @@ paths:
       tags:
         - overlays
       responses:
-        '200':
+        "200":
           description: Cancellation requested
           content:
             application/json:
@@ -15541,10 +15612,10 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Poster reset cancellation requested'
-        '400':
+                    example: "Poster reset cancellation requested"
+        "400":
           description: No reset job running
-        '401':
+        "401":
           description: Authentication required
 
   /overlay-settings/generate-local-folders:
@@ -15554,7 +15625,7 @@ paths:
       tags:
         - overlays
       responses:
-        '202':
+        "202":
           description: Folder generation started
           content:
             application/json:
@@ -15563,7 +15634,7 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Folder generation started'
+                    example: "Folder generation started"
                   status:
                     type: object
                     properties:
@@ -15587,9 +15658,9 @@ paths:
                             description: Items skipped due to missing TMDB ID
                           percentage:
                             type: number
-        '409':
+        "409":
           description: Folder generation already running or overlay application is running
-        '401':
+        "401":
           description: Authentication required
 
   /overlay-settings/generate-local-folders-status:
@@ -15599,7 +15670,7 @@ paths:
       tags:
         - overlays
       responses:
-        '200':
+        "200":
           description: Folder generation status
           content:
             application/json:
@@ -15638,7 +15709,7 @@ paths:
                         type: number
                       percentage:
                         type: number
-        '401':
+        "401":
           description: Authentication required
 
   /overlay-settings/cancel-generate-local-folders:
@@ -15648,7 +15719,7 @@ paths:
       tags:
         - overlays
       responses:
-        '200':
+        "200":
           description: Cancellation requested
           content:
             application/json:
@@ -15657,10 +15728,10 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Folder generation cancellation requested'
-        '400':
+                    example: "Folder generation cancellation requested"
+        "400":
           description: No folder generation running
-        '401':
+        "401":
           description: Authentication required
 
   /overlay-settings/populate-local-from-plex:
@@ -15670,7 +15741,7 @@ paths:
       tags:
         - overlays
       responses:
-        '202':
+        "202":
           description: Plex poster population started
           content:
             application/json:
@@ -15679,7 +15750,7 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Plex poster population started'
+                    example: "Plex poster population started"
                   status:
                     type: object
                     properties:
@@ -15703,9 +15774,9 @@ paths:
                             description: Items skipped due to missing TMDB ID or poster URL
                           percentage:
                             type: number
-        '409':
+        "409":
           description: Plex poster population already running or overlay application is running
-        '401':
+        "401":
           description: Authentication required
 
   /overlay-settings/populate-local-from-plex-status:
@@ -15715,7 +15786,7 @@ paths:
       tags:
         - overlays
       responses:
-        '200':
+        "200":
           description: Plex poster population status
           content:
             application/json:
@@ -15754,7 +15825,7 @@ paths:
                         type: number
                       percentage:
                         type: number
-        '401':
+        "401":
           description: Authentication required
 
   /overlay-settings/cancel-populate-local-from-plex:
@@ -15764,7 +15835,7 @@ paths:
       tags:
         - overlays
       responses:
-        '200':
+        "200":
           description: Cancellation requested
           content:
             application/json:
@@ -15773,10 +15844,10 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: 'Plex poster population cancellation requested'
-        '400':
+                    example: "Plex poster population cancellation requested"
+        "400":
           description: No Plex poster population running
-        '401':
+        "401":
           description: Authentication required
 
   /plex/image:
@@ -15793,9 +15864,9 @@ paths:
           schema:
             type: string
           description: The Plex image path (e.g., /library/metadata/123/thumb/456)
-          example: '/library/metadata/12345/thumb/1234567890'
+          example: "/library/metadata/12345/thumb/1234567890"
       responses:
-        '200':
+        "200":
           description: Image data
           content:
             image/jpeg:
@@ -15806,11 +15877,11 @@ paths:
               schema:
                 type: string
                 format: binary
-        '400':
+        "400":
           description: Missing image path parameter
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to fetch image from Plex
 
   /plex/search:
@@ -15827,7 +15898,7 @@ paths:
           schema:
             type: string
           description: Search term
-          example: 'Inception'
+          example: "Inception"
         - in: query
           name: limit
           required: false
@@ -15837,7 +15908,7 @@ paths:
           description: Maximum number of results to return
           example: 20
       responses:
-        '200':
+        "200":
           description: Search results
           content:
             application/json:
@@ -15851,34 +15922,34 @@ paths:
                       properties:
                         ratingKey:
                           type: string
-                          example: '12345'
+                          example: "12345"
                         title:
                           type: string
-                          example: 'Inception'
+                          example: "Inception"
                         year:
                           type: integer
                           example: 2010
                         type:
                           type: string
                           enum: [movie, show]
-                          example: 'movie'
+                          example: "movie"
                         thumb:
                           type: string
-                          example: '/library/metadata/12345/thumb/1234567890'
+                          example: "/library/metadata/12345/thumb/1234567890"
                         libraryId:
                           type: string
-                          example: '1'
+                          example: "1"
                         libraryName:
                           type: string
-                          example: 'Movies'
+                          example: "Movies"
                   totalResults:
                     type: integer
                     example: 5
-        '400':
+        "400":
           description: Query parameter is required
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to search Plex
 
   /plex/labels:
@@ -15888,7 +15959,7 @@ paths:
       tags:
         - overlays
       responses:
-        '200':
+        "200":
           description: Unique labels across all libraries
           content:
             application/json:
@@ -15900,10 +15971,10 @@ paths:
                     description: Array of unique label names sorted alphabetically
                     items:
                       type: string
-                    example: ['4K DV', 'HDR', 'Kids']
-        '401':
+                    example: ["4K DV", "HDR", "Kids"]
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to fetch Plex labels
 
   /overlay-test:
@@ -15924,9 +15995,9 @@ paths:
                 ratingKey:
                   type: string
                   description: Plex rating key of the item to test
-                  example: '12345'
+                  example: "12345"
       responses:
-        '200':
+        "200":
           description: Overlay test completed successfully
           content:
             application/json:
@@ -15942,23 +16013,23 @@ paths:
                     properties:
                       ratingKey:
                         type: string
-                        example: '12345'
+                        example: "12345"
                       title:
                         type: string
-                        example: 'Inception'
+                        example: "Inception"
                       year:
                         type: integer
                         example: 2010
                       type:
                         type: string
                         enum: [movie, show]
-                        example: 'movie'
+                        example: "movie"
                       libraryId:
                         type: string
-                        example: '1'
+                        example: "1"
                       libraryName:
                         type: string
-                        example: 'Movies'
+                        example: "Movies"
                   templates:
                     type: array
                     description: All enabled templates for the library with match results
@@ -15970,7 +16041,7 @@ paths:
                           example: 1
                         name:
                           type: string
-                          example: 'IMDb Rating Badge'
+                          example: "IMDb Rating Badge"
                         matched:
                           type: boolean
                           description: Whether this template's conditions were met
@@ -16003,10 +16074,10 @@ paths:
                                           enum: [and, or]
                                         field:
                                           type: string
-                                          example: 'imdbRating'
+                                          example: "imdbRating"
                                         operator:
                                           type: string
-                                          example: 'gte'
+                                          example: "gte"
                                         value:
                                           description: Expected value
                                         actualValue:
@@ -16032,13 +16103,13 @@ paths:
                       computed:
                         type: object
                         description: Computed fields
-        '400':
+        "400":
           description: Invalid request (missing ratingKey, no library config, item is episode/season)
-        '401':
+        "401":
           description: Authentication required
-        '404':
+        "404":
           description: Item not found in Plex
-        '500':
+        "500":
           description: Failed to test overlay
 
   /uploads/poster:
@@ -16062,9 +16133,9 @@ paths:
                 poster:
                   type: string
                   format: binary
-                  description: 'Poster image file (JPEG, PNG, WebP, max 10MB)'
+                  description: "Poster image file (JPEG, PNG, WebP, max 10MB)"
       responses:
-        '200':
+        "200":
           description: Poster uploaded successfully
           content:
             application/json:
@@ -16077,11 +16148,11 @@ paths:
                   url:
                     type: string
                     description: URL to access the uploaded poster
-        '400':
+        "400":
           description: Bad request - invalid file or upload error
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Internal server error
 
   /uploads/wallpaper:
@@ -16105,9 +16176,9 @@ paths:
                 wallpaper:
                   type: string
                   format: binary
-                  description: 'Wallpaper image file (JPEG, PNG, WebP, max 10MB)'
+                  description: "Wallpaper image file (JPEG, PNG, WebP, max 10MB)"
       responses:
-        '200':
+        "200":
           description: Wallpaper uploaded successfully
           content:
             application/json:
@@ -16118,11 +16189,11 @@ paths:
                     type: string
                   url:
                     type: string
-        '400':
+        "400":
           description: Bad request - invalid file or upload error
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Internal server error
 
   /uploads/theme:
@@ -16146,9 +16217,9 @@ paths:
                 theme:
                   type: string
                   format: binary
-                  description: 'Audio file (MP3, max 10MB)'
+                  description: "Audio file (MP3, max 10MB)"
       responses:
-        '200':
+        "200":
           description: Theme uploaded successfully
           content:
             application/json:
@@ -16159,11 +16230,11 @@ paths:
                     type: string
                   url:
                     type: string
-        '400':
+        "400":
           description: Bad request - invalid file or upload error
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Internal server error
 
   /uploads/icon:
@@ -16187,18 +16258,18 @@ paths:
                 icon:
                   type: string
                   format: binary
-                  description: 'Icon file (JPEG, PNG, WebP, SVG, max 10MB)'
+                  description: "Icon file (JPEG, PNG, WebP, SVG, max 10MB)"
                 name:
                   type: string
-                  description: 'Display name for the icon'
+                  description: "Display name for the icon"
                 category:
                   type: string
-                  description: 'Category for the icon'
+                  description: "Category for the icon"
                 description:
                   type: string
-                  description: 'Description of the icon'
+                  description: "Description of the icon"
       responses:
-        '200':
+        "200":
           description: Icon uploaded successfully
           content:
             application/json:
@@ -16216,11 +16287,11 @@ paths:
                         type: string
                       category:
                         type: string
-        '400':
+        "400":
           description: Bad request - invalid file type or upload error
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Internal server error
 
   /uploads/poster-template:
@@ -16244,9 +16315,9 @@ paths:
                 file:
                   type: string
                   format: binary
-                  description: 'ZIP file containing template.json and assets (max 50MB)'
+                  description: "ZIP file containing template.json and assets (max 50MB)"
       responses:
-        '201':
+        "201":
           description: Template imported successfully
           content:
             application/json:
@@ -16269,11 +16340,11 @@ paths:
                   updatedAt:
                     type: string
                     format: date-time
-        '400':
+        "400":
           description: Bad request - invalid ZIP, missing template.json, or unsupported version
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to import template
 
   /uploads/overlay-template-export/{id}:
@@ -16293,20 +16364,20 @@ paths:
             type: integer
           description: ID of the overlay template to export
       responses:
-        '200':
+        "200":
           description: ZIP archive download
           content:
             application/zip:
               schema:
                 type: string
                 format: binary
-        '400':
+        "400":
           description: Invalid template ID
-        '401':
+        "401":
           description: Authentication required
-        '404':
+        "404":
           description: Template not found
-        '500':
+        "500":
           description: Failed to export template
 
   /uploads/overlay-template:
@@ -16330,9 +16401,9 @@ paths:
                 file:
                   type: string
                   format: binary
-                  description: 'ZIP file containing template.json and assets (max 50MB)'
+                  description: "ZIP file containing template.json and assets (max 50MB)"
       responses:
-        '201':
+        "201":
           description: Overlay template imported successfully
           content:
             application/json:
@@ -16360,11 +16431,11 @@ paths:
                   updatedAt:
                     type: string
                     format: date-time
-        '400':
+        "400":
           description: Bad request - invalid ZIP, missing template.json, or unsupported version
-        '401':
+        "401":
           description: Authentication required
-        '500':
+        "500":
           description: Failed to import overlay template
 
 security:

--- a/server/routes/overlayLibraryConfigs.ts
+++ b/server/routes/overlayLibraryConfigs.ts
@@ -276,6 +276,76 @@ router.post('/:libraryId/apply', async (req, res, next) => {
   }
 });
 
+// POST /api/v1/overlay-library-configs/:libraryId/apply-items - Apply overlays to specific items
+router.post('/:libraryId/apply-items', async (req, res, next) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({
+        error: 'Authentication required',
+      });
+    }
+
+    const { libraryId } = req.params;
+    const { ratingKey } = req.body;
+
+    if (!ratingKey || typeof ratingKey !== 'string') {
+      return res.status(400).json({
+        error: 'ratingKey is required and must be a string',
+      });
+    }
+
+    // Check if full overlay application is running
+    const overlayApplication = (await import('@server/lib/overlayApplication'))
+      .default;
+    if (overlayApplication.running) {
+      return res.status(409).json({
+        error:
+          'Full overlay sync is currently running. Please wait for it to complete or cancel it before syncing individual items.',
+        conflictType: 'full-sync-running',
+      });
+    }
+
+    // Check if this library is already being processed
+    const libraryStatus = overlayLibraryService.getLibraryStatus(libraryId);
+    if (libraryStatus.running) {
+      return res.status(409).json({
+        error: 'This library is already being synced.',
+        conflictType: 'library-already-running',
+      });
+    }
+
+    logger.info('Applying overlays to single item', {
+      libraryId,
+      ratingKey,
+      userId: req.user?.id,
+    });
+
+    // Start async overlay application for single item
+    overlayLibraryService
+      .applyOverlaysToCollectionItems([ratingKey], libraryId)
+      .catch((error: unknown) => {
+        logger.error('Single item overlay application failed', {
+          libraryId,
+          ratingKey,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+
+    // Return immediately - overlay application runs in background
+    return res.status(202).json({
+      message: 'Overlay application started for item',
+      libraryId,
+      ratingKey,
+    });
+  } catch (error) {
+    logger.error('Failed to start single item overlay application:', error);
+    return next({
+      status: 500,
+      message: 'Failed to start overlay application',
+    });
+  }
+});
+
 // GET /api/v1/overlay-library-configs/:libraryId/status - Get overlay application status for library
 router.get('/:libraryId/status', (req, res) => {
   const { libraryId } = req.params;


### PR DESCRIPTION
#### Description

Adds the ability to refresh a specific library item (rather than just an entire library) via a POST request, for example:

`curl -X POST "http://agregarr:port/api/v1/overlay-library-configs/1/apply-items" \
  -H "X-Api-Key: [API-Key]" \
  -H "Content-Type: application/json" \
  -d '{"ratingKey": "12345"}'`

#### Checklist

- [X] Type checking (`yarn typecheck`)
- [X] Build succeeds (`yarn build`)
- [X] Translation keys extracted (`yarn i18n:extract`) - if new user-facing strings added

#### Issues Fixed or Closed

- Implements/Closes #559 