### PR TITLE
fix: accept Plex webhook thumb field to prevent MulterError

### DIFF
--- a/server/routes/plex-webhook.ts
+++ b/server/routes/plex-webhook.ts
@@ -73,7 +73,7 @@ async function unscrobblePlaceholder(
 }
 
 // POST / — receives Plex webhook events (multipart/form-data)
-router.post('/', upload.none(), async (req, res) => {
+router.post('/', upload.single('thumb'), async (req, res) => {
   // Respond immediately — Plex doesn't wait for our processing
   res.sendStatus(200);
 


### PR DESCRIPTION
Plex webhooks are `multipart/form-data` with two fields: `payload` (JSON text) and `thumb` (JPEG). The route uses `upload.none()` which rejects any file fields, so every webhook carrying a thumbnail throws `MulterError: Unexpected field`. This is especially noisy during sync since collection/overlay activity triggers Plex webhooks.

Switched to `upload.single('thumb')` so multer accepts the image into memory. The handler only reads `req.body.payload`, never `req.file`, so the buffer is discarded after the request.

Fixes #565