### PR TITLE
Fix: fixed a 502 timeout error when you load a Custom advanced filter…

### DIFF
--- a/server/lib/collections/sources/tmdb.ts
+++ b/server/lib/collections/sources/tmdb.ts
@@ -803,27 +803,27 @@ export class TmdbCollectionSync extends BaseCollectionSync<'tmdb'> {
               try {
                 return mediaType === 'tv'
                   ? await this.tmdbClient.getAdvancedDiscoverTv({
-                    ...(discoverFilters as Parameters<
-                      typeof this.tmdbClient.getAdvancedDiscoverTv
-                    >[0]),
-                    page,
-                  })
+                      ...(discoverFilters as Parameters<
+                        typeof this.tmdbClient.getAdvancedDiscoverTv
+                      >[0]),
+                      page,
+                    })
                   : await this.tmdbClient.getAdvancedDiscoverMovies({
-                    ...(discoverFilters as Parameters<
-                      typeof this.tmdbClient.getAdvancedDiscoverMovies
-                    >[0]),
-                    page,
-                  });
+                      ...(discoverFilters as Parameters<
+                        typeof this.tmdbClient.getAdvancedDiscoverMovies
+                      >[0]),
+                      page,
+                    });
               } catch (err) {
                 lastError = err;
                 // Only retry on transient server/gateway errors (5xx)
                 const status =
                   err != null &&
-                    typeof err === 'object' &&
-                    'response' in err &&
-                    err.response != null &&
-                    typeof err.response === 'object' &&
-                    'status' in err.response
+                  typeof err === 'object' &&
+                  'response' in err &&
+                  err.response != null &&
+                  typeof err.response === 'object' &&
+                  'status' in err.response
                     ? (err.response as { status: number }).status
                     : undefined;
                 if (status !== undefined && status < 500) {
@@ -1682,7 +1682,8 @@ export class TmdbCollectionSync extends BaseCollectionSync<'tmdb'> {
     }
 
     logger.info(
-      `TMDB franchise discovery complete: ${movieApiCalls} movie API calls, ${collectionApiCalls} collection API calls (${tmdbIds.length - processedTmdbIds.size
+      `TMDB franchise discovery complete: ${movieApiCalls} movie API calls, ${collectionApiCalls} collection API calls (${
+        tmdbIds.length - processedTmdbIds.size
       } movies skipped)`,
       {
         label: 'TMDB Franchise',

--- a/server/lib/collections/sources/tmdb.ts
+++ b/server/lib/collections/sources/tmdb.ts
@@ -787,23 +787,90 @@ export class TmdbCollectionSync extends BaseCollectionSync<'tmdb'> {
           let currentPage = 1;
           let hasMorePages = true;
           const BATCH_SIZE = 5;
+          const MAX_RETRIES = 3;
 
-          while (hasMorePages) {
-            for (let i = 0; i < BATCH_SIZE && hasMorePages; i++) {
-              const data =
-                mediaType === 'tv'
+          const fetchPage = async (
+            page: number
+          ): Promise<
+            | Awaited<
+                ReturnType<typeof this.tmdbClient.getAdvancedDiscoverTv>
+              >
+            | Awaited<
+                ReturnType<typeof this.tmdbClient.getAdvancedDiscoverMovies>
+              >
+          > => {
+            let lastError: unknown;
+            for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+              if (attempt > 0) {
+                const delayMs = 1000 * Math.pow(2, attempt - 1); // 1s, 2s, 4s
+                logger.warn(
+                  `TMDB advanced discover retry ${attempt}/${MAX_RETRIES} for page ${page} after ${delayMs}ms`,
+                  { label: 'Collection Sync', page, attempt }
+                );
+                await new Promise((resolve) => setTimeout(resolve, delayMs));
+              }
+              try {
+                return mediaType === 'tv'
                   ? await this.tmdbClient.getAdvancedDiscoverTv({
                       ...(discoverFilters as Parameters<
                         typeof this.tmdbClient.getAdvancedDiscoverTv
                       >[0]),
-                      page: currentPage,
+                      page,
                     })
                   : await this.tmdbClient.getAdvancedDiscoverMovies({
                       ...(discoverFilters as Parameters<
                         typeof this.tmdbClient.getAdvancedDiscoverMovies
                       >[0]),
-                      page: currentPage,
+                      page,
                     });
+              } catch (err) {
+                lastError = err;
+                // Only retry on transient server/gateway errors (5xx)
+                const status =
+                  err != null &&
+                  typeof err === 'object' &&
+                  'response' in err &&
+                  err.response != null &&
+                  typeof err.response === 'object' &&
+                  'status' in err.response
+                    ? (err.response as { status: number }).status
+                    : undefined;
+                if (status !== undefined && status < 500) {
+                  throw err; // 4xx — no point retrying
+                }
+              }
+            }
+            throw lastError;
+          };
+
+          while (hasMorePages) {
+            for (let i = 0; i < BATCH_SIZE && hasMorePages; i++) {
+              let data:
+                | Awaited<
+                    ReturnType<typeof this.tmdbClient.getAdvancedDiscoverTv>
+                  >
+                | Awaited<
+                    ReturnType<
+                      typeof this.tmdbClient.getAdvancedDiscoverMovies
+                    >
+                  >;
+              try {
+                data = await fetchPage(currentPage);
+              } catch (fetchError) {
+                logger.warn(
+                  'TMDB advanced discover request failed after retries, stopping pagination',
+                  {
+                    label: 'Collection Sync',
+                    page: currentPage,
+                    error:
+                      fetchError instanceof Error
+                        ? fetchError.message
+                        : String(fetchError),
+                  }
+                );
+                hasMorePages = false;
+                break;
+              }
 
               if (!data.results || data.results.length === 0) {
                 hasMorePages = false;

--- a/server/lib/collections/sources/tmdb.ts
+++ b/server/lib/collections/sources/tmdb.ts
@@ -803,27 +803,27 @@ export class TmdbCollectionSync extends BaseCollectionSync<'tmdb'> {
               try {
                 return mediaType === 'tv'
                   ? await this.tmdbClient.getAdvancedDiscoverTv({
-                      ...(discoverFilters as Parameters<
-                        typeof this.tmdbClient.getAdvancedDiscoverTv
-                      >[0]),
-                      page,
-                    })
+                    ...(discoverFilters as Parameters<
+                      typeof this.tmdbClient.getAdvancedDiscoverTv
+                    >[0]),
+                    page,
+                  })
                   : await this.tmdbClient.getAdvancedDiscoverMovies({
-                      ...(discoverFilters as Parameters<
-                        typeof this.tmdbClient.getAdvancedDiscoverMovies
-                      >[0]),
-                      page,
-                    });
+                    ...(discoverFilters as Parameters<
+                      typeof this.tmdbClient.getAdvancedDiscoverMovies
+                    >[0]),
+                    page,
+                  });
               } catch (err) {
                 lastError = err;
                 // Only retry on transient server/gateway errors (5xx)
                 const status =
                   err != null &&
-                  typeof err === 'object' &&
-                  'response' in err &&
-                  err.response != null &&
-                  typeof err.response === 'object' &&
-                  'status' in err.response
+                    typeof err === 'object' &&
+                    'response' in err &&
+                    err.response != null &&
+                    typeof err.response === 'object' &&
+                    'status' in err.response
                     ? (err.response as { status: number }).status
                     : undefined;
                 if (status !== undefined && status < 500) {
@@ -1682,8 +1682,7 @@ export class TmdbCollectionSync extends BaseCollectionSync<'tmdb'> {
     }
 
     logger.info(
-      `TMDB franchise discovery complete: ${movieApiCalls} movie API calls, ${collectionApiCalls} collection API calls (${
-        tmdbIds.length - processedTmdbIds.size
+      `TMDB franchise discovery complete: ${movieApiCalls} movie API calls, ${collectionApiCalls} collection API calls (${tmdbIds.length - processedTmdbIds.size
       } movies skipped)`,
       {
         label: 'TMDB Franchise',

--- a/server/lib/collections/sources/tmdb.ts
+++ b/server/lib/collections/sources/tmdb.ts
@@ -789,16 +789,7 @@ export class TmdbCollectionSync extends BaseCollectionSync<'tmdb'> {
           const BATCH_SIZE = 5;
           const MAX_RETRIES = 3;
 
-          const fetchPage = async (
-            page: number
-          ): Promise<
-            | Awaited<
-                ReturnType<typeof this.tmdbClient.getAdvancedDiscoverTv>
-              >
-            | Awaited<
-                ReturnType<typeof this.tmdbClient.getAdvancedDiscoverMovies>
-              >
-          > => {
+          const fetchPage = async (page: number) => {
             let lastError: unknown;
             for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
               if (attempt > 0) {
@@ -845,15 +836,7 @@ export class TmdbCollectionSync extends BaseCollectionSync<'tmdb'> {
 
           while (hasMorePages) {
             for (let i = 0; i < BATCH_SIZE && hasMorePages; i++) {
-              let data:
-                | Awaited<
-                    ReturnType<typeof this.tmdbClient.getAdvancedDiscoverTv>
-                  >
-                | Awaited<
-                    ReturnType<
-                      typeof this.tmdbClient.getAdvancedDiscoverMovies
-                    >
-                  >;
+              let data: Awaited<ReturnType<typeof fetchPage>>;
               try {
                 data = await fetchPage(currentPage);
               } catch (fetchError) {


### PR DESCRIPTION
… for the first time

#### Description
Added a cooldown/backoff to prevent from spamming the TMDB endpoint when you create a new collection. Before with a filter type you havent ran before you would get the following error. Once you run it the second time it seemed to work. If you would like to see anything cleaned up or improved let me know.
#### Screenshot (if UI-related)
<img width="1828" height="931" alt="image" src="https://github.com/user-attachments/assets/d215a13a-0993-40e7-a89b-262ad723c3dc" />

#### Checklist

- [x ] Type checking (`yarn typecheck`)
- [ x] Build succeeds (`yarn build`)
- [ x] Translation keys extracted (`yarn i18n:extract`) - if new user-facing strings added
- [ x] Database migration included - if schema changes required

**Runs automatically on `git commit`** (If you bypassed husky (`HUSKY=0`), run these manually as well before submitting.):

- [x ] Formatting (prettier) (`yarn format`)
- [ x] Linting (`yarn lint`)

#### Issues Fixed or Closed

- Fixes #XXXX - no ticket known, found this when testing something else
