### PR TITLE
feat: refresh overlay of a single item

### DIFF
--- a/agregarr-api.yml
+++ b/agregarr-api.yml
@@ -15199,6 +15199,77 @@ paths:
         '500':
           description: Failed to start overlay application
 
+  /overlay-library-configs/{libraryId}/apply-items:
+    post:
+      summary: Apply overlays to a specific library item
+      description: Applies configured overlay templates to a single poster item in a library (runs asynchronously).
+      tags:
+        - overlays
+      parameters:
+        - name: libraryId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Plex library ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ratingKey:
+                  type: string
+                  example: '12345'
+              required:
+                - ratingKey
+      responses:
+        '202':
+          description: Overlay application started for item (runs in background)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 'Overlay application started for item'
+                  libraryId:
+                    type: string
+                    example: '1'
+                  ratingKey:
+                    type: string
+                    example: '12345'
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: 'ratingKey is required and must be a string'
+        '401':
+          description: Authentication required
+        '409':
+          description: Conflict - another overlay operation is already running
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: 'Full overlay sync is currently running. Please wait for it to complete or cancel it before syncing individual items.'
+                  conflictType:
+                    type: string
+                    enum: [full-sync-running, library-already-running]
+                    example: 'full-sync-running'
+        '500':
+          description: Failed to start single item overlay application
+
   /overlay-library-configs/{libraryId}/status:
     get:
       summary: Get overlay application status for library

--- a/server/routes/overlayLibraryConfigs.ts
+++ b/server/routes/overlayLibraryConfigs.ts
@@ -276,6 +276,76 @@ router.post('/:libraryId/apply', async (req, res, next) => {
   }
 });
 
