### PR TITLE
fix(overlays): populate Maintainerr daysUntilAction for season collec…

### DIFF
--- a/apply_fix.py
+++ b/apply_fix.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Apply the Maintainerr season-overlay fix to an agregarr checkout.
+
+Run from the repo root:  python3 apply_fix.py
+Idempotent: refuses to double-apply.
+"""
+import sys, os
+
+EDITS = []
+
+EDITS.append((
+    "server/lib/overlays/OverlayContextBuilder.ts",
+"""      for (const collection of maintainerrCollections) {
+        const mediaItem = collection.media.find((m) => {
+          const id = m.mediaServerId || m.plexId?.toString();
+          return id === item.ratingKey;
+        });
+
+        if (mediaItem && collection.deleteAfterDays) {
+          // Calculate days since item was added to collection
+          const addedDate = new Date(mediaItem.addDate);
+          const now = new Date();
+          const daysSinceAdded = Math.floor(
+            (now.getTime() - addedDate.getTime()) / (1000 * 60 * 60 * 24)
+          );
+
+          // Calculate days until action: deleteAfterDays - daysSinceAdded
+          // Positive = days remaining, negative = overdue
+          const daysUntilAction = collection.deleteAfterDays - daysSinceAdded;
+
+          matchingCollections.push({ collection, daysUntilAction });
+        }
+      }""",
+"""      // Number of child items (seasons/episodes) matched via the tmdbId
+      // fallback below, so templates can distinguish "this whole show is
+      // leaving" from "2 of its seasons are leaving".
+      let childItemsMatched = 0;
+
+      for (const collection of maintainerrCollections) {
+        if (!collection.deleteAfterDays) {
+          continue;
+        }
+
+        // Primary match: the collection member is this exact Plex item.
+        // Applies to movie-type collections and show-type collections.
+        let mediaItems = collection.media.filter((m) => {
+          const id = m.mediaServerId || m.plexId?.toString();
+          return id === item.ratingKey;
+        });
+
+        // Fallback for season- and episode-type Maintainerr collections.
+        // Their members are season/episode ratingKeys, which can never equal
+        // the show's ratingKey, so the primary match always misses and
+        // daysUntilAction is never calculated for TV. Maintainerr reports the
+        // parent series' tmdbId on those rows, so match the show to its queued
+        // children that way. A show may have several queued seasons; collect
+        // them all and let the existing lowest-daysUntilAction selection win.
+        if (mediaItems.length === 0 && mediaType === 'show' && tmdbId) {
+          mediaItems = collection.media.filter((m) => m.tmdbId === tmdbId);
+          childItemsMatched += mediaItems.length;
+        }
+
+        for (const mediaItem of mediaItems) {
+          // Calculate days since item was added to collection
+          const addedDate = new Date(mediaItem.addDate);
+          const now = new Date();
+          const daysSinceAdded = Math.floor(
+            (now.getTime() - addedDate.getTime()) / (1000 * 60 * 60 * 24)
+          );
+
+          // Calculate days until action: deleteAfterDays - daysSinceAdded
+          // Positive = days remaining, negative = overdue
+          const daysUntilAction = collection.deleteAfterDays - daysSinceAdded;
+
+          matchingCollections.push({ collection, daysUntilAction });
+        }
+      }""",
+))
+
+EDITS.append((
+    "server/lib/overlays/OverlayContextBuilder.ts",
+"""        context.daysUntilAction = selected.daysUntilAction;
+
+        logger.debug('Calculated Maintainerr daysUntilAction', {
+          label: 'OverlayContextBuilder',
+          ratingKey: item.ratingKey,
+          title: item.title,
+          matchingCollections: matchingCollections.length,
+          selectedCollection: selected.collection.title,
+          daysUntilAction: selected.daysUntilAction,
+        });""",
+"""        context.daysUntilAction = selected.daysUntilAction;
+
+        if (childItemsMatched > 0) {
+          context.seasonsLeavingCount = childItemsMatched;
+        }
+
+        logger.debug('Calculated Maintainerr daysUntilAction', {
+          label: 'OverlayContextBuilder',
+          ratingKey: item.ratingKey,
+          title: item.title,
+          matchingCollections: matchingCollections.length,
+          childItemsMatched,
+          selectedCollection: selected.collection.title,
+          daysUntilAction: selected.daysUntilAction,
+        });""",
+))
+
+EDITS.append((
+    "server/lib/overlays/OverlayTemplateRenderer.ts",
+"""  // Maintainerr integration
+  daysUntilAction?: number; // Days until Maintainerr takes action (negative = overdue)""",
+"""  // Maintainerr integration
+  daysUntilAction?: number; // Days until Maintainerr takes action (negative = overdue)
+  seasonsLeavingCount?: number; // Number of this show's seasons/episodes queued for action""",
+))
+
+EDITS.append((
+    "server/routes/overlayTemplates.ts",
+"""  daysUntilAction?: number;
+}""",
+"""  daysUntilAction?: number;
+  seasonsLeavingCount?: number;
+}""",
+))
+
+EDITS.append((
+    "server/api/maintainerr.ts",
+"""  type: number;""",
+"""  type: number | 'movie' | 'show' | 'season' | 'episode';""",
+))
+
+
+def main():
+    if not os.path.isdir("server/lib/overlays"):
+        sys.exit("Run this from the agregarr repo root.")
+
+    # Pre-flight: verify every target is present exactly once.
+    for path, old, new in EDITS:
+        if not os.path.exists(path):
+            sys.exit("Missing file: %s" % path)
+        text = open(path, encoding="utf-8").read()
+        if new in text:
+            sys.exit("Already applied (found new text in %s). Nothing to do." % path)
+        count = text.count(old)
+        if count != 1:
+            sys.exit(
+                "Expected exactly 1 match in %s, found %d. Upstream has moved; "
+                "the patch needs rebasing." % (path, count)
+            )
+
+    for path, old, new in EDITS:
+        text = open(path, encoding="utf-8").read()
+        open(path, "w", encoding="utf-8").write(text.replace(old, new, 1))
+        print("patched %s" % path)
+
+    print("\nDone. Verify with:  git --no-pager diff --stat")
+    print("Expected: 4 files changed, 33 insertions(+), 3 deletions(-)")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/api/maintainerr.ts
+++ b/server/api/maintainerr.ts
@@ -30,7 +30,7 @@ export interface MaintainerrCollection {
   manualCollectionName: string;
   listExclusions: boolean;
   forceOverseerr: boolean;
-  type: number;
+  type: number | 'movie' | 'show' | 'season' | 'episode';
   keepLogsForMonths: number;
   addDate: string;
   handledMediaAmount: number;

--- a/server/lib/overlays/OverlayContextBuilder.ts
+++ b/server/lib/overlays/OverlayContextBuilder.ts
@@ -756,13 +756,36 @@ export async function buildRenderContext(
         daysUntilAction: number;
       }[] = [];
 
+      // Number of child items (seasons/episodes) matched via the tmdbId
+      // fallback below, so templates can distinguish "this whole show is
+      // leaving" from "2 of its seasons are leaving".
+      let childItemsMatched = 0;
+
       for (const collection of maintainerrCollections) {
-        const mediaItem = collection.media.find((m) => {
+        if (!collection.deleteAfterDays) {
+          continue;
+        }
+
+        // Primary match: the collection member is this exact Plex item.
+        // Applies to movie-type collections and show-type collections.
+        let mediaItems = collection.media.filter((m) => {
           const id = m.mediaServerId || m.plexId?.toString();
           return id === item.ratingKey;
         });
 
-        if (mediaItem && collection.deleteAfterDays) {
+        // Fallback for season- and episode-type Maintainerr collections.
+        // Their members are season/episode ratingKeys, which can never equal
+        // the show's ratingKey, so the primary match always misses and
+        // daysUntilAction is never calculated for TV. Maintainerr reports the
+        // parent series' tmdbId on those rows, so match the show to its queued
+        // children that way. A show may have several queued seasons; collect
+        // them all and let the existing lowest-daysUntilAction selection win.
+        if (mediaItems.length === 0 && mediaType === 'show' && tmdbId) {
+          mediaItems = collection.media.filter((m) => m.tmdbId === tmdbId);
+          childItemsMatched += mediaItems.length;
+        }
+
+        for (const mediaItem of mediaItems) {
           // Calculate days since item was added to collection
           const addedDate = new Date(mediaItem.addDate);
           const now = new Date();
@@ -786,11 +809,16 @@ export async function buildRenderContext(
 
         context.daysUntilAction = selected.daysUntilAction;
 
+        if (childItemsMatched > 0) {
+          context.seasonsLeavingCount = childItemsMatched;
+        }
+
         logger.debug('Calculated Maintainerr daysUntilAction', {
           label: 'OverlayContextBuilder',
           ratingKey: item.ratingKey,
           title: item.title,
           matchingCollections: matchingCollections.length,
+          childItemsMatched,
           selectedCollection: selected.collection.title,
           daysUntilAction: selected.daysUntilAction,
         });

--- a/server/lib/overlays/OverlayTemplateRenderer.ts
+++ b/server/lib/overlays/OverlayTemplateRenderer.ts
@@ -441,6 +441,7 @@ export interface OverlayRenderContext {
 
   // Maintainerr integration
   daysUntilAction?: number; // Days until Maintainerr takes action (negative = overdue)
+  seasonsLeavingCount?: number; // Number of this show's seasons/episodes queued for action
 
   // Collection membership (populated at runtime from Plex collection contents)
   collection?: string[]; // Array of collection IDs this item belongs to

--- a/server/routes/overlayTemplates.ts
+++ b/server/routes/overlayTemplates.ts
@@ -151,6 +151,7 @@ interface PreviewPosterMetadata {
   releaseDate?: string;
   runtime?: number;
   daysUntilAction?: number;
+  seasonsLeavingCount?: number;
 }
 
 // Apply authentication to all routes


### PR DESCRIPTION
#### Description

Maintainerr overlays never populate for TV when the Maintainerr rule group is scoped to seasons (or episodes).

`OverlayLibraryService` only evaluates movie and show items - it explicitly skips `season` and `episode` types. `OverlayContextBuilder` then matches Maintainerr collection members by `mediaServerId || plexId` against the item's `ratingKey`. Season-type collections contain *season* ratingKeys, which can never equal the parent show's ratingKey, so the match always misses and `daysUntilAction` is silently left undefined. Movies work because there the collection member and the overlaid item are the same object.

Confirmed on a live instance running current `develop` (`4a10150`) and Maintainerr v3. Same instance, same overlay job - movies calculate, seasons produce no `Calculated Maintainerr daysUntilAction` line at all:

```
[info][Maintainerr Connection]: Maintainerr connection test successful {"responseTime":15,"collectionsFound":3}
[info][OverlayLibrary]: Applying overlays to library {"libraryId":"2","templateCount":2,"templates":["IMDb Rating","Maintainerr Deleting Soon"]}
```

…with zero calculations for any TV item, while the movies library produced them normally.

**Fix**

Full disclosure, Claude helped with this one. By all means use the fix or base your own off of it. 

Maintainerr reports the parent series' `tmdbId` on season and episode rows (verified against `/api/collections/overlay-data`). This adds a `tmdbId` fallback for show items when the ratingKey match misses, collecting every queued child and keeping the existing lowest-`daysUntilAction` selection.

Also adds `seasonsLeavingCount` to the render context, so a template can say "2 seasons leaving" rather than implying the whole series is going. I deliberately did **not** touch the stock preset - this is additive, and nothing changes for existing users unless they author a template that uses the new variable.

Separately, `MaintainerrCollection.type` is declared `number` but `/api/collections/overlay-data` returns a string (`"movie"`, `"show"`, `"season"`, `"episode"`). Nothing reads it today, but it would mislead any future code that branches on collection type, so it's widened to accept both forms (the legacy `/api/collections` fallback may still return the numeric form).

**Testing**

Verified against a real library via the overlay Test Item route (no poster uploads):

| Case | Result |
| --- | --- |
| Single-season show (`Spartacus: House of Ashur`) | `childItemsMatched: 1`, `daysUntilAction: 30` ✅ |
| Multi-season show (`Dexter`, 2 seasons queued) | `childItemsMatched: 2`, lowest value selected ✅ |
| Movie control (`Popstar: Never Stop Never Stopping`) | `childItemsMatched: 0`, `daysUntilAction: 4` - unchanged ✅ |

```
[debug][OverlayContextBuilder]: Calculated Maintainerr daysUntilAction {"ratingKey":"47944","title":"Spartacus: House of Ashur","matchingCollections":1,"childItemsMatched":1,"selectedCollection":"Leaving Soon","daysUntilAction":30}
[debug][OverlayContextBuilder]: Calculated Maintainerr daysUntilAction {"ratingKey":"29737","title":"Dexter","matchingCollections":2,"childItemsMatched":2,"selectedCollection":"Leaving Soon","daysUntilAction":30}
[debug][OverlayContextBuilder]: Calculated Maintainerr daysUntilAction {"ratingKey":"58551","title":"Popstar: Never Stop Never Stopping","matchingCollections":1,"childItemsMatched":0,"selectedCollection":"Movie Clean-up!","daysUntilAction":4}
```

The movie case is the important one - `childItemsMatched: 0` confirms the fallback only fires when the primary match misses, leaving the working path untouched.

**Known gaps**

- Not tested against a **show-type** Maintainerr collection (I don't run one). The primary ratingKey path is unchanged and should handle it, but it's unverified.
- `seasonsLeavingCount` counts seasons *or* episodes depending on collection type. The name is season-biased; happy to rename.
- No unit tests added.

#### Screenshot (if UI-related)

<!-- Drag in the Test Item screenshot showing "daysUntilAction gte 0 (actual: 30)" with the rendered badge -->

#### Checklist

- [x] Type checking (`yarn typecheck`)
- [x] Build succeeds (`yarn build`)
- [ ] Translation keys extracted (`yarn i18n:extract`) - if new user-facing strings added - n/a, no new user-facing strings
- [ ] Database migration included - if schema changes required - n/a, no schema changes

**Runs automatically on `git commit`** (If you bypassed husky (`HUSKY=0`), run these manually as well before submitting.):

- [x] Formatting (prettier) (`yarn format`)
- [x] Linting (`yarn lint`)

#### Issues Fixed or Closed

- Fixes #552