### PR TITLE
fix: align poster filename sanitization with validation allowlist

### DIFF
--- a/server/lib/posterStorage.ts
+++ b/server/lib/posterStorage.ts
@@ -342,11 +342,6 @@ export async function savePosterFile(
 export async function deletePosterFile(filename: string): Promise<void> {
   if (!filename) return;
 
-  // Security: Validate filename to prevent path traversal
-  if (!isValidFilename(filename)) {
-    throw new Error('Invalid filename');
-  }
-
   const filePath = path.join(POSTER_STORAGE_DIR, filename);
 
   // Security: Ensure the resolved path is within the poster directory

--- a/server/lib/posterStorage.ts
+++ b/server/lib/posterStorage.ts
@@ -24,8 +24,11 @@ const POSTER_HEIGHT = 1500; // Standard poster height (2:3 ratio)
 function sanitizeFilename(name: string): string {
   return (
     name
-      // Replace path separators and other unsafe characters
-      .replace(/[/\\:*?"<>|]/g, '_')
+      .normalize('NFC')
+      // Keep only characters allowed by isValidFilename's friendlyPattern
+      .replace(/[^\p{L}0-9_\-\s.()]/gu, '_')
+      // Collapse consecutive dots to prevent path traversal rejection
+      .replace(/\.{2,}/g, '.')
       // Replace multiple spaces/underscores with single underscore
       .replace(/[\s_]+/g, '_')
       // Remove leading/trailing underscores and dots
@@ -57,7 +60,7 @@ function isValidFilename(filename: string): boolean {
   // - Friendly names: any safe characters + extension
   // - Legacy UUID format
   // - Generated patterns (for auto-generated posters)
-  const friendlyPattern = /^[a-zA-Z0-9_\-\s.()]+\.(jpg|jpeg|png|webp)$/i;
+  const friendlyPattern = /^[\p{L}0-9_\-\s.()]+\.(jpg|jpeg|png|webp)$/iu;
   const uuidPattern =
     /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\.(jpg|jpeg|png|webp)$/i;
   const generatedPattern = /^generated_[a-z0-9]+\.(jpg|jpeg|png|webp)$/i;


### PR DESCRIPTION
`sanitizeFilename()` used a denylist (`[/\\:*?"<>|]`) but `isValidFilename()` used an allowlist (`[a-zA-Z0-9_\-\s.()]`). Characters like `!` passed sanitization but failed validation, so Agregarr saved poster files it then refused to serve.

Changed `sanitizeFilename` to use the same character set as `isValidFilename`. Also added `\p{L}` (unicode letters) to both functions so international collection names (CJK, accented characters) produce valid filenames instead of collapsing to underscores. Added NFC normalization for decomposed unicode and consecutive dot collapsing to prevent path traversal rejection.

Fixes #585