+// POST /api/v1/overlay-library-configs/:libraryId/apply-items - Apply overlays to specific items
+router.post('/:libraryId/apply-items', async (req, res, next) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({
+        error: 'Authentication required',
+      });
+    }
+
+    const { libraryId } = req.params;
+    const { ratingKey } = req.body;
+
+    if (!ratingKey || typeof ratingKey !== 'string') {
+      return res.status(400).json({
+        error: 'ratingKey is required and must be a string',
+      });
+    }
+
+    // Check if full overlay application is running
+    const overlayApplication = (await import('@server/lib/overlayApplication'))
+      .default;
+    if (overlayApplication.running) {
+      return res.status(409).json({
+        error:
+          'Full overlay sync is currently running. Please wait for it to complete or cancel it before syncing individual items.',
+        conflictType: 'full-sync-running',
+      });
+    }
+
+    // Check if this library is already being processed
+    const libraryStatus = overlayLibraryService.getLibraryStatus(libraryId);
+    if (libraryStatus.running) {
+      return res.status(409).json({
+        error: 'This library is already being synced.',
+        conflictType: 'library-already-running',
+      });
+    }
+
+    logger.info('Applying overlays to single item', {
+      libraryId,
+      ratingKey,
+      userId: req.user?.id,
+    });
+
+    // Start async overlay application for single item
+    overlayLibraryService
+      .applyOverlaysToCollectionItems([ratingKey], libraryId)
+      .catch((error: unknown) => {
+        logger.error('Single item overlay application failed', {
+          libraryId,
+          ratingKey,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+
+    // Return immediately - overlay application runs in background
+    return res.status(202).json({
+      message: 'Overlay application started for item',
+      libraryId,
+      ratingKey,
+    });
+  } catch (error) {
+    logger.error('Failed to start single item overlay application:', error);
+    return next({
+      status: 500,
+      message: 'Failed to start overlay application',
+    });
+  }
+});
+
 // GET /api/v1/overlay-library-configs/:libraryId/status - Get overlay application status for library
 router.get('/:libraryId/status', (req, res) => {
   const { libraryId } = req.params;

--- a/src/components/Posters/TestItemModal.tsx
+++ b/src/components/Posters/TestItemModal.tsx
@@ -7,6 +7,7 @@ import type {
 } from '@app/types/overlayTest';
 import { Transition } from '@headlessui/react';
 import {
+  ArrowPathIcon,
   CheckCircleIcon,
   ChevronDownIcon,
   MagnifyingGlassIcon,
@@ -30,6 +31,11 @@ const messages = defineMessages({
   contextVariables: 'Context Variables ({count})',
   undefined: 'undefined',
   noPoster: 'No Poster',
+  refreshPoster: 'Refresh Poster',
+  refreshPosterSuccess: 'Poster refresh started for {title}',
+  refreshPosterError: 'Failed to start poster refresh',
+  refreshPosterConflict:
+    'A sync is already running. Please wait and try again.',
 });
 
 interface TestItemModalProps {
@@ -51,6 +57,10 @@ const TestItemModal: React.FC<TestItemModalProps> = ({ isOpen, onClose }) => {
   );
   const [isSearching, setIsSearching] = useState(false);
   const [isTesting, setIsTesting] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [refreshingItems, setRefreshingItems] = useState<Set<string>>(
+    new Set()
+  );
   const [expandedTemplate, setExpandedTemplate] = useState<number | null>(null);
 
   const handleSearch = async () => {
@@ -127,6 +137,68 @@ const TestItemModal: React.FC<TestItemModalProps> = ({ isOpen, onClose }) => {
     setExpandedTemplate(null);
   };
 
+  const handleRefreshPoster = async () => {
+    if (!testResults) return;
+
+    setIsRefreshing(true);
+    try {
+      await axios.post(
+        `/api/v1/overlay-library-configs/${testResults.item.libraryId}/apply-items`,
+        { ratingKey: testResults.item.ratingKey }
+      );
+      addToast(
+        intl.formatMessage(messages.refreshPosterSuccess, {
+          title: testResults.item.title,
+        }),
+        { appearance: 'success', autoDismiss: true }
+      );
+    } catch (error) {
+      const status = axios.isAxiosError(error) ? error.response?.status : null;
+      const message =
+        status === 409
+          ? intl.formatMessage(messages.refreshPosterConflict)
+          : intl.formatMessage(messages.refreshPosterError);
+      addToast(message, { appearance: 'error', autoDismiss: true });
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  const handleRefreshItem = async (
+    e: React.MouseEvent,
+    item: PlexSearchResult
+  ) => {
+    e.stopPropagation();
+    if (refreshingItems.has(item.ratingKey)) return;
+
+    setRefreshingItems((prev) => new Set(prev).add(item.ratingKey));
+    try {
+      await axios.post(
+        `/api/v1/overlay-library-configs/${item.libraryId}/apply-items`,
+        { ratingKey: item.ratingKey }
+      );
+      addToast(
+        intl.formatMessage(messages.refreshPosterSuccess, {
+          title: item.title,
+        }),
+        { appearance: 'success', autoDismiss: true }
+      );
+    } catch (error) {
+      const status = axios.isAxiosError(error) ? error.response?.status : null;
+      const message =
+        status === 409
+          ? intl.formatMessage(messages.refreshPosterConflict)
+          : intl.formatMessage(messages.refreshPosterError);
+      addToast(message, { appearance: 'error', autoDismiss: true });
+    } finally {
+      setRefreshingItems((prev) => {
+        const next = new Set(prev);
+        next.delete(item.ratingKey);
+        return next;
+      });
+    }
+  };
+
   const handleClose = () => {
     setStage('search');
     setSearchQuery('');
@@ -193,7 +265,7 @@ const TestItemModal: React.FC<TestItemModalProps> = ({ isOpen, onClose }) => {
                     <button
                       key={item.ratingKey}
                       onClick={() => setSelectedItem(item)}
-                      className={`relative rounded-lg p-2 transition-all ${
+                      className={`group relative rounded-lg p-2 transition-all ${
                         selectedItem?.ratingKey === item.ratingKey
                           ? 'bg-stone-700 ring-4 ring-orange-500'
                           : 'hover:bg-stone-700/50'
@@ -211,6 +283,20 @@ const TestItemModal: React.FC<TestItemModalProps> = ({ isOpen, onClose }) => {
                             {intl.formatMessage(messages.noPoster)}
                           </div>
                         )}
+                        <button
+                          onClick={(e) => handleRefreshItem(e, item)}
+                          disabled={refreshingItems.has(item.ratingKey)}
+                          title={intl.formatMessage(messages.refreshPoster)}
+                          className="absolute bottom-2 right-2 rounded-full bg-black/60 p-2.5 text-white opacity-0 transition-opacity hover:bg-orange-600 disabled:cursor-not-allowed disabled:opacity-50 group-hover:opacity-100"
+                        >
+                          <ArrowPathIcon
+                            className={`h-5 w-5 ${
+                              refreshingItems.has(item.ratingKey)
+                                ? 'animate-spin'
+                                : ''
+                            }`}
+                          />
+                        </button>
                       </div>
                       <div className="text-left">
                         <p className="truncate text-sm font-medium text-white">
@@ -275,6 +361,19 @@ const TestItemModal: React.FC<TestItemModalProps> = ({ isOpen, onClose }) => {
                       })}
                     </p>
                   </div>
+                  <Button
+                    buttonType="primary"
+                    onClick={handleRefreshPoster}
+                    disabled={isRefreshing}
+                    className="flex w-full items-center justify-center space-x-2"
+                  >
+                    <ArrowPathIcon
+                      className={`h-4 w-4 ${
+                        isRefreshing ? 'animate-spin' : ''
+                      }`}
+                    />
+                    <span>{intl.formatMessage(messages.refreshPoster)}</span>
+                  </Button>
                 </>
               ) : null}
             </div>


### PR DESCRIPTION
#### Description
Adds the ability to refresh a specific library item (rather than just an entire library) via a POST request, for example:

`curl -X POST "http://agregarr:port/api/v1/overlay-library-configs/1/apply-items" \
  -H "X-Api-Key: [Api-Key]" \
  -H "Content-Type: application/json" \
  -d '{"ratingKey": "12345"}'`

#### Checklist

- [X] Type checking (`yarn typecheck`)
- [X] Build succeeds (`yarn build`)

**Runs automatically on `git commit`** (If you bypassed husky (`HUSKY=0`), run these manually as well before submitting.):

- [X] Formatting (prettier) (`yarn format`)
- [X] Linting (`yarn lint`)

#### Issues Fixed or Closed

- Fixes #559 
