### PR TITLE
fix: apply mutual exclusion to filtered hub smart collections

### DIFF
--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -2376,14 +2376,16 @@ class PlexAPI {
       | 'recently_added'
       | 'recently_released'
       | 'recently_released_episodes',
-    maxItems?: number
+    maxItems?: number,
+    excludeCollectionTitles?: string[]
   ): Promise<void> {
     return this.smartCollectionManager.updateFilteredHubUri(
       smartCollectionRatingKey,
       libraryKey,
       mediaType,
       subtype,
-      maxItems
+      maxItems,
+      excludeCollectionTitles
     );
   }
 

--- a/server/lib/collections/plex/PlexSmartCollectionManager.ts
+++ b/server/lib/collections/plex/PlexSmartCollectionManager.ts
@@ -284,6 +284,7 @@ class PlexSmartCollectionManager {
    * @param mediaType - 'movie' or 'tv'
    * @param subtype - Hub subtype ('recently_added', 'recently_released', or 'recently_released_episodes')
    * @param maxItems - Maximum number of items to include in the smart collection
+   * @param excludeCollectionTitles - Collection titles to exclude via Plex smart filter
    * @returns The rating key of the created smart collection or null if failed
    */
   public async createFilteredHub(
@@ -294,7 +295,8 @@ class PlexSmartCollectionManager {
       | 'recently_added'
       | 'recently_released'
       | 'recently_released_episodes',
-    maxItems?: number
+    maxItems?: number,
+    excludeCollectionTitles?: string[]
   ): Promise<string | null> {
     try {
       logger.debug(
@@ -357,6 +359,13 @@ class PlexSmartCollectionManager {
         }
       } else {
         throw new Error(`Unsupported filtered hub subtype: ${subtype}`);
+      }
+
+      // Add collection exclusion filters
+      if (excludeCollectionTitles?.length) {
+        for (const colTitle of excludeCollectionTitles) {
+          filterUri += `&collection!=${encodeURIComponent(colTitle)}`;
+        }
       }
 
       // Add limit parameter if specified
@@ -657,6 +666,7 @@ class PlexSmartCollectionManager {
    * @param mediaType - 'movie' or 'tv'
    * @param subtype - Hub subtype ('recently_added', 'recently_released', or 'recently_released_episodes')
    * @param maxItems - Maximum number of items to include in the smart collection
+   * @param excludeCollectionTitles - Collection titles to exclude via Plex smart filter
    * @returns Promise<void>
    */
   public async updateFilteredHubUri(
@@ -667,7 +677,8 @@ class PlexSmartCollectionManager {
       | 'recently_added'
       | 'recently_released'
       | 'recently_released_episodes',
-    maxItems?: number
+    maxItems?: number,
+    excludeCollectionTitles?: string[]
   ): Promise<void> {
     try {
       logger.debug(
@@ -731,6 +742,13 @@ class PlexSmartCollectionManager {
         }
       } else {
         throw new Error(`Unsupported filtered hub subtype: ${subtype}`);
+      }
+
+      // Add collection exclusion filters
+      if (excludeCollectionTitles?.length) {
+        for (const colTitle of excludeCollectionTitles) {
+          filterUri += `&collection!=${encodeURIComponent(colTitle)}`;
+        }
       }
 
       // Add limit parameter if specified

--- a/server/lib/collections/sources/recentlyadded.ts
+++ b/server/lib/collections/sources/recentlyadded.ts
@@ -18,6 +18,8 @@ import {
   extractTmdbIdFromGuids,
   extractTvdbIdFromGuids,
   getCollectionMediaType,
+  parseConfigIdFromLabel,
+  updateConfigWithRatingKey,
   type LibraryItemsCache,
 } from '@server/lib/collections/core/CollectionUtilities';
 import type {
@@ -208,16 +210,45 @@ export class FilteredHubCollectionSync extends BaseCollectionSync<'filtered_hub'
         const excludedConfig = settings.plex.collectionConfigs?.find(
           (c) => c.id === excludedId
         );
-        if (!excludedConfig?.collectionRatingKey) {
+        if (!excludedConfig) {
           logger.debug(
-            `Skipping exclusion for config ${excludedId}: no collection rating key`,
+            `Skipping exclusion for config ${excludedId}: config not found`,
             { label: 'Filtered Hub Collections' }
           );
           continue;
         }
-        const plexCol = libraryCollections.find(
-          (c) => c.ratingKey === excludedConfig.collectionRatingKey
-        );
+
+        let plexCol: (typeof libraryCollections)[number] | undefined;
+
+        if (excludedConfig.collectionRatingKey) {
+          plexCol = libraryCollections.find(
+            (c) => c.ratingKey === excludedConfig.collectionRatingKey
+          );
+        }
+
+        // Fallback: ratingKey missing or stale (collection was recreated).
+        // Search by Agregarr label which encodes the config ID.
+        // Only attempt if excluded config is in the same library as this hub.
+        if (!plexCol && excludedConfig.libraryId === config.libraryId) {
+          plexCol = libraryCollections.find((c) =>
+            c.labels?.some((label) => {
+              const labelText = typeof label === 'string' ? label : label.tag;
+              return parseConfigIdFromLabel(labelText) === excludedId;
+            })
+          );
+          if (plexCol) {
+            logger.info(
+              `Exclusion config ${excludedId} (${excludedConfig.name}): resolved via label fallback (ratingKey ${plexCol.ratingKey})`,
+              { label: 'Filtered Hub Collections' }
+            );
+            updateConfigWithRatingKey(
+              excludedId,
+              plexCol.ratingKey,
+              excludedConfig.libraryId
+            );
+          }
+        }
+
         if (plexCol?.title) {
           excludeCollectionTitles.push(plexCol.title);
         } else {

--- a/server/lib/collections/sources/recentlyadded.ts
+++ b/server/lib/collections/sources/recentlyadded.ts
@@ -33,7 +33,7 @@ import type {
   SyncResult,
 } from '@server/lib/collections/core/types';
 import { CollectionSyncErrorType } from '@server/lib/collections/core/types';
-import type { CollectionConfig } from '@server/lib/settings';
+import { getSettings, type CollectionConfig } from '@server/lib/settings';
 import logger from '@server/logger';
 
 export class FilteredHubCollectionSync extends BaseCollectionSync<'filtered_hub'> {
@@ -197,6 +197,45 @@ export class FilteredHubCollectionSync extends BaseCollectionSync<'filtered_hub'
       generatedName: collectionName,
     });
 
+    // Resolve collection exclusions to Plex collection titles
+    const excludeCollectionTitles: string[] = [];
+    if (config.excludeFromCollections?.length) {
+      const settings = getSettings();
+      const libraryCollections = allCollections.filter(
+        (col) => col.libraryKey === config.libraryId
+      );
+      for (const excludedId of config.excludeFromCollections) {
+        const excludedConfig = settings.plex.collectionConfigs?.find(
+          (c) => c.id === excludedId
+        );
+        if (!excludedConfig?.collectionRatingKey) {
+          logger.debug(
+            `Skipping exclusion for config ${excludedId}: no collection rating key`,
+            { label: 'Filtered Hub Collections' }
+          );
+          continue;
+        }
+        const plexCol = libraryCollections.find(
+          (c) => c.ratingKey === excludedConfig.collectionRatingKey
+        );
+        if (plexCol?.title) {
+          excludeCollectionTitles.push(plexCol.title);
+        } else {
+          logger.debug(
+            `Skipping exclusion for config ${excludedId}: Plex collection not found`,
+            { label: 'Filtered Hub Collections' }
+          );
+        }
+      }
+      if (excludeCollectionTitles.length > 0) {
+        logger.info('Applying collection exclusions to filtered hub', {
+          label: 'Filtered Hub Collections',
+          configName: config.name,
+          excludedCollections: excludeCollectionTitles,
+        });
+      }
+    }
+
     // Check if smart collection already exists
     // Define custom label for this collection
     const customLabel = `Agregarr-filtered_hub-${config.id}`;
@@ -252,7 +291,8 @@ export class FilteredHubCollectionSync extends BaseCollectionSync<'filtered_hub'
         config.libraryId,
         mediaType,
         subtype,
-        config.maxItems
+        config.maxItems,
+        excludeCollectionTitles.length > 0 ? excludeCollectionTitles : undefined
       );
 
       logger.info('Updated filtered hub smart collection URI', {
@@ -281,7 +321,8 @@ export class FilteredHubCollectionSync extends BaseCollectionSync<'filtered_hub'
         config.libraryId,
         mediaType,
         subtype,
-        config.maxItems
+        config.maxItems,
+        excludeCollectionTitles.length > 0 ? excludeCollectionTitles : undefined
       );
 
       if (!smartCollectionKey) {


### PR DESCRIPTION
Mutual exclusion was silently ignored on filtered hub collections. The UI allowed configuring it, but nothing happened.

Filtered hubs are Plex smart collections. Agregarr builds a smart URI and hands it to Plex to evaluate server-side. `applyCollectionExclusions()` operates on a `CollectionItem[]` array, but filtered hubs never materialise one, so the exclusion code never ran.

Plex supports `collection!=Title` as a native smart filter parameter. The fix resolves excluded config IDs to their current Plex collection titles and appends `&collection!=Title` to the smart URI. Plex handles the exclusion at query time. No labels, no extra API calls, no cleanup logic.

- Added optional `excludeCollectionTitles` param to `createFilteredHub` and `updateFilteredHubUri`
- `recentlyadded.ts` resolves `config.excludeFromCollections` to Plex titles via the `allCollections` array already available
- Gracefully skips exclusions where the target collection hasn't synced yet

Tested with movies and TV, multiple exclusions, special characters in collection names, chained with existing `label!=` filters.

Fixes #510