### PR TITLE
feat: use /api/collections/overlay-data endpoint

### DIFF
--- a/server/api/maintainerr.ts
+++ b/server/api/maintainerr.ts
@@ -58,11 +58,34 @@ class MaintainerrAPI {
 
   public async getCollections(): Promise<MaintainerrCollection[]> {
     try {
+      // Try the dedicated overlay-data endpoint first (Maintainerr >= 3.4.0)
       const response = await this.axios.get<MaintainerrCollection[]>(
-        '/api/collections'
+        '/api/collections/overlay-data'
       );
       return response.data;
     } catch (e) {
+      // Fall back to the legacy endpoint (Maintainerr <= 3.3.x)
+      if (axios.isAxiosError(e) && e.response?.status === 404) {
+        logger.info(
+          'overlay-data endpoint not available, falling back to /api/collections',
+          { label: 'Maintainerr API' }
+        );
+        try {
+          const response = await this.axios.get<MaintainerrCollection[]>(
+            '/api/collections'
+          );
+          return response.data;
+        } catch (fallbackErr) {
+          logger.error(
+            'Something went wrong fetching Maintainerr collections',
+            {
+              label: 'Maintainerr API',
+              errorMessage: fallbackErr.message,
+            }
+          );
+          throw fallbackErr;
+        }
+      }
       logger.error('Something went wrong fetching Maintainerr collections', {
         label: 'Maintainerr API',
         errorMessage: e.message,


### PR DESCRIPTION
#### Description

Maintainerr >= 3.4.0 changed `GET /api/collections` to return only 2 preview items per collection (a UI optimization). This broke integrations that rely on the full media list.

This PR updates `getCollections()` to use the new `/api/collections/overlay-data` endpoint (which returns all media items), with a fallback to `/api/collections` for Maintainerr <= 3.3.x compatibility.

**AI Disclosure:** This change was developed with assistance from an AI coding assistant (Warp). The root cause analysis was AI-assisted based on comparison of Maintainerr 3.3.0 and 3.4.0 source code. The same fix was tested in the maintainerr-overlay-helperr project but not yet verified within Agregarr.

#### Screenshot (if UI-related)

N/A

#### Checklist

- [ ] Type checking (`yarn typecheck`)
- [ ] Build succeeds (`yarn build`)
- [ ] Translation keys extracted (`yarn i18n:extract`) - if new user-facing strings added
- [ ] Database migration included - if schema changes required

**Runs automatically on `git commit`** (If you bypassed husky (`HUSKY=0`), run these manually as well before submitting.):

- [ ] Formatting (prettier) (`yarn format`)
- [ ] Linting (`yarn lint`)

#### Issues Fixed or Closed

- N/A