### PR TITLE
fix(letterboxd): stop requiring removed data-film-id attribute

### DIFF
--- a/server/lib/collections/sources/letterboxd.ts
+++ b/server/lib/collections/sources/letterboxd.ts
@@ -827,10 +827,11 @@ export class LetterboxdCollectionSync extends BaseCollectionSync<'letterboxd'> {
         // Secondary pattern - grid items (watchlists)
         /<li[^>]*class="[^"]*griditem[^"]*"[^>]*>(.*?)<\/li>/gs,
         // Fallback pattern - any li containing film data
-        /<li[^>]*[^>]*>(.*?data-film-id="[^"]*".*?)<\/li>/gs,
+        // Note: Letterboxd removed the data-film-id attribute from list pages;
+        // key off data-target-link instead, which is still present.
+        /<li[^>]*[^>]*>(.*?data-target-link="[^"]*".*?)<\/li>/gs,
       ];
 
-      const filmIdRegex = /data-film-id="([^"]+)"/;
       const targetLinkRegex = /data-target-link="([^"]+)"/;
       const fullDisplayNameRegex = /data-item-full-display-name="([^"]+)"/;
       const titleRegex = /data-item-name="([^"]+)"/;
@@ -871,10 +872,6 @@ export class LetterboxdCollectionSync extends BaseCollectionSync<'letterboxd'> {
       for (const match of matches) {
         if (count >= maxItems) break;
         const itemHtml = match[1];
-
-        // Extract film ID
-        const filmIdMatch = itemHtml.match(filmIdRegex);
-        if (!filmIdMatch) continue;
 
         // Extract target link (movie slug)
         const targetLinkMatch = itemHtml.match(targetLinkRegex);


### PR DESCRIPTION
## Summary

Letterboxd has removed the `data-film-id` attribute from list-page poster markup site-wide. Every Letterboxd-sourced collection currently fails silently — the page fetches fine (confirmed via `CloudflareSolver.fetchPage()`, so this isn't a bot-blocking issue), pattern 1 finds all the `<li>` items, but each one is skipped because `filmIdMatch` never matches, leaving "Successfully parsed 0 movies" with `hasError:false`.

Confirmed this against several different lists, including some that synced successfully in the past — `data-item-name`, `data-target-link`, and `data-item-full-display-name` are all still present and correct; only `data-film-id` is gone.

`filmIdMatch`'s captured value was never used elsewhere in the function — it was a pure existence gate. This PR removes it, and updates the dead fallback pattern (which also matched on `data-film-id`) to key off `data-target-link` instead, which is still present.

Fixes #586, related to #584.

## Test plan

- [x] `yarn typecheck:server` passes
- [x] `yarn lint` passes on the changed file
- [x] Verified locally against live Letterboxd pages (via the same `CloudflareSolver.fetchPage()` + `parseLetterboxdListHtml()` this app uses): went from 0/55 to 55/55 items parsed on `letterboxd.com/criterion/list/top-closet-picks-criterion-collection/`, and 0/105 to 105/105 on the official Top 250 Science Fiction Films list
- [ ] Would appreciate a maintainer double-checking against a watchlist URL (griditem pattern) since I didn't have one handy to test against

🤖 Generated with [Claude Code](https://claude.com/claude-code)
