### PR TITLE
fix: prevent jobs page crash on unparseable cron expressions

### DIFF
--- a/src/components/Settings/SettingsJobsCache/index.tsx
+++ b/src/components/Settings/SettingsJobsCache/index.tsx
@@ -396,9 +396,16 @@ const SettingsJobs = () => {
                 <div className="form-input-area mt-2 mb-1">
                   <div>
                     {jobModalState.job &&
-                      cronstrue.toString(jobModalState.job.cronSchedule, {
-                        locale,
-                      })}
+                      (() => {
+                        try {
+                          return cronstrue.toString(
+                            jobModalState.job.cronSchedule,
+                            { locale }
+                          );
+                        } catch {
+                          return jobModalState.job.cronSchedule;
+                        }
+                      })()}
                   </div>
                   <div className="text-sm text-gray-500">
                     {jobModalState.job?.cronSchedule}


### PR DESCRIPTION
`cronstrue.toString()` throws on cron expressions it can't parse, like day-of-week syntax (`0 0 0 * * 0`) entered via manual `settings.json` edits. The unhandled exception crashes the entire `/settings/jobs` page with an "Oops" error.

Wrapped the call in a try-catch. Falls back to displaying the raw cron expression when `cronstrue` can't produce a human-readable version.

Fixes #587