### PR TITLE
fix: detect real content in TV placeholder cleanup via Plex metadata

### DIFF
--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -1438,12 +1438,12 @@ class PlexAPI {
         }
       }
 
-      // Check if label exists (case-insensitive)
-      const labelIndex = existingLabels.findIndex(
-        (existingLabel) => existingLabel.toLowerCase() === label.toLowerCase()
+      // Remove ALL case-insensitive matches (handles duplicates with different casing)
+      const updatedLabels = existingLabels.filter(
+        (existingLabel) => existingLabel.toLowerCase() !== label.toLowerCase()
       );
 
-      if (labelIndex === -1) {
+      if (updatedLabels.length === existingLabels.length) {
         logger.debug('Label does not exist on item, nothing to remove', {
           label: 'Plex API',
           ratingKey,
@@ -1451,11 +1451,6 @@ class PlexAPI {
         });
         return;
       }
-
-      // Remove the label from the array
-      const updatedLabels = existingLabels.filter(
-        (_, index) => index !== labelIndex
-      );
 
       // Build params with remaining labels
       const params: Record<string, string> = {};

--- a/server/lib/placeholders/services/PlaceholderContextService.ts
+++ b/server/lib/placeholders/services/PlaceholderContextService.ts
@@ -175,26 +175,21 @@ export class PlaceholderContextService {
       // TV shows: Check if only Season 00 exists (our trailer placeholder pattern)
       // Real shows will have Season 01+ when content arrives
 
-      // Check if children are provided and inspect them
-      const childSeasons =
-        plexMetadata.Children?.Metadata || plexMetadata.Children?.Directory;
-      if (childSeasons) {
+      // Merge both child arrays (Plex may populate either or both)
+      const childSeasons = [
+        ...(plexMetadata.Children?.Metadata || []),
+        ...(plexMetadata.Children?.Directory || []),
+      ];
+      if (childSeasons.length > 0) {
         const seasons = childSeasons as {
           index?: number;
         }[];
 
-        // If no seasons at all, assume it's not a placeholder (might be corrupted metadata)
-        if (seasons.length === 0) {
-          return false;
-        }
-
-        // Check if all seasons are Season 00 (specials/trailers only)
         const nonZeroSeasons = seasons.filter(
-          (s) => s.index && s.index > 0
+          (s) => s.index !== undefined && s.index > 0
         ).length;
 
-        // Only a placeholder if ALL seasons are Season 00
-        return nonZeroSeasons === 0 && seasons.length > 0;
+        return nonZeroSeasons === 0;
       }
 
       // If no children metadata provided, use leafCount as a heuristic

--- a/server/lib/placeholders/services/PlaceholderDiscovery.ts
+++ b/server/lib/placeholders/services/PlaceholderDiscovery.ts
@@ -142,12 +142,38 @@ export async function discoverPlaceholdersFromMarkers(
 
       const plexItem = plexMatches.get(`${marker.tmdbId}-tv`);
 
-      // Marker file on disk proves this is an Agregarr-created placeholder.
-      // Don't re-verify via isPlaceholderItem — returns false for TV shows
-      // when Children metadata is missing from the Plex API response.
+      // Check Plex metadata to detect real content (mirrors the movie path)
       let needsTitleFix = false;
       if (plexItem) {
-        needsTitleFix = true;
+        let isStillPlaceholder = true;
+        try {
+          const plexMetadata = await plexClient.getMetadata(
+            plexItem.ratingKey.toString(),
+            { includeChildren: true }
+          );
+          isStillPlaceholder =
+            placeholderContextService.isPlaceholderItem(plexMetadata);
+        } catch (error) {
+          logger.warn('Failed to fetch Plex metadata for placeholder check', {
+            label: 'PlaceholderService',
+            title: marker.title,
+            ratingKey: plexItem.ratingKey,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+
+        if (!isStillPlaceholder) {
+          logger.info(
+            'TV placeholder has real content now - triggering cleanup',
+            {
+              label: 'PlaceholderService',
+              title: marker.title,
+              ratingKey: plexItem.ratingKey,
+            }
+          );
+        } else {
+          needsTitleFix = true;
+        }
       }
 
       discovered.push({
@@ -192,13 +218,38 @@ export async function discoverPlaceholdersFromMarkers(
 
         const plexItem = plexMatches.get(`${dbRecord.tmdbId}-tv`);
 
-        // Marker file on disk proves this is an Agregarr-created placeholder.
-        // Don't re-verify via isPlaceholderItem — returns false for TV shows
-        // when Children metadata is missing from the Plex API response.
-        // Only *arr download status determines cleanup vs title-fix.
+        // Check Plex metadata to detect real content (mirrors Tier 1)
         let needsTitleFix = false;
         if (plexItem) {
-          needsTitleFix = true;
+          let isStillPlaceholder = true;
+          try {
+            const plexMetadata = await plexClient.getMetadata(
+              plexItem.ratingKey.toString(),
+              { includeChildren: true }
+            );
+            isStillPlaceholder =
+              placeholderContextService.isPlaceholderItem(plexMetadata);
+          } catch (error) {
+            logger.warn('Failed to fetch Plex metadata for placeholder check', {
+              label: 'PlaceholderService',
+              title: marker.title,
+              ratingKey: plexItem.ratingKey,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+
+          if (!isStillPlaceholder) {
+            logger.info(
+              'Tier 2: TV placeholder has real content now - triggering cleanup',
+              {
+                label: 'PlaceholderService',
+                title: marker.title,
+                ratingKey: plexItem.ratingKey,
+              }
+            );
+          } else {
+            needsTitleFix = true;
+          }
         }
 
         discovered.push({


### PR DESCRIPTION
TV placeholder discovery (Tier 1 and Tier 2) never checked whether real content had arrived. When a Plex item was found for a marker, it always kept it as a placeholder without verifying. Movies already used `getMetadata(includeChildren)` + `isPlaceholderItem()` to detect real content, but TV skipped this entirely.

If Sonarr didn't report the show as downloaded (missing tvdbId, show not in Sonarr, Sonarr unreachable), cleanup never triggered. The show would keep its Season 00 trailer file, label, and overlay indefinitely.

**Changes**

- TV Tier 1 and Tier 2 discovery now fetches Plex metadata with `includeChildren: true` and checks for real seasons (Season 1+) before deciding. If the show still only has Season 00, it stays a placeholder. If real seasons exist, cleanup triggers. Mirrors what the movie discovery path already does.
- Fixed `isPlaceholderItem` using `Metadata || Directory` to pick child arrays. An empty `Metadata` array (truthy `[]`) would hide a populated `Directory` array. Now merges both with spread.
- Each `getMetadata` call is wrapped in try/catch so one Plex error doesn't abort discovery for remaining placeholders.