### PR TITLE
fix: refresh Plex shared-server cache at start of user filter batches

### DIFF
--- a/server/lib/collections/plex/PlexUserManager.ts
+++ b/server/lib/collections/plex/PlexUserManager.ts
@@ -219,8 +219,14 @@ export async function getSharedServers(
 /**
  * Get all Plex user IDs from shared servers (V2 API)
  * Returns array of Plex user IDs for all users with access to the server
+ *
+ * @param forceRefresh When true, bypass the shared-server cache and refetch
+ *   from Plex. Batch operations should pass true so that each run starts
+ *   from the user's current Plex state, not a snapshot from the previous run.
  */
-export async function getAllPlexUserIds(): Promise<string[]> {
+export async function getAllPlexUserIds(
+  forceRefresh = false
+): Promise<string[]> {
   try {
     const settings = getSettings();
     const admin = await getAdminUser();
@@ -235,7 +241,8 @@ export async function getAllPlexUserIds(): Promise<string[]> {
 
     const sharedServers = await getSharedServers(
       settings.plex.machineId,
-      admin.plexToken
+      admin.plexToken,
+      forceRefresh
     );
 
     // V2 uses invitedId instead of userID
@@ -528,8 +535,10 @@ export async function applyPreSyncUserRestrictions(): Promise<void> {
       label: 'Plex User Manager',
     });
 
-    // Get all Plex users who need restrictions applied
-    const allPlexUserIds = await getAllPlexUserIds();
+    // Get all Plex users who need restrictions applied. Force a refresh so
+    // this run reads the user's current Plex sharing settings rather than a
+    // snapshot cached from the previous run.
+    const allPlexUserIds = await getAllPlexUserIds(true);
     if (allPlexUserIds.length === 0) {
       logger.warn('No Plex users found - skipping user restrictions', {
         label: 'Plex User Manager',
@@ -603,8 +612,10 @@ export async function applySelectivePreSyncUserRestrictions(
       }
     );
 
-    // Get all Plex users who need restrictions applied
-    const allPlexUserIds = await getAllPlexUserIds();
+    // Get all Plex users who need restrictions applied. Force a refresh so
+    // this run reads the user's current Plex sharing settings rather than a
+    // snapshot cached from the previous run.
+    const allPlexUserIds = await getAllPlexUserIds(true);
     if (allPlexUserIds.length === 0) {
       logger.warn('No Plex users found - skipping user restrictions', {
         label: 'Plex User Manager',

--- a/server/lib/collections/services/CollectionCleanupService.ts
+++ b/server/lib/collections/services/CollectionCleanupService.ts
@@ -298,7 +298,9 @@ export class CollectionCleanupService {
         '@server/lib/collections/plex/PlexUserManager'
       );
 
-      const allPlexUserIds = await getAllPlexUserIds();
+      // Force a refresh so this cleanup pass reads the user's current Plex
+      // sharing settings rather than a stale snapshot from a previous run.
+      const allPlexUserIds = await getAllPlexUserIds(true);
 
       if (allPlexUserIds.length > 0) {
         logger.info(

--- a/server/lib/collections/services/CollectionSyncService.ts
+++ b/server/lib/collections/services/CollectionSyncService.ts
@@ -813,8 +813,9 @@ export class CollectionSyncService {
         '@server/lib/collections/plex/PlexUserManager'
       );
 
-      // Get all Plex users
-      const allPlexUserIds = await getAllPlexUserIds();
+      // Get all Plex users. Force a refresh so this cleanup pass reads the
+      // user's current Plex sharing settings rather than a stale snapshot.
+      const allPlexUserIds = await getAllPlexUserIds(true);
       if (allPlexUserIds.length === 0) {
         logger.debug('No Plex users found - skipping user filter cleanup', {
           label: 'Collection Sync Service',


### PR DESCRIPTION
`getAllPlexUserIds()` and per-user reads in `updateUserFilterSettings()` share a module-level `sharedServerCache` in `PlexUserManager.ts` that has no TTL and is only invalidated by the post-write verification step. As a result, manual edits made in Plex Home → user → Restrictions between runs are invisible to the next batch: it reads the cached snapshot from the previous run, rebuilds the full sharing settings payload from it, and POSTs that snapshot back, silently overwriting the user's UI changes.

Pass `forceRefresh=true` from the four batch entry points so each batch reads fresh sharing settings and seeds the cache for the rest of that batch:

- `applyPreSyncUserRestrictions`
- `applySelectivePreSyncUserRestrictions`
- `CollectionSyncService.cleanupUserFilterLabels`
- `CollectionCleanupService` Agregarr-label cleanup

Fixes #577