### PR TITLE
Fix Letterboxd custom list parsing without film IDs

### DIFF
--- a/server/lib/collections/sources/letterboxd.ts
+++ b/server/lib/collections/sources/letterboxd.ts
@@ -830,7 +830,6 @@ export class LetterboxdCollectionSync extends BaseCollectionSync<'letterboxd'> {
         /<li[^>]*[^>]*>(.*?data-film-id="[^"]*".*?)<\/li>/gs,
       ];
 
-      const filmIdRegex = /data-film-id="([^"]+)"/;
       const targetLinkRegex = /data-target-link="([^"]+)"/;
       const fullDisplayNameRegex = /data-item-full-display-name="([^"]+)"/;
       const titleRegex = /data-item-name="([^"]+)"/;
@@ -872,9 +871,8 @@ export class LetterboxdCollectionSync extends BaseCollectionSync<'letterboxd'> {
         if (count >= maxItems) break;
         const itemHtml = match[1];
 
-        // Extract film ID
-        const filmIdMatch = itemHtml.match(filmIdRegex);
-        if (!filmIdMatch) continue;
+        // Letterboxd list items may no longer include data-film-id.
+        // The parser only needs target link/title/year for TMDB resolution.
 
         // Extract target link (movie slug)
         const targetLinkMatch = itemHtml.match(targetLinkRegex);


### PR DESCRIPTION
## Summary

Letterboxd custom list pages no longer appear to include `data-film-id` on list items, but they still include `data-target-link`, `data-item-name`, and `data-item-full-display-name`.

The parser was requiring `data-film-id` before continuing, even though the parsed result only uses title, year, and Letterboxd URL for TMDB resolution. As a result, custom lists could fetch successfully but parse 0 movies.

This removes the unused `data-film-id` requirement and allows parsing to continue using the fields that are still present.

## Testing

Tested against a current Letterboxd custom list page:

`https://letterboxd.com/browsehorror/list/horror-movies-everyone-should-watch-at-least/`

Before:

- `posteritem` matches: 100
- `data-film-id` matches: 0
- parsed items: 0

After:

- `posteritem` matches: 100
- parsed items: 100

Also ran:

```bash
yarn lint
yarn typecheck:server