### PR TITLE
fix(placeholders): clean up legacy edition-tagged placeholder files

### DIFF
--- a/server/lib/placeholders/services/PlaceholderCleanup.ts
+++ b/server/lib/placeholders/services/PlaceholderCleanup.ts
@@ -314,8 +314,16 @@ export async function cleanupOrphanedPlaceholderFiles(): Promise<number> {
 
               const files = await fs.readdir(folderPath);
               for (const file of files) {
-                // Check if this is a placeholder file (contains edition-Trailer)
-                if (!file.includes('{edition-Trailer}')) continue;
+                // Check if this is a placeholder file. Older Agregarr versions
+                // used {edition-Placeholder} and {edition-Coming Soon} before
+                // the rename to {edition-Trailer}, so legacy files must also
+                // be matched or they accumulate forever.
+                if (
+                  !file.includes('{edition-Trailer}') &&
+                  !file.includes('{edition-Placeholder}') &&
+                  !file.includes('{edition-Coming Soon}')
+                )
+                  continue;
 
                 const filePath = path.join(folderPath, file);
 


### PR DESCRIPTION
The orphaned placeholder file scanner only matched `{edition-Trailer}`, but `removePlaceholder()` accepts `{edition-Placeholder}` and `{edition-Coming Soon}` as well. These were the placeholder filename formats used before the rename in `7e44d53c`. Files created with the older formats were never picked up by the orphan scan, so they accumulated in the placeholder root indefinitely.

Updated the file scan in `cleanupOrphanedPlaceholderFiles` to match the same set of filename markers `removePlaceholder` recognises.

Fixes #575