### PR TITLE
fix: self-heal stale collectionRatingKey during label-based fallback

### DIFF
--- a/server/lib/collections/core/BaseCollectionSync.ts
+++ b/server/lib/collections/core/BaseCollectionSync.ts
@@ -1629,6 +1629,7 @@ export abstract class BaseCollectionSync<TSource extends CollectionSource>
       // First, try to find collection by stored ratingKey if available
       // This is more reliable than label matching for all single collections
       // Skip for multi-collection patterns (one config generates multiple collections)
+      let ratingKeyWasStale = false;
       const isMultiCollectionPattern =
         (config?.type === 'overseerr' && config?.subtype === 'users') ||
         (config?.type === 'tmdb' && config?.subtype === 'auto_franchise');
@@ -1656,6 +1657,7 @@ export abstract class BaseCollectionSync<TSource extends CollectionSource>
                   configName: config.name,
                 }
               );
+              ratingKeyWasStale = true;
             } else {
               logger.debug(
                 `Found existing collection by stored ratingKey: ${existingByRatingKey.title}`,
@@ -1685,6 +1687,7 @@ export abstract class BaseCollectionSync<TSource extends CollectionSource>
               error: error instanceof Error ? error.message : String(error),
             }
           );
+          ratingKeyWasStale = true;
         }
       }
 
@@ -1804,6 +1807,22 @@ export abstract class BaseCollectionSync<TSource extends CollectionSource>
               labels: matchedCollection.labels,
             }
           );
+
+          // Self-heal: persist the correct ratingKey when the stored one was stale
+          if (ratingKeyWasStale && config?.id && config.libraryId) {
+            logger.info(
+              `Self-healing stale ratingKey for "${config.name}": ${config.collectionRatingKey} → ${matchedCollection.collection.ratingKey}`,
+              { label: 'Base Collection Sync' }
+            );
+            const libraryId = Array.isArray(config.libraryId)
+              ? config.libraryId[0]
+              : config.libraryId;
+            updateConfigWithRatingKey(
+              config.id,
+              matchedCollection.collection.ratingKey,
+              libraryId
+            );
+          }
 
           return {
             ratingKey: matchedCollection.collection.ratingKey,

--- a/server/lib/collections/core/BaseCollectionSync.ts
+++ b/server/lib/collections/core/BaseCollectionSync.ts
@@ -1638,7 +1638,9 @@ export abstract class BaseCollectionSync<TSource extends CollectionSource>
           const existingByRatingKey = await plexClient.getCollectionMetadata(
             config.collectionRatingKey
           );
-          if (existingByRatingKey) {
+          if (!existingByRatingKey) {
+            ratingKeyWasStale = true;
+          } else {
             // CRITICAL: Validate that the found collection is in the correct library
             // This prevents linked configs from stealing each other's rating keys
             const collectionLibraryKey =


### PR DESCRIPTION
When a stored `collectionRatingKey` returns 404 from Plex (collection was recreated), `findExistingCollection()` falls back to label-based search and finds the collection under a new ratingKey. But it never persists the new key, so the next sync hits the same 404 and the collection stays stuck in "needs sync" state.

Now updates the config with the correct ratingKey when the label search succeeds after a stale key was detected. Mirrors the self-heal pattern already used in filtered hub collections (`recentlyadded.ts:254-258`).

Fixes #562