### PR TITLE
fix(collections): MDBList and AniList custom URL lost on save

### DIFF
--- a/src/components/Collections/Views/CollectionSettings.tsx
+++ b/src/components/Collections/Views/CollectionSettings.tsx
@@ -426,6 +426,7 @@ const CollectionSettings = ({
           imdbCustomListUrl: config.imdbCustomListUrl,
           letterboxdCustomListUrl: config.letterboxdCustomListUrl,
           mdblistCustomListUrl: config.mdblistCustomListUrl,
+          anilistCustomListUrl: config.anilistCustomListUrl,
           radarrInstanceId: config.radarrInstanceId,
           radarrTagId: config.radarrTagId,
           sonarrInstanceId: config.sonarrInstanceId,

--- a/src/components/Collections/Views/CollectionSettings.tsx
+++ b/src/components/Collections/Views/CollectionSettings.tsx
@@ -425,6 +425,7 @@ const CollectionSettings = ({
           tmdbCustomCollectionUrl: config.tmdbCustomCollectionUrl,
           imdbCustomListUrl: config.imdbCustomListUrl,
           letterboxdCustomListUrl: config.letterboxdCustomListUrl,
+          mdblistCustomListUrl: config.mdblistCustomListUrl,
           radarrInstanceId: config.radarrInstanceId,
           radarrTagId: config.radarrTagId,
           sonarrInstanceId: config.sonarrInstanceId,


### PR DESCRIPTION
#### Description

Both bugs are the same root cause: `saveCollectionConfigs` in CollectionSettings.tsx builds the update payload by explicitly listing each source's custom URL field, and mdblistCustomListUrl / anilistCustomListUrl were missing from that list. The value entered in the form (and validated by the live preview) was silently dropped before the save request was sent.

#### Screenshot (if UI-related)

#### Checklist

- [x] Type checking (`yarn typecheck`)
- [x] Build succeeds (`yarn build`)
- [x] Translation keys extracted (`yarn i18n:extract`) - if new user-facing strings added
- [x] Database migration included - if schema changes required

**Runs automatically on `git commit`** (If you bypassed husky (`HUSKY=0`), run these manually as well before submitting.):

- [x] Formatting (prettier) (`yarn format`)
- [x] Linting (`yarn lint`)

#### Issues Fixed or Closed

- Fixes #624
