### PR TITLE
fix: invalidate stale AWS WAF tokens and add solve backoff

### DIFF
--- a/server/lib/collections/utils/AwsWafTokenSolver.ts
+++ b/server/lib/collections/utils/AwsWafTokenSolver.ts
@@ -10,11 +10,18 @@ import { chromium, type BrowserContext, type Cookie } from 'playwright';
  * The token is cached and reused until it expires (typically 5-10 minutes).
  */
 export class AwsWafTokenSolver {
+  private static readonly MAX_TOKEN_TTL = 5 * 60 * 1000; // 5 minutes
+  private static readonly BACKOFF_BASE_MS = 60 * 1000; // 1 minute
+
   private static tokenCache: Map<
     string,
     { token: string; expiresAt: number; sessionCookies: Cookie[] }
   > = new Map();
   private static solvingInProgress: Map<string, Promise<Cookie[]>> = new Map();
+  private static solveFailures: Map<
+    string,
+    { count: number; backoffUntil: number }
+  > = new Map();
 
   /**
    * Get cookies for a domain, solving WAF challenge if needed
@@ -31,6 +38,19 @@ export class AwsWafTokenSolver {
         expiresIn: Math.round((cached.expiresAt - Date.now()) / 1000) + 's',
       });
       return cached.sessionCookies;
+    }
+
+    // Check if we're in backoff after repeated failures
+    const failure = this.solveFailures.get(domain);
+    if (failure && failure.backoffUntil > Date.now()) {
+      const waitSecs = Math.round((failure.backoffUntil - Date.now()) / 1000);
+      logger.warn(
+        `WAF solver in backoff after ${failure.count} failures, ${waitSecs}s remaining`,
+        { label: 'AWS WAF Solver', domain }
+      );
+      throw new Error(
+        `WAF solver backing off for ${domain} (${failure.count} consecutive failures)`
+      );
     }
 
     // Check if solving is already in progress for this domain
@@ -153,10 +173,11 @@ export class AwsWafTokenSolver {
         tokenLength: wafToken.value.length,
       });
 
-      // Cache the token (expires in 5 minutes or based on cookie expiry)
-      const expiresAt = wafToken.expires
+      // Cap cache TTL — server can invalidate tokens well before cookie expiry
+      const cookieExpiry = wafToken.expires
         ? wafToken.expires * 1000
-        : Date.now() + 5 * 60 * 1000; // 5 minutes default
+        : Date.now() + this.MAX_TOKEN_TTL;
+      const expiresAt = Math.min(cookieExpiry, Date.now() + this.MAX_TOKEN_TTL);
 
       this.tokenCache.set(domain, {
         token: wafToken.value,
@@ -164,13 +185,28 @@ export class AwsWafTokenSolver {
         sessionCookies: cookies,
       });
 
+      // Reset failure counter on success
+      this.solveFailures.delete(domain);
+
       await browser.close();
 
       return cookies;
     } catch (error) {
+      // Track consecutive failures for backoff
+      const prev = this.solveFailures.get(domain);
+      const count = (prev?.count ?? 0) + 1;
+      const backoffMs =
+        this.BACKOFF_BASE_MS * Math.pow(2, Math.min(count - 1, 4));
+      this.solveFailures.set(domain, {
+        count,
+        backoffUntil: Date.now() + backoffMs,
+      });
+
       logger.error('Failed to solve AWS WAF challenge', {
         label: 'AWS WAF Solver',
         domain,
+        consecutiveFailures: count,
+        backoffSeconds: Math.round(backoffMs / 1000),
         error: error instanceof Error ? error.message : String(error),
       });
 
@@ -187,7 +223,7 @@ export class AwsWafTokenSolver {
   }
 
   /**
-   * Clear cached token for a domain
+   * Clear cached token for a domain (preserves backoff state)
    */
   static clearCache(domain?: string): void {
     if (domain) {
@@ -201,6 +237,18 @@ export class AwsWafTokenSolver {
       logger.debug('Cleared all cached tokens', {
         label: 'AWS WAF Solver',
       });
+    }
+  }
+
+  /**
+   * Full reset — clears tokens AND backoff state
+   */
+  static resetAll(domain?: string): void {
+    this.clearCache(domain);
+    if (domain) {
+      this.solveFailures.delete(domain);
+    } else {
+      this.solveFailures.clear();
     }
   }
 }

--- a/server/lib/collections/utils/ImdbAxiosClient.ts
+++ b/server/lib/collections/utils/ImdbAxiosClient.ts
@@ -86,7 +86,9 @@ export class ImdbAxiosClient {
           });
 
           try {
-            // Solve the challenge
+            // Clear any cached token — we just proved it's invalid by getting 202
+            AwsWafTokenSolver.clearCache(new URL(response.config.url).hostname);
+
             const cookies = await AwsWafTokenSolver.getCookies(
               response.config.url
             );
@@ -180,7 +182,7 @@ export class ImdbAxiosClient {
     this.isInitialized = false;
     this.instance = null;
     this.cookieJar = null;
-    AwsWafTokenSolver.clearCache('www.imdb.com');
+    AwsWafTokenSolver.resetAll('www.imdb.com');
 
     logger.debug('IMDb axios client reset', {
       label: 'IMDb Axios Client',


### PR DESCRIPTION
The WAF token cache trusts the cookie's declared expiry (up to 55 hours) but AWS can invalidate tokens server-side much sooner. When a cached token gets rejected (HTTP 202), the retry reuses the same stale token and gives up after one attempt. The 1991-byte WAF challenge page passes through to the HTML parser, which finds 0 items.

- Clear cached token before re-solving when a 202 proves it's invalid
- Cap token cache TTL to 5 minutes regardless of cookie expiry
- Add exponential backoff (1-16 min) after consecutive Playwright solve failures to prevent Chromium process storms
- Separate `clearCache` (token only) from `resetAll` (token + backoff) so the interceptor's cache invalidation doesn't reset backoff